### PR TITLE
Change how to specify pod as critical

### DIFF
--- a/nvidia-device-plugin.yml
+++ b/nvidia-device-plugin.yml
@@ -8,22 +8,26 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      # Mark this pod as a critical add-on; when enabled, the critical add-on scheduler
-      # reserves resources for critical add-on pods so that they can be rescheduled after
-      # a failure.  This annotation works in tandem with the toleration below.
+      # This annotation is deprecated. Kept here for backward compatibility
+      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ""
       labels:
         name: nvidia-device-plugin-ds
     spec:
       tolerations:
-      # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
-      # This, along with the annotation above marks this pod as a critical add-on.
+      # This toleration is deprecated. Kept here for backward compatibility
+      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
       - key: CriticalAddonsOnly
         operator: Exists
       - key: nvidia.com/gpu
         operator: Exists
         effect: NoSchedule
+      # Mark this pod as a critical add-on; when enabled, the critical add-on
+      # scheduler reserves resources for critical add-on pods so that they can
+      # be rescheduled after a failure.
+      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+      priorityClassName: "system-node-critical"
       containers:
       - image: nvidia/k8s-device-plugin:1.0.0-beta
         name: nvidia-device-plugin-ctr


### PR DESCRIPTION
Use annotation and tolerations to mark pod as critical is deprecated in version 1.13 and removed in version 1.14 of Kubernetes. We need to use the priorityClassName pod attribute set as “system-cluster-critical” or “system-node-critical”.

Signed-off-by: Jordan Jacobelli <jjacobelli@nvidia.com>