### PR TITLE
gitlab location is where developers should open PRs on

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Please note that:
     - ...
 - Support will only be provided for the official NVIDIA device plugin (and not
   for forks or other variants of this plugin).
+- This is currently a read-only mirror of https://gitlab.com/nvidia/kubernetes/device-plugin and as such an MR should be created there instead.
 
 ## Prerequisites
 


### PR DESCRIPTION
As noted in https://github.com/NVIDIA/k8s-device-plugin/pull/391#issuecomment-1476176846, this repo is a read-only mirror of a gitlab repo.  This puts a note in the README so developers can be made aware of this.