### PR TITLE
Adding shared GPU support by replicating GPUs.

### DIFF
--- a/SHARED_GPU_TUTORIAL.md
+++ b/SHARED_GPU_TUTORIAL.md
@@ -1,0 +1,38 @@
+# Tutorial
+
+We will deploy two types of daemonsets via the helm chart.  One to support sharing of GPUs and one to support exclusive (regular non-shared GPUs).
+
+Label GPU nodes as either shared or exclusive.
+
+```shell
+kubectl label node nodename1 gpu-node-type=exclusive
+...
+kubectl label node nodename2 gpu-node-type=shared
+...
+```
+
+Deploy the driver twice.  Once for the exclusive GPU nodes and once for the shared GPU nodes based on the above node labels.
+
+```shell
+helm install nvidia-exclusive deployments/helm/nvidia-device-plugin --set nodeSelector='gpu-node-type=exclusive'
+helm install nvidia-exclusive deployments/helm/nvidia-device-plugin --set nodeSelector='gpu-node-type=shared' --set resourceConfig='gpu:sharedgpu:4'
+```
+
+You can use [kubectl-view-allocations](https://github.com/davidB/kubectl-view-allocations) to see that you now have two extended resource types.  The tool will also tell you the quantity in use and available.
+
+- nvidia.com/gpu
+- nvidia.com/sharedgpu
+
+Create two pods with shared GPUs that do some work on the GPUs.
+
+```bash
+kubectl create -f pods/pod-shared-pytorch.yml
+kubectl create -f pods/pod-shared-pytorch.yml
+```
+
+Inspect the logs of the pods to see that both are using pytorch with CUDA support to train a DNN model on MNIST.  
+You can also run `nvidia-smi -L` to see that the GPU is the same (given that they are actually sharing a GPU and didn't pick up different GPUs if you have more than one GPU on your system).
+
+Note that in the pods, `nvidia-smi` only lists that pod's processes (yet the percentage is actually for all processes) but from the host everything for a given GPU.
+
+You can also create pods with exclusive ownership by replacing "nvidia.com/sharedgpu" with "nvidia.com/gpu" as shown in this [example pod](pods/pod1.yml).

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset.yml
@@ -64,6 +64,9 @@ spec:
         - "--device-list-strategy={{ .Values.deviceListStrategy }}"
         - "--device-id-strategy={{ .Values.deviceIDStrategy }}"
         - "--nvidia-driver-root={{ .Values.nvidiaDriverRoot }}"
+        {{- with .Values.resourceConfig }}
+        - "--resource-config={{ . }}"
+        {{- end }}
         securityContext:
         {{- if ne (len .Values.securityContext) 0 }}
           {{- toYaml .Values.securityContext | nindent 10 }}

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -6,6 +6,12 @@ deviceListStrategy: envvar
 deviceIDStrategy: uuid
 nvidiaDriverRoot: "/"
 
+# This is used to specify renaming and replicas (for enabling sharing)
+# For example, to share regular gpus with 4 pods and to share mig-3g.20gb GPUs with 2 pods and rename to small.
+# resourceConfig: gpu:sharedgpu:4,mig-3g.20gb:small:2
+# The pod would then request a shared mig gpu by specifying a resource of "nvidia.com/small: 1"
+resourceConfig: ""
+
 nameOverride: ""
 fullnameOverride: ""
 selectorLabelsOverride: {}

--- a/pods/pod1-nogpu.yml
+++ b/pods/pod1-nogpu.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1-nogpu
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - image: nvcr.io/nvidia/cuda
+    name: pod1-ctr
+    command: ["sleep"]
+    args: ["100000"]
+    resources:
+      limits:
+        cpu: 100m
+        memory: 512Mi

--- a/pods/pod1-shared-pytorch.yml
+++ b/pods/pod1-shared-pytorch.yml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1-shared-pytorch
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - image: pytorch/pytorch
+    name: main
+    command:
+      - /bin/bash
+      - -c
+      - python -c "import requests, os; open('main.py', 'wb').write(requests.get(os.getenv('SRC_URL'), allow_redirects=True).content)" && cat main.py && python main.py
+    env:
+    - name: SRC_URL
+      value: https://raw.githubusercontent.com/pytorch/examples/master/mnist/main.py
+    resources:
+      limits:
+        cpu: 1000m
+        memory: 2Gi
+        nvidia.com/sharedgpu: 1

--- a/pods/pod1-shared.yml
+++ b/pods/pod1-shared.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1-shared
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - image: nvcr.io/nvidia/cuda
+    name: pod1-ctr
+    command: ["sleep"]
+    args: ["100000"]
+    resources:
+      limits:
+        cpu: 100m
+        memory: 512Mi
+        nvidia.com/sharedgpu: 2

--- a/pods/pod1.yml
+++ b/pods/pod1.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+spec:
+  restartPolicy: OnFailure
+  containers:
+  - image: nvcr.io/nvidia/cuda
+    name: pod1-ctr
+    command: ["sleep"]
+    args: ["100000"]
+    resources:
+      limits:
+        cpu: 100m
+        memory: 512Mi
+        nvidia.com/gpu: 1

--- a/replica.go
+++ b/replica.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const joinStr = "-replica-"
+
+func stripReplica(deviceReplica string) string {
+	return strings.Split(deviceReplica, joinStr)[0]
+}
+
+func stripReplicas(deviceReplicaIDs []string) []string {
+	deviceIDs := make([]string, 0, len(deviceReplicaIDs))
+	// remove replicas. We only want the raw devices now.
+	devices := make(map[string]bool)
+	for _, id := range deviceReplicaIDs {
+		devID := stripReplica(id)
+		if _, exists := devices[devID]; !exists {
+			devices[devID] = true
+			deviceIDs = append(deviceIDs, devID)
+		}
+	}
+	sort.Strings(deviceIDs)
+	return deviceIDs
+}
+
+func find(a []string, x string) int {
+	for i, n := range a {
+		if x == n {
+			return i
+		}
+	}
+	return len(a)
+}
+
+func remove(s []string, i int) []string {
+	s[i] = s[len(s)-1]
+	// We do not need to put s[i] at the end, as it will be discarded anyway
+	return s[:len(s)-1]
+}
+
+type devCount struct {
+	Allocated          bool
+	ReplicaDeviceNames []string
+}
+
+// allocate a specific replica device to this physical device
+func (d *devCount) allocate(allocatedDevice string) bool {
+	idx := find(d.ReplicaDeviceNames, allocatedDevice)
+	if idx == len(d.ReplicaDeviceNames) {
+		return false
+	}
+	d.ReplicaDeviceNames = remove(d.ReplicaDeviceNames, idx)
+	d.Allocated = true
+	return true
+}
+
+// allocate one of it's replicas and return the one allocated
+func (d *devCount) allocateAny() string {
+	allocatedDevice := d.ReplicaDeviceNames[0]
+	d.ReplicaDeviceNames = d.ReplicaDeviceNames[1:]
+	d.Allocated = true
+	return allocatedDevice
+}
+
+type NonUniqueError struct{}
+
+var _ error = NonUniqueError{}
+
+func (m NonUniqueError) Error() string {
+	return "allocation resulted in non-unique devices due to requesting multiple GPU replicas and not having enough physical GPUs"
+}
+
+// Generate a list of devices in order in which they should be used.
+func prioritizeDevices(availableDeviceIDs []string, mustIncludeDeviceIDs []string, allocationSize int) ([]string, error) {
+
+	rawDeviceCount := make(map[string]*devCount)
+
+	// Get the counts by raw device
+	for _, id := range availableDeviceIDs {
+		dev := stripReplica(id)
+		deviceCount, exists := rawDeviceCount[dev]
+		if exists {
+			deviceCount.ReplicaDeviceNames = append(deviceCount.ReplicaDeviceNames, id)
+		} else {
+			rawDeviceCount[dev] = &devCount{
+				Allocated:          false,
+				ReplicaDeviceNames: []string{id},
+			}
+		}
+	}
+
+	// sort ReplicaDeviceNames to make the following deterministic
+	for _, deviceCount := range rawDeviceCount {
+		sort.Strings(deviceCount.ReplicaDeviceNames)
+	}
+
+	// Pick GPU one at a time (that is least used) but try to make them unique
+	// return best effort slice and true if non-unique).
+	allocated := make([]string, len(mustIncludeDeviceIDs), allocationSize)
+
+	unique := true
+
+	// allocate all the replicas that must be included
+	for i, deviceID := range mustIncludeDeviceIDs {
+		deviceCount, exists := rawDeviceCount[stripReplica(deviceID)]
+		if !exists {
+			return nil, fmt.Errorf("device '%s' in mustIncludeDeviceIDs is missing from availableDeviceIDs", deviceID)
+		}
+		if deviceCount.Allocated {
+			// This physical GPU is already allocated so we are no longer unique
+			unique = false
+		}
+		if !deviceCount.allocate(deviceID) {
+			return nil, fmt.Errorf("device '%s' in mustIncludeDeviceIDs is missing from availableDeviceIDs", deviceID)
+		}
+		allocated[i] = deviceID
+	}
+
+	// Used to make the algorithm deterministic.
+	// We pick the lexicongraphically first device name is always chosen.
+	rawDeviceCountSorted := make([]string, 0)
+	for k := range rawDeviceCount {
+		rawDeviceCountSorted = append(rawDeviceCountSorted, k)
+	}
+	sort.Strings(rawDeviceCountSorted)
+
+	for i := len(allocated); i < allocationSize; i++ {
+		// The goal is to get the least used and most unique device.
+		// First priority is selecting a unique device.
+		// Second priority is selecting the least utilized device.
+
+		// Find the least utilized device also determining if the device is unique or not.
+		allocatedHighest := 0
+		unallocatedHighest := 0
+		var leastUtilizedDevAllocated *devCount
+		var leastUtilizedDevUnallocated *devCount
+
+		for _, dev := range rawDeviceCountSorted {
+			deviceCount := rawDeviceCount[dev]
+			count := len(deviceCount.ReplicaDeviceNames)
+			if deviceCount.Allocated {
+				if count > allocatedHighest {
+					leastUtilizedDevAllocated = deviceCount
+					allocatedHighest = count
+				}
+			} else {
+				if count > unallocatedHighest {
+					leastUtilizedDevUnallocated = deviceCount
+					unallocatedHighest = count
+				}
+			}
+		}
+
+		// Prioritize unique (aka "unallocated") devices.
+		var deviceCount *devCount
+		if leastUtilizedDevUnallocated != nil {
+			deviceCount = leastUtilizedDevUnallocated
+		} else if leastUtilizedDevAllocated != nil {
+			deviceCount = leastUtilizedDevAllocated
+		} else {
+			return nil, errors.New("no devices left to allocate")
+		}
+		if deviceCount.Allocated {
+			// This physical GPU is already allocated so we are no longer unique
+			unique = false
+		}
+		allocated = append(allocated, deviceCount.allocateAny())
+	}
+	sort.Strings(allocated)
+
+	var err error
+	if !unique {
+		err = &NonUniqueError{}
+	}
+	return allocated, err
+}

--- a/replica_test.go
+++ b/replica_test.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func Test_prioritizeDevices(t *testing.T) {
+	type args struct {
+		availableDeviceIDs   []string
+		mustIncludeDeviceIDs []string
+		allocationSize       int
+	}
+	tests := []struct {
+		name  string
+		args  args
+		want  []string
+		want1 error
+	}{
+		{"Basic",
+			args{[]string{"a-replica-0", "a-replica-1", "b-replica-1"}, []string{}, 1},
+			[]string{"a-replica-0"}, nil,
+		},
+		{"Multiple Unique",
+			args{[]string{"a-replica-0", "a-replica-1", "b-replica-1"}, []string{}, 2},
+			[]string{"a-replica-0", "b-replica-1"}, nil,
+		},
+		{"NonuniqueError",
+			args{[]string{"a-replica-0", "a-replica-1", "a-replica-2", "b-replica-1"}, []string{}, 3},
+			[]string{"a-replica-0", "a-replica-1", "b-replica-1"}, &NonUniqueError{},
+		},
+		{"Must Include Greater Utilized",
+			args{[]string{"a-replica-0", "a-replica-1", "b-replica-1"}, []string{"b-replica-1"}, 1},
+			[]string{"b-replica-1"}, nil,
+		},
+		{"Must Include Least Utilized",
+			args{[]string{"a-replica-0", "a-replica-1", "b-replica-1"}, []string{"a-replica-1"}, 1},
+			[]string{"a-replica-1"}, nil,
+		},
+		{"Must Include Two",
+			args{[]string{"a-replica-0", "a-replica-1", "b-replica-1"}, []string{"a-replica-1"}, 2},
+			[]string{"a-replica-1", "b-replica-1"}, nil,
+		},
+		{"NonuniqueError Must Include",
+			args{[]string{"a-replica-0", "a-replica-1", "a-replica-2", "b-replica-2", "b-replica-1"}, []string{"a-replica-2"}, 3},
+			[]string{"a-replica-0", "a-replica-2", "b-replica-1"}, &NonUniqueError{},
+		},
+		{"Must Include",
+			args{[]string{"a-replica-0", "a-replica-1", "a-replica-2", "b-replica-1", "c-replica-0"}, []string{"a-replica-2"}, 3},
+			[]string{"a-replica-2", "b-replica-1", "c-replica-0"}, nil,
+		},
+		{"Must Include Entire Allocated",
+			args{[]string{"a-replica-0", "a-replica-1", "a-replica-2", "b-replica-1"}, []string{"a-replica-2", "b-replica-1", "a-replica-1"}, 3},
+			[]string{"a-replica-1", "a-replica-2", "b-replica-1"}, &NonUniqueError{},
+		},
+		{"Deterministic",
+			args{[]string{"a-replica-1", "b-replica-1", "c-replica-1", "d-replica-1", "e-replica-1", "f-replica-1", "g-replica-1", "h-replica-1"}, []string{}, 1},
+			[]string{"a-replica-1"}, nil,
+		},
+		{"OversizedRequest", // With the scheduler, this should not happen in the first place.
+			args{[]string{"a-replica-0", "a-replica-1", "a-replica-2", "b-replica-1"}, []string{}, 5},
+			nil, fmt.Errorf("no devices left to allocate"),
+		},
+		{"Undersized", // With the scheduler, this should not happen in the first place.
+			args{[]string{"a-replica-0", "a-replica-1", "a-replica-2", "b-replica-1"}, []string{}, 0},
+			[]string{}, nil,
+		},
+		{"NoneAvailable", // With the scheduler, this should not happen in the first place.
+			args{[]string{}, []string{}, 1},
+			nil, fmt.Errorf("no devices left to allocate"),
+		},
+		{"SubsetSame", // Should never happen
+			args{[]string{"a-replica-0", "a-replica-1"}, []string{"a-replica-2"}, 1},
+			nil, fmt.Errorf("device '%s' in mustIncludeDeviceIDs is missing from availableDeviceIDs", "a-replica-2"),
+		},
+		{"SubsetDifferent", // Should never happen
+			args{[]string{"a-replica-0", "a-replica-1"}, []string{"b-replica-2"}, 1},
+			nil, fmt.Errorf("device '%s' in mustIncludeDeviceIDs is missing from availableDeviceIDs", "b-replica-2"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := prioritizeDevices(tt.args.availableDeviceIDs, tt.args.mustIncludeDeviceIDs, tt.args.allocationSize)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("prioritizeDevices() got = %v, want %v", got, tt.want)
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("prioritizeDevices() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
+func Test_stripReplicas(t *testing.T) {
+	type args struct {
+		deviceReplicaIDs []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []string
+	}{
+		{"Simple", args{[]string{"b-replica-5", "a-replica-1", "a-replica-0"}}, []string{"a", "b"}},
+		{"Simple2", args{[]string{"b-replica-0", "a-replica-1", "a-replica-2", "c-replica-2"}}, []string{"a", "b", "c"}},
+		{"Empty", args{[]string{}}, []string{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stripReplicas(tt.args.deviceReplicaIDs); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("stripReplicas() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/server.go
+++ b/server.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -57,33 +58,50 @@ type NvidiaDevicePlugin struct {
 	deviceListEnvvar string
 	allocatePolicy   gpuallocator.Policy
 	socket           string
+	replicas         uint
 
-	server        *grpc.Server
-	cachedDevices []*Device
-	health        chan *Device
-	stop          chan interface{}
+	server         *grpc.Server
+	cachedDevices  []*Device // raw devices
+	deviceReplicas []*Device // devices presented to k8s that include the replicas
+	health         chan *Device
+	stop           chan interface{}
 }
 
 // NewNvidiaDevicePlugin returns an initialized NvidiaDevicePlugin
-func NewNvidiaDevicePlugin(resourceName string, resourceManager ResourceManager, deviceListEnvvar string, allocatePolicy gpuallocator.Policy, socket string) *NvidiaDevicePlugin {
+func NewNvidiaDevicePlugin(resourceName string, resourceManager ResourceManager, deviceListEnvvar string, allocatePolicy gpuallocator.Policy, socket string, replicas uint) *NvidiaDevicePlugin {
+	// always replicate internally for consistency to avoid a few if statements later on
+	if replicas == 0 {
+		replicas = 1
+	}
+
 	return &NvidiaDevicePlugin{
 		ResourceManager:  resourceManager,
 		resourceName:     resourceName,
 		deviceListEnvvar: deviceListEnvvar,
 		allocatePolicy:   allocatePolicy,
 		socket:           socket,
+		replicas:         replicas,
 
 		// These will be reinitialized every
 		// time the plugin server is restarted.
-		cachedDevices: nil,
-		server:        nil,
-		health:        nil,
-		stop:          nil,
+		cachedDevices:  nil,
+		deviceReplicas: nil,
+		server:         nil,
+		health:         nil,
+		stop:           nil,
 	}
 }
 
 func (m *NvidiaDevicePlugin) initialize() {
 	m.cachedDevices = m.Devices()
+	for _, dev := range m.cachedDevices {
+		for i := uint(0); i < m.replicas; i++ {
+			replicatedDev := *dev // This is replicating the Device struct
+			replicatedDev.ID = fmt.Sprintf("%s%s%d", dev.ID, joinStr, i)
+			m.deviceReplicas = append(m.deviceReplicas, &replicatedDev)
+		}
+	}
+
 	m.server = grpc.NewServer([]grpc.ServerOption{}...)
 	m.health = make(chan *Device)
 	m.stop = make(chan interface{})
@@ -92,6 +110,7 @@ func (m *NvidiaDevicePlugin) initialize() {
 func (m *NvidiaDevicePlugin) cleanup() {
 	close(m.stop)
 	m.cachedDevices = nil
+	m.deviceReplicas = nil
 	m.server = nil
 	m.health = nil
 	m.stop = nil
@@ -201,7 +220,7 @@ func (m *NvidiaDevicePlugin) Register() error {
 		Endpoint:     path.Base(m.socket),
 		ResourceName: m.resourceName,
 		Options: &pluginapi.DevicePluginOptions{
-			GetPreferredAllocationAvailable: (m.allocatePolicy != nil),
+			GetPreferredAllocationAvailable: (m.allocatePolicy != nil || m.replicas > 1),
 		},
 	}
 
@@ -215,7 +234,7 @@ func (m *NvidiaDevicePlugin) Register() error {
 // GetDevicePluginOptions returns the values of the optional settings for this plugin
 func (m *NvidiaDevicePlugin) GetDevicePluginOptions(context.Context, *pluginapi.Empty) (*pluginapi.DevicePluginOptions, error) {
 	options := &pluginapi.DevicePluginOptions{
-		GetPreferredAllocationAvailable: (m.allocatePolicy != nil),
+		GetPreferredAllocationAvailable: (m.allocatePolicy != nil || m.replicas > 1),
 	}
 	return options, nil
 }
@@ -239,23 +258,41 @@ func (m *NvidiaDevicePlugin) ListAndWatch(e *pluginapi.Empty, s pluginapi.Device
 
 // GetPreferredAllocation returns the preferred allocation from the set of devices specified in the request
 func (m *NvidiaDevicePlugin) GetPreferredAllocation(ctx context.Context, r *pluginapi.PreferredAllocationRequest) (*pluginapi.PreferredAllocationResponse, error) {
+
+	// Note there should only be -replica-0 and not any -replica-1 or -replica-2, etc.
+	// since this function is only called when we have no replicas.
 	response := &pluginapi.PreferredAllocationResponse{}
 	for _, req := range r.ContainerRequests {
-		available, err := gpuallocator.NewDevicesFrom(req.AvailableDeviceIDs)
+		available, err := gpuallocator.NewDevicesFrom(stripReplicas(req.AvailableDeviceIDs))
 		if err != nil {
-			return nil, fmt.Errorf("Unable to retrieve list of available devices: %v", err)
+			return nil, fmt.Errorf("unable to retrieve list of available devices: %w", err)
 		}
 
-		required, err := gpuallocator.NewDevicesFrom(req.MustIncludeDeviceIDs)
+		required, err := gpuallocator.NewDevicesFrom(stripReplicas(req.MustIncludeDeviceIDs))
 		if err != nil {
-			return nil, fmt.Errorf("Unable to retrieve list of required devices: %v", err)
+			return nil, fmt.Errorf("unable to retrieve list of required devices: %w", err)
 		}
-
-		allocated := m.allocatePolicy.Allocate(available, required, int(req.AllocationSize))
 
 		var deviceIds []string
-		for _, device := range allocated {
-			deviceIds = append(deviceIds, device.UUID)
+		if m.replicas > 1 {
+			ids, err := prioritizeDevices(req.AvailableDeviceIDs, req.MustIncludeDeviceIDs, int(req.AllocationSize))
+			if err != nil {
+				var nonUnique *NonUniqueError
+				if errors.As(err, &nonUnique) {
+					// non unique assignment is not fatal however sub-optimal
+					log.Print("Ignoring: ", nonUnique)
+				} else {
+					return nil, err
+				}
+			}
+			deviceIds = ids
+		} else if m.allocatePolicy != nil {
+			allocated := m.allocatePolicy.Allocate(available, required, int(req.AllocationSize))
+			for _, device := range allocated {
+				deviceIds = append(deviceIds, device.UUID)
+			}
+		} else {
+			return nil, errors.New("GetPreferredAllocation() not implemented in this case")
 		}
 
 		resp := &pluginapi.ContainerPreferredAllocationResponse{
@@ -272,6 +309,15 @@ func (m *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Alloc
 	responses := pluginapi.AllocateResponse{}
 	for _, req := range reqs.ContainerRequests {
 		for _, id := range req.DevicesIDs {
+			if !m.deviceReplicaExists(id) {
+				return nil, fmt.Errorf("invalid allocation request for '%s': unknown device: %s", m.resourceName, id)
+			}
+		}
+
+		uuids := stripReplicas(req.DevicesIDs)
+		log.Printf("kubelet is requesting devices %s, but using raw devices %s", req.DevicesIDs, uuids)
+
+		for _, id := range uuids {
 			if !m.deviceExists(id) {
 				return nil, fmt.Errorf("invalid allocation request for '%s': unknown device: %s", m.resourceName, id)
 			}
@@ -279,7 +325,6 @@ func (m *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.Alloc
 
 		response := pluginapi.ContainerAllocateResponse{}
 
-		uuids := req.DevicesIDs
 		deviceIDs := m.deviceIDsFromUUIDs(uuids)
 
 		if deviceListStrategyFlag == DeviceListStrategyEnvvar {
@@ -320,6 +365,7 @@ func (m *NvidiaDevicePlugin) dial(unixSocketPath string, timeout time.Duration) 
 	return c, nil
 }
 
+// deviceExists checks if a k8s device exists
 func (m *NvidiaDevicePlugin) deviceExists(id string) bool {
 	for _, d := range m.cachedDevices {
 		if d.ID == id {
@@ -329,6 +375,17 @@ func (m *NvidiaDevicePlugin) deviceExists(id string) bool {
 	return false
 }
 
+// deviceReplicaExists checks if a k8s device replica exists
+func (m *NvidiaDevicePlugin) deviceReplicaExists(id string) bool {
+	for _, d := range m.deviceReplicas {
+		if d.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// apiDevices returns the K8S API Device type. This includes replicas
 func (m *NvidiaDevicePlugin) deviceIDsFromUUIDs(uuids []string) []string {
 	if deviceIDStrategyFlag == DeviceIDStrategyUUID {
 		return uuids
@@ -349,7 +406,7 @@ func (m *NvidiaDevicePlugin) deviceIDsFromUUIDs(uuids []string) []string {
 
 func (m *NvidiaDevicePlugin) apiDevices() []*pluginapi.Device {
 	var pdevs []*pluginapi.Device
-	for _, d := range m.cachedDevices {
+	for _, d := range m.deviceReplicas {
 		pdevs = append(pdevs, &d.Device)
 	}
 	return pdevs


### PR DESCRIPTION
Adding shared GPU support by replicating GPUs.  Closes #169 

This also supports renaming GPUs.

This was pulled from the ACT3 internal repository and has gone through the public release process with the U.S. Air Force.