### PR TITLE
[add]: support for hostNetwork parameter in daemonset deployment

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/daemonset.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset.yml
@@ -24,6 +24,10 @@ metadata:
   labels:
     {{- include "nvidia-device-plugin.labels" . | nindent 4 }}
 spec:
+  {{- if .Values.hostNetwork }}
+  hostNetwork: {{ .Values.hostNetwork }}
+  dnsPolicy: ClusterFirstWithHostNet
+  {{- end }}
   {{- if not .Values.legacyDaemonsetAPI }}
   selector:
     matchLabels:


### PR DESCRIPTION
If hostNetwork parameter is set to true then host ip is assigned to the daemonset instead of assigning a new ip.

This can be set to true, when:

Daemonset is not externallly accessed.
It saves an Ip address.
If hostNetwork is available in values yaml. and value is 'true' then add the hostNetwork parameter to template spec.

spec:
{{- if .Values.hostNetwork }}
hostNetwork: {{ .Values.hostNetwork }}
{{- end }}

Signed-off-by: Vasudev Singh C vasudev.singhc@jda.com