### PR TITLE
Change NVIDIA Driver requirement from `~=` to `>=`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please note that:
 ## Prerequisites
 
 The list of prerequisites for running the NVIDIA device plugin is described below:
-* NVIDIA drivers ~= 384.81
+* NVIDIA drivers >= 384.81
 * nvidia-docker version > 2.0 (see how to [install](https://github.com/NVIDIA/nvidia-docker) and it's [prerequisites](https://github.com/nvidia/nvidia-docker/wiki/Installation-\(version-2.0\)#prerequisites))
 * docker configured with nvidia as the [default runtime](https://github.com/NVIDIA/nvidia-docker/wiki/Advanced-topics#default-runtime).
 * Kubernetes version >= 1.10


### PR DESCRIPTION
Change NVIDIA Driver requirement from `~=` to `>=` in README.md

Signed-off-by: Atsushi SAKAI <sakaia@jp.fujitsu.com>