### PR TITLE
Add GOLANG_ARCH arg to Ubuntu 20.04 Dockerfile

### DIFF
--- a/docker/Dockerfile.ubuntu20.04
+++ b/docker/Dockerfile.ubuntu20.04
@@ -22,8 +22,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/*
 
 ARG GOLANG_VERSION=1.15.8
+ARG GOLANG_ARCH=amd64
 RUN : "${GOLANG_VERSION:?ERROR: Build argument GOLANG_VERSION needs to be set and non-empty.}"
-RUN wget -nv -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz \
+RUN wget -nv -O - https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-${GOLANG_ARCH}.tar.gz \
     | tar -C /usr/local -xz
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH


### PR DESCRIPTION
This enables the plugin to be built for arm64/aarch64 platforms, such as NVIDIA Clara AGX with a dGPU (on which this build has been tested).

Doing so requires the following build arguments to 'docker build':

    --build-arg CUDA_IMAGE=cuda-arm64 --build-arg GOLANG_ARCH=arm64