### PR TITLE
Clarify FS watcher error with path

### DIFF
--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -154,7 +154,7 @@ func start(c *cli.Context, flags []cli.Flag) error {
 	klog.Info("Starting FS watcher.")
 	watcher, err := newFSWatcher(pluginapi.DevicePluginPath)
 	if err != nil {
-		return fmt.Errorf("failed to create FS watcher: %v", err)
+		return fmt.Errorf("failed to create FS watcher for %s: %v", pluginapi.DevicePluginPath, err)
 	}
 	defer watcher.Close()
 


### PR DESCRIPTION
This PR clarifies the following error:

```
failed to create FS watcher: no such file or directory
```

As a very fresh user, it's hard to distinguish which file is looking for.