### PR TITLE
Fix containerd config in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ version = 2
           runtime_root = ""
           runtime_type = "io.containerd.runc.v2"
           [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
-            BinaryName = "/usr/bin/nvidia-container-runtime
+            BinaryName = "/usr/bin/nvidia-container-runtime"
 ```
 And then restart `containerd`:
 ```


### PR DESCRIPTION
I've tried to configure my `containerd` with the snippet you provided and spotted a typo. It's fixed here.