### PR TITLE
Add prestart-hook for device plugin

### DIFF
--- a/api/config/v1/flags.go
+++ b/api/config/v1/flags.go
@@ -31,6 +31,8 @@ func updateFromCLIFlag[T any](pflag **T, c *cli.Context, flagName string) {
 		switch flag := any(pflag).(type) {
 		case **string:
 			*flag = ptr(c.String(flagName))
+		case **[]string:
+			*flag = ptr(c.StringSlice(flagName))
 		case **bool:
 			*flag = ptr(c.Bool(flagName))
 		case **Duration:
@@ -61,6 +63,7 @@ type PluginCommandLineFlags struct {
 	DeviceListStrategy *string `json:"deviceListStrategy" yaml:"deviceListStrategy"`
 	DeviceIDStrategy   *string `json:"deviceIDStrategy"   yaml:"deviceIDStrategy"`
 	NvidiaCTKPath      *string `json:"nvidiaCTKPath"      yaml:"nvidiaCTKPath"`
+	PreStartCommand    *[]string `json:"preStartCommand"    yaml:"preStartCommand"`
 }
 
 // GFDCommandLineFlags holds the list of command line flags specific to GFD.
@@ -102,6 +105,8 @@ func (f *Flags) UpdateFromCLIFlags(c *cli.Context, flags []cli.Flag) {
 				updateFromCLIFlag(&f.Plugin.DeviceIDStrategy, c, n)
 			case "nvidia-ctk-path":
 				updateFromCLIFlag(&f.Plugin.NvidiaCTKPath, c, n)
+			case "pre-start-command":
+				updateFromCLIFlag(&f.Plugin.PreStartCommand, c, n)
 			}
 			// GFD specific flags
 			if f.GFD == nil {

--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -102,6 +102,10 @@ func main() {
 			Value:   spec.DefaultNvidiaCTKPath,
 			Usage:   "The path to use for the nvidia-ctk in the generated CDI specification.",
 			EnvVars: []string{"NVIDIA_CTK_PATH"},
+		&cli.StringSliceFlag{
+			Name:    "pre-start-command",
+			Usage:   "command to run to initialize device (repeat this arg for command and each argument)",
+			EnvVars: []string{"PRE_START_CMD"},
 		},
 	}
 
@@ -254,11 +258,21 @@ func startPlugins(c *cli.Context, flags []cli.Flag, restarting bool) ([]*NvidiaD
 		return nil, false, fmt.Errorf("error getting plugins: %v", err)
 	}
 
+	// If needed, get prestart hook.
+	var preStartHook *PreStartHook = nil
+	preStartCommand := *config.Flags.Plugin.PreStartCommand
+	if len(preStartCommand) > 0 {
+		preStartHook = NewPreStartHook(preStartCommand)
+	}
+
 	// Loop through all plugins, starting them if they have any devices
 	// to serve. If even one plugin fails to start properly, try
 	// starting them all again.
 	started := 0
 	for _, p := range plugins {
+
+		p.SetPreStartHook(preStartHook)
+
 		// Just continue if there are no devices to serve for plugin p.
 		if len(p.Devices()) == 0 {
 			continue

--- a/cmd/nvidia-device-plugin/prestart-hook.go
+++ b/cmd/nvidia-device-plugin/prestart-hook.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+
+	"golang.org/x/net/context"
+	"golang.org/x/sync/semaphore"
+
+	"github.com/NVIDIA/k8s-device-plugin/internal/rm"
+)
+
+type PreStartHook struct {
+	preStartCmd     []string
+	deviceInfos     map[string]*DevicePreStartInfo
+	deviceInfosLock *semaphore.Weighted // Take this if you want to add/remove elements to/from deviceInfos. Not needed for operations on the values themselves.
+}
+
+type DevicePreStartInfo struct {
+	lock             *semaphore.Weighted
+	preStartFailures int32
+}
+
+func NewPreStartHook(cmd []string) *PreStartHook {
+	log.Println("Using PreStart hook")
+	for i, a := range cmd {
+		log.Printf("PreStartHook arg[%d] = %s\n", i, a)
+	}
+
+	return &PreStartHook{
+		preStartCmd:     cmd,
+		deviceInfos:     make(map[string]*DevicePreStartInfo),
+		deviceInfosLock: semaphore.NewWeighted(1),
+	}
+}
+
+func (hook *PreStartHook) TryHandlePreStartContainer(ctx context.Context, deviceIDs []string, allDevices rm.Devices, unhealthy chan<- *rm.Device) error {
+
+	devices, err := findDevices(deviceIDs, allDevices)
+	if err != nil {
+		return err
+	}
+
+	return hook.tryHandlePreStartContainer(ctx, devices, unhealthy)
+}
+
+func (hook *PreStartHook) tryHandlePreStartContainer(ctx context.Context, devices []*rm.Device, unhealthyChan chan<- *rm.Device) error {
+	logCtx := getLogContextFromDevices(devices)
+
+	// check if any of the devices are already unhealthy
+	for _, device := range devices {
+		if device.Health != "Healthy" {
+			return fmt.Errorf("Device %s has health status %s", deviceString(device), device.Health)
+		}
+	}
+
+	// lock devices
+	for _, device := range devices {
+
+		preStartInfo, err := hook.getDevicePreStartInfo(ctx, device.ID, logCtx)
+		if err != nil {
+			return err
+		}
+
+		log.Printf("PreStartHook(%s): locking device %s...\n", logCtx, deviceString(device))
+		if err := preStartInfo.lockDevice(ctx); err != nil {
+			return err
+		}
+		log.Printf("PreStartHook(%s): locked device %s\n", logCtx, deviceString(device))
+		defer preStartInfo.unlockDevice(ctx)
+	}
+
+	// run pre-start container command
+	unhealthy, err := hook.runPreStartContainerCommand(ctx, devices)
+	log.Printf("PreStartHook(%s): pre start container command completed. unhealthy:%v command-err:%v context-err:%v\n", logCtx, unhealthy, err, ctx.Err())
+
+	// if ctx deadline exceeded or command exited with non-zero exit code then add failure to all devices
+	// when we fail 5 times then mark device as unhealthy
+	if err == nil {
+		err = ctx.Err()
+	}
+
+	if err != nil {
+		log.Printf("PreStartHook(%s): Error running pre-start command due to error: %v\n", logCtx, err)
+		for _, device := range devices {
+			preStartInfo, err := hook.getDevicePreStartInfo(ctx, device.ID, logCtx)
+			if err != nil {
+				log.Printf("PreStartHook(%s): %v", logCtx, err)
+				continue
+			}
+
+			failures := preStartInfo.incPreStartFailures()
+			log.Printf("PreStartHook(%s): Failure count for device %s: %d\n", logCtx, device.ID, failures)
+			if failures > 4 {
+				markUnhealthy(device, unhealthyChan, logCtx)
+			}
+		}
+		return err
+	}
+
+	// if no timeout and exit code 0 then reset all pre-start failure counts
+	for _, device := range devices {
+		if preStartInfo, err := hook.getDevicePreStartInfo(ctx, device.ID, logCtx); err == nil {
+			preStartInfo.resetPreStartFailures()
+		} else {
+			log.Printf("PreStartHook(%s): Unable to failure reset count. Device not found: %v\n", logCtx, err)
+		}
+
+	}
+
+	// mark reported devices as unhealthy
+	for _, uuid := range unhealthy {
+		if device, err := findDevice(uuid, devices); err == nil {
+			markUnhealthy(device, unhealthyChan, logCtx)
+		} else {
+			log.Printf("PreStartHook(%s): Unable to mark device as unhealty. Device not found: %v\n", logCtx, err)
+		}
+	}
+
+	if len(unhealthy) > 0 {
+		return fmt.Errorf("Found unhealthy devices %s", strings.Join(unhealthy, " "))
+	}
+	return nil
+}
+
+func (hook *PreStartHook) runPreStartContainerCommand(ctx context.Context, devices []*rm.Device) (unhealthy []string, err error) {
+	if len(devices) == 0 {
+		return
+	}
+	logCtx := getLogContextFromDevices(devices)
+
+	cmd := hook.preStartCmd[0]
+	args := hook.preStartCmd[1:]
+	for _, device := range devices {
+		uuid := strings.TrimPrefix(device.ID, "GPU-")
+		args = append(args, uuid)
+	}
+
+	log.Printf("PreStartHook(%s): creating command %s %v\n", logCtx, cmd, args)
+	cmdCtx := exec.CommandContext(ctx, cmd, args...)
+	log.Printf("PreStartHook(%s): created command\n", logCtx)
+
+	stdout, err := cmdCtx.StdoutPipe()
+	if err != nil {
+		err = fmt.Errorf("error getting stdout pipe: %v", err)
+		return
+	}
+	stdoutDone := make(chan struct{})
+	go func() {
+		s := bufio.NewScanner(stdout)
+		for s.Scan() {
+			line := s.Text()
+			fmt.Printf("PreStartHook(%s)::out: %s\n", logCtx, line)
+		}
+		stdoutDone <- struct{}{}
+	}()
+	log.Printf("PreStartHook(%s): got stdout\n", logCtx)
+
+	stderr, err := cmdCtx.StderrPipe()
+	if err != nil {
+		err = fmt.Errorf("error getting stderr pipe: %v", err)
+		return
+	}
+	stderrDone := make(chan []string)
+	go func() {
+		s := bufio.NewScanner(stderr)
+		uuids := []string{}
+		for s.Scan() {
+			line := s.Text()
+			log.Printf("PreStartHook(%s)::err: %s\n", logCtx, line)
+			uuids = append(uuids, line)
+		}
+		stderrDone <- uuids
+	}()
+	log.Printf("PreStartHook(%s): got stderr\n", logCtx)
+
+	err = cmdCtx.Start()
+	if err != nil {
+		err = fmt.Errorf("error starting: %v", err)
+		return
+	}
+	log.Printf("PreStartHook(%s): started command\n", logCtx)
+
+	err = cmdCtx.Wait()
+	if err != nil {
+		err = fmt.Errorf("command failed to run: %v", err)
+	}
+	log.Printf("PreStartHook(%s): command exited with code %d\n", logCtx, cmdCtx.ProcessState.ExitCode())
+
+	<-stdoutDone
+	log.Printf("PreStartHook(%s): stdout closed\n", logCtx)
+
+	unhealthy = <-stderrDone
+	log.Printf("PreStartHook(%s): stderr closed\n", logCtx)
+
+	return
+}
+
+func markUnhealthy(device *rm.Device, unhealthyChan chan<- *rm.Device, logCtx string) {
+	log.Printf("PreStartHook(%s): Marking device %s as unhealthy\n", logCtx, deviceString(device))
+	unhealthyChan <- device
+}
+
+func getLogContextFromDeviceIDs(deviceIDs []string) string {
+	return strings.ReplaceAll(strings.Join(deviceIDs, "-"), "nvidia", "")
+}
+
+func getLogContextFromDevices(devices []*rm.Device) string {
+	ids := make([]string, len(devices))
+	for i, v := range devices {
+		ids[i] = v.ID
+	}
+	return getLogContextFromDeviceIDs(ids)
+}
+
+func (hook *PreStartHook) getDevicePreStartInfo(ctx context.Context, deviceId string, logCtx string) (*DevicePreStartInfo, error) {
+	err := hook.deviceInfosLock.Acquire(ctx, 1)
+	if err != nil {
+		return nil, err
+	}
+
+	defer hook.deviceInfosLock.Release(1)
+	info, ok := hook.deviceInfos[deviceId]
+	if !ok {
+		log.Printf("PreStartHook(%s): Creating device PreStart info for %q\n", logCtx, deviceId)
+		info = newDevicePreStartInfo()
+		hook.deviceInfos[deviceId] = info
+	}
+	return info, nil
+}
+
+func findDevice(deviceId string, allDevices []*rm.Device) (*rm.Device, error) {
+	for _, device := range allDevices {
+		if device.ID == deviceId {
+			return device, nil
+		}
+	}
+	return nil, fmt.Errorf("Device %q not found", deviceId)
+}
+
+func findDevices(deviceIds []string, allDevices rm.Devices) ([]*rm.Device, error) {
+	result := make([]*rm.Device, len(deviceIds))
+	for i, deviceId := range deviceIds {
+		result[i] = allDevices.GetByID(deviceId)
+		if result[i] == nil {
+			return nil, fmt.Errorf("Device %q not found", deviceId)
+		}
+	}
+	return result, nil
+}
+
+func deviceString(device *rm.Device) string {
+	return fmt.Sprintf("%q %s", device.ID, strings.Join(device.Paths, " "))
+}
+
+func newDevicePreStartInfo() *DevicePreStartInfo {
+	return &DevicePreStartInfo{
+		lock:             semaphore.NewWeighted(1),
+		preStartFailures: 0,
+	}
+}
+
+func (d *DevicePreStartInfo) lockDevice(ctx context.Context) error {
+	return d.lock.Acquire(ctx, 1)
+}
+
+func (d *DevicePreStartInfo) unlockDevice(ctx context.Context) {
+	d.lock.Release(1)
+}
+
+// increments pre-start failure count and return the current value
+func (d *DevicePreStartInfo) incPreStartFailures() int32 {
+	return atomic.AddInt32(&d.preStartFailures, 1)
+}
+
+// resets pre-start failure back count to zero
+func (d *DevicePreStartInfo) resetPreStartFailures() {
+	atomic.StoreInt32(&d.preStartFailures, 0)
+}

--- a/cmd/nvidia-device-plugin/server.go
+++ b/cmd/nvidia-device-plugin/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 
 	"k8s.io/klog/v2"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
@@ -53,9 +54,10 @@ type NvidiaDevicePlugin struct {
 
 	cdi cdi.Interface
 
-	server *grpc.Server
-	health chan *rm.Device
-	stop   chan interface{}
+	server       *grpc.Server
+	health       chan *rm.Device
+	stop         chan interface{}
+	preStartHook *PreStartHook
 }
 
 // NewNvidiaDevicePlugin returns an initialized NvidiaDevicePlugin
@@ -71,9 +73,10 @@ func NewNvidiaDevicePlugin(config *spec.Config, resourceManager rm.ResourceManag
 
 		// These will be reinitialized every
 		// time the plugin server is restarted.
-		server: nil,
-		health: nil,
-		stop:   nil,
+		server:       nil,
+		health:       nil,
+		stop:         nil,
+		preStartHook: nil,
 	}
 }
 
@@ -88,6 +91,10 @@ func (plugin *NvidiaDevicePlugin) cleanup() {
 	plugin.server = nil
 	plugin.health = nil
 	plugin.stop = nil
+}
+
+func (m *NvidiaDevicePlugin) SetPreStartHook(hook *PreStartHook) {
+	m.preStartHook = hook
 }
 
 // Devices returns the full set of devices associated with the plugin.
@@ -205,6 +212,7 @@ func (plugin *NvidiaDevicePlugin) Register() error {
 		ResourceName: string(plugin.rm.Resource()),
 		Options: &pluginapi.DevicePluginOptions{
 			GetPreferredAllocationAvailable: true,
+			PreStartRequired:                plugin.preStartRequired(),
 		},
 	}
 
@@ -213,6 +221,13 @@ func (plugin *NvidiaDevicePlugin) Register() error {
 		return err
 	}
 	return nil
+}
+
+func (m *NvidiaDevicePlugin) preStartRequired() bool {
+	if m.preStartHook != nil {
+		return true
+	}
+	return false
 }
 
 // GetDevicePluginOptions returns the values of the optional settings for this plugin
@@ -343,8 +358,14 @@ func (plugin *NvidiaDevicePlugin) getAllocateResponseForCDIAnnotations(responseI
 	return &response
 }
 
-// PreStartContainer is unimplemented for this plugin
-func (plugin *NvidiaDevicePlugin) PreStartContainer(context.Context, *pluginapi.PreStartContainerRequest) (*pluginapi.PreStartContainerResponse, error) {
+func (plugin *NvidiaDevicePlugin) PreStartContainer(ctx context.Context, r *pluginapi.PreStartContainerRequest) (*pluginapi.PreStartContainerResponse, error) {
+	if plugin.preStartRequired() {
+		timeoutCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+		defer cancel()
+		if err := plugin.preStartHook.TryHandlePreStartContainer(timeoutCtx, r.DevicesIDs, plugin.rm.Devices(), plugin.health); err != nil {
+			return &pluginapi.PreStartContainerResponse{}, grpc.Errorf(codes.FailedPrecondition, fmt.Sprintf("GPU device plugin pre-start hook failed: %v", err))
+		}
+	}
 	return &pluginapi.PreStartContainerResponse{}, nil
 }
 

--- a/go.sum
+++ b/go.sum
@@ -747,6 +747,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20171026204733-164713f0dfce/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/vendor/golang.org/x/sync/AUTHORS
+++ b/vendor/golang.org/x/sync/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/sync/CONTRIBUTORS
+++ b/vendor/golang.org/x/sync/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/semaphore/semaphore.go
+++ b/vendor/golang.org/x/sync/semaphore/semaphore.go
@@ -1,0 +1,136 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semaphore provides a weighted semaphore implementation.
+package semaphore // import "golang.org/x/sync/semaphore"
+
+import (
+	"container/list"
+	"context"
+	"sync"
+)
+
+type waiter struct {
+	n     int64
+	ready chan<- struct{} // Closed when semaphore acquired.
+}
+
+// NewWeighted creates a new weighted semaphore with the given
+// maximum combined weight for concurrent access.
+func NewWeighted(n int64) *Weighted {
+	w := &Weighted{size: n}
+	return w
+}
+
+// Weighted provides a way to bound concurrent access to a resource.
+// The callers can request access with a given weight.
+type Weighted struct {
+	size    int64
+	cur     int64
+	mu      sync.Mutex
+	waiters list.List
+}
+
+// Acquire acquires the semaphore with a weight of n, blocking until resources
+// are available or ctx is done. On success, returns nil. On failure, returns
+// ctx.Err() and leaves the semaphore unchanged.
+//
+// If ctx is already done, Acquire may still succeed without blocking.
+func (s *Weighted) Acquire(ctx context.Context, n int64) error {
+	s.mu.Lock()
+	if s.size-s.cur >= n && s.waiters.Len() == 0 {
+		s.cur += n
+		s.mu.Unlock()
+		return nil
+	}
+
+	if n > s.size {
+		// Don't make other Acquire calls block on one that's doomed to fail.
+		s.mu.Unlock()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ready := make(chan struct{})
+	w := waiter{n: n, ready: ready}
+	elem := s.waiters.PushBack(w)
+	s.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		err := ctx.Err()
+		s.mu.Lock()
+		select {
+		case <-ready:
+			// Acquired the semaphore after we were canceled.  Rather than trying to
+			// fix up the queue, just pretend we didn't notice the cancelation.
+			err = nil
+		default:
+			isFront := s.waiters.Front() == elem
+			s.waiters.Remove(elem)
+			// If we're at the front and there're extra tokens left, notify other waiters.
+			if isFront && s.size > s.cur {
+				s.notifyWaiters()
+			}
+		}
+		s.mu.Unlock()
+		return err
+
+	case <-ready:
+		return nil
+	}
+}
+
+// TryAcquire acquires the semaphore with a weight of n without blocking.
+// On success, returns true. On failure, returns false and leaves the semaphore unchanged.
+func (s *Weighted) TryAcquire(n int64) bool {
+	s.mu.Lock()
+	success := s.size-s.cur >= n && s.waiters.Len() == 0
+	if success {
+		s.cur += n
+	}
+	s.mu.Unlock()
+	return success
+}
+
+// Release releases the semaphore with a weight of n.
+func (s *Weighted) Release(n int64) {
+	s.mu.Lock()
+	s.cur -= n
+	if s.cur < 0 {
+		s.mu.Unlock()
+		panic("semaphore: released more than held")
+	}
+	s.notifyWaiters()
+	s.mu.Unlock()
+}
+
+func (s *Weighted) notifyWaiters() {
+	for {
+		next := s.waiters.Front()
+		if next == nil {
+			break // No more waiters blocked.
+		}
+
+		w := next.Value.(waiter)
+		if s.size-s.cur < w.n {
+			// Not enough tokens for the next waiter.  We could keep going (to try to
+			// find a waiter with a smaller request), but under load that could cause
+			// starvation for large requests; instead, we leave all remaining waiters
+			// blocked.
+			//
+			// Consider a semaphore used as a read-write lock, with N tokens, N
+			// readers, and one writer.  Each reader can Acquire(1) to obtain a read
+			// lock.  The writer can Acquire(N) to obtain a write lock, excluding all
+			// of the readers.  If we allow the readers to jump ahead in the queue,
+			// the writer will starve — there is always one token available for every
+			// reader.
+			break
+		}
+
+		s.cur += w.n
+		s.waiters.Remove(next)
+		close(w.ready)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -148,6 +148,8 @@ golang.org/x/net/trace
 ## explicit; go 1.11
 golang.org/x/oauth2
 golang.org/x/oauth2/internal
+## explicit
+golang.org/x/sync/semaphore
 # golang.org/x/sys v0.5.0
 ## explicit; go 1.17
 golang.org/x/sys/internal/unsafeheader


### PR DESCRIPTION
Fixes #383 

We wanted to see what NVIDIA thinks of this addition to the k8s-device-plugin.  

We wanted to provide a way to delete the memory of a previous node and this PR achieves that.  We use this in our production cluster and we wanted to get it merged upstream.  

We provided a way to inject custom prehook commands so a separate caller can do a purge of memory if needed.

Happy to leave this as a discussion item!