### PR TITLE
accepting a XIDs to ignore from healthcheck

### DIFF
--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -28,14 +28,17 @@ import (
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
-var migStrategyFlag string
-var failOnInitErrorFlag bool
-var passDeviceSpecsFlag bool
-var deviceListStrategyFlag string
-var deviceIDStrategyFlag string
-var nvidiaDriverRootFlag string
+var (
+	migStrategyFlag        string
+	failOnInitErrorFlag    bool
+	passDeviceSpecsFlag    bool
+	deviceListStrategyFlag string
+	deviceIDStrategyFlag   string
+	nvidiaDriverRootFlag   string
+	ignoreXIDSliceFlag     []int64
 
-var version string // This should be set at build time to indicate the actual version
+	version string // This should be set at build time to indicate the actual version
+)
 
 func main() {
 	c := cli.NewApp()
@@ -86,6 +89,16 @@ func main() {
 			Destination: &nvidiaDriverRootFlag,
 			EnvVars:     []string{"NVIDIA_DRIVER_ROOT"},
 		},
+		&cli.Int64SliceFlag{
+			Name:    "ignore-xid",
+			Value:   cli.NewInt64Slice(31, 43, 45),
+			Usage:   "ignore these XIDs from affecting healthcheck as they are not hardware errors",
+			EnvVars: []string{"IGNORE_XID"},
+		},
+	}
+	c.Action = func(ctx *cli.Context) error {
+		ignoreXIDSliceFlag = ctx.Int64Slice("ignore-xid")
+		return nil
 	}
 
 	err := c.Run(os.Args)

--- a/cmd/nvidia-device-plugin/nvidia.go
+++ b/cmd/nvidia-device-plugin/nvidia.go
@@ -202,11 +202,12 @@ func checkHealth(stop <-chan interface{}, devices []*Device, unhealthy chan<- *D
 			continue
 		}
 
-		// FIXME: formalize the full list and document it.
-		// http://docs.nvidia.com/deploy/xid-errors/index.html#topic_4
-		// Application errors: the GPU should still be healthy
-		if e.Edata == 31 || e.Edata == 43 || e.Edata == 45 {
-			continue
+		// allowing the end user to supply which XIDs to ignore as application error as
+		// http://docs.nvidia.com/deploy/xid-errors/index.html#topic_4 is not alway kept up to date
+		for _, v := range ignoreXIDSliceFlag {
+			if e.Edata == uint64(v) {
+				continue
+			}
 		}
 
 		if e.UUID == nil || len(*e.UUID) == 0 {


### PR DESCRIPTION
It's not always clear if the XID reported by the hardware is actual
hardware or application errors. The list if XID is also not alway up to
date. Allowing the end user to provide a list of XIDs they can safely
ignore to prevent GPUs from become unhealthy when it's an application
issues.