### PR TITLE
Fixed typo in server.go

### DIFF
--- a/server.go
+++ b/server.go
@@ -77,7 +77,7 @@ func (m *NvidiaDevicePlugin) cleanup() {
 }
 
 // Start starts the gRPC server, registers the device plugin with the Kubelet,
-// and starts the device healthecks.
+// and starts the device healthchecks.
 func (m *NvidiaDevicePlugin) Start() error {
 	m.initialize()
 


### PR DESCRIPTION
Fixed typo 'healthecks' to 'healthchecks' in server.go