### PR TITLE
fix a bug in server.go

### DIFF
--- a/server.go
+++ b/server.go
@@ -194,7 +194,7 @@ func (m *NvidiaDevicePlugin) healthcheck() {
 
 	var xids chan *pluginapi.Device
 	if !strings.Contains(disableHealthChecks, "xids") {
-		xids = make(chan *pluginapi.Device)
+		xids := make(chan *pluginapi.Device)
 		go watchXIDs(ctx, m.devs, xids)
 	}
 

--- a/server.go
+++ b/server.go
@@ -194,7 +194,7 @@ func (m *NvidiaDevicePlugin) healthcheck() {
 
 	var xids chan *pluginapi.Device
 	if !strings.Contains(disableHealthChecks, "xids") {
-		xids := make(chan *pluginapi.Device)
+		xids = make(chan *pluginapi.Device)
 		go watchXIDs(ctx, m.devs, xids)
 	}
 


### PR DESCRIPTION
`xids := make(chan *pluginapi.Device) ` 
should be
`xids = make(chan *pluginapi.Device) `