### PR TITLE
Set the default 'updateStrategy' to 'RollingUpdate' in branch v1.12

### DIFF
--- a/nvidia-device-plugin.yml
+++ b/nvidia-device-plugin.yml
@@ -4,6 +4,8 @@ metadata:
   name: nvidia-device-plugin-daemonset-1.12
   namespace: kube-system
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler


### PR DESCRIPTION
This change allows us to patch the device plugin to (for example) update the
image tag to the latest version and have an automated rolling upgrade be
performed to update the plugin on all agent nodes.

Previously, the device plugin on each node would *only* be restarted with the
new image if the pod representing it was explicitly shutdown and restarted.