### PR TITLE
#364 Check config symlink instead of file existence in config-manager

### DIFF
--- a/cmd/config-manager/main.go
+++ b/cmd/config-manager/main.go
@@ -394,18 +394,18 @@ func updateSymlink(config string, f *Flags) (bool, error) {
 		src = filepath.Join(f.ConfigFileSrcdir, config)
 	}
 
-	exists, err := fileExists(f.ConfigFileDst)
+	exists, err := symlinkExists(f.ConfigFileDst)
 	if err != nil {
-		return false, fmt.Errorf("error checking if file '%s' exists: %v", f.ConfigFileDst, err)
+		return false, fmt.Errorf("error checking if symlink '%s' exists: %v", f.ConfigFileDst, err)
 	}
 	if exists {
 		srcRealpath, err := filepath.EvalSymlinks(src)
-		if err != nil {
+		if err != nil && !os.IsNotExist(err) {
 			return false, fmt.Errorf("error evaluating realpath of '%v': %v", src, err)
 		}
 
 		dstRealpath, err := filepath.EvalSymlinks(f.ConfigFileDst)
-		if err != nil {
+		if err != nil && !os.IsNotExist(err) {
 			return false, fmt.Errorf("error evaluating realpath of '%v': %v", f.ConfigFileDst, err)
 		}
 
@@ -456,8 +456,8 @@ func findPidToSignal(f *Flags) (int, error) {
 	return -1, fmt.Errorf("no process found")
 }
 
-func fileExists(filename string) (bool, error) {
-	info, err := os.Stat(filename)
+func symlinkExists(filename string) (bool, error) {
+	info, err := os.Lstat(filename)
 	if os.IsNotExist(err) {
 		return false, nil
 	}


### PR DESCRIPTION
As described in issue #364, when changing value of the configuration label, the config-manager tries to create the symlink to the new config file without properly deleting the symlink pointing to the previous (deleted) configuration file, thus resulting in the "file exists" error mentioned above when trying to create the symlink to the new configuration. 

The PR makes the config-manager check for symlink existence instead of checking if the linked file exists.