### PR TITLE
fix: nil pointer dereference around getDevices:d.CPUAffinity

### DIFF
--- a/nvidia.go
+++ b/nvidia.go
@@ -40,13 +40,18 @@ func getDevices() []*pluginapi.Device {
 	for i := uint(0); i < n; i++ {
 		d, err := nvml.NewDeviceLite(i)
 		check(err)
+		var cpu_affinity int64 = 0
+		if d.CPUAffinity != nil {
+			cpu_affinity = int64(*(d.CPUAffinity))
+		}
+
 		devs = append(devs, &pluginapi.Device{
 			ID:     d.UUID,
 			Health: pluginapi.Healthy,
 			Topology: &pluginapi.TopologyInfo{
 				Nodes: []*pluginapi.NUMANode{
 					&pluginapi.NUMANode{
-						ID: int64(*(d.CPUAffinity)),
+						ID: cpu_affinity,
 					},
 				},
 			}})


### PR DESCRIPTION
As mentioned in issue:140 by @jucrouzet and @RenaudWasTaken , when CPUAffinity is not set, *(d.CPUAffinity) simply fails, and cause the whole process to exit.