### PR TITLE
update the Dockerfile: NVIDIA_DRIVER_CAPABILITIES=utility,compute

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ FROM nvcr.io/nvidia/${CUDA_IMAGE}:${CUDA_VERSION}-base-${BASE_DIST}
 
 ENV NVIDIA_DISABLE_REQUIRE="true"
 ENV NVIDIA_VISIBLE_DEVICES=all
-ENV NVIDIA_DRIVER_CAPABILITIES=utility
+ENV NVIDIA_DRIVER_CAPABILITIES=utility,compute
 
 LABEL io.k8s.display-name="NVIDIA Device Plugin"
 LABEL name="NVIDIA Device Plugin"


### PR DESCRIPTION
There are no nvidia-uvm and nvidia-uvm-tools in the nvidia-device-plugin container , so there will be no nvidia-uvm and nvidia-uvm-tools in the containers which are created by the nvidia-device-plugin container.Add "NVIDIA_DRIVER_CAPABILITIES=utility,compute" in the Dockerfile can resolve this problem.