### PR TITLE
log Xid, UUID when gpus go unhealthy.

### DIFF
--- a/nvidia.go
+++ b/nvidia.go
@@ -84,6 +84,7 @@ func watchXIDs(ctx context.Context, devs []*pluginapi.Device, xids chan<- *plugi
 		if e.UUID == nil || len(*e.UUID) == 0 {
 			// All devices are unhealthy
 			for _, d := range devs {
+				log.Printf("XidCriticalError: Xid=%d, All devices will go unhealthy.", e.Edata)
 				xids <- d
 			}
 			continue
@@ -91,6 +92,7 @@ func watchXIDs(ctx context.Context, devs []*pluginapi.Device, xids chan<- *plugi
 
 		for _, d := range devs {
 			if d.ID == *e.UUID {
+				log.Printf("XidCriticalError: Xid=%d on GPU=%s, the device will go unhealthy.", e.Edata, d.ID)
 				xids <- d
 			}
 		}

--- a/server.go
+++ b/server.go
@@ -140,6 +140,7 @@ func (m *NvidiaDevicePlugin) ListAndWatch(e *pluginapi.Empty, s pluginapi.Device
 		case d := <-m.health:
 			// FIXME: there is no way to recover from the Unhealthy state.
 			d.Health = pluginapi.Unhealthy
+			log.Printf("device marked unhealthy: %s", d.ID)
 			s.Send(&pluginapi.ListAndWatchResponse{Devices: m.devs})
 		}
 	}


### PR DESCRIPTION
current plugin doesn't log even when XidCriticalError happened and which device went unhealthy status.  logging XidCriticalError information in the plugin would be helpful when inspecting why Allocatable GPUs of the node reduced.