### PR TITLE
Add ability to restart container on device failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,15 +182,16 @@ deploying the plugin via `helm`.
 
 ### As command line flags or envvars
 
-| Flag                     | Envvar                  | Default Value   |
-|--------------------------|-------------------------|-----------------|
-| `--mig-strategy`         | `$MIG_STRATEGY`         | `"none"`        |
-| `--fail-on-init-error`   | `$FAIL_ON_INIT_ERROR`   | `true`          |
-| `--nvidia-driver-root`   | `$NVIDIA_DRIVER_ROOT`   | `"/"`           |
-| `--pass-device-specs`    | `$PASS_DEVICE_SPECS`    | `false`         |
-| `--device-list-strategy` | `$DEVICE_LIST_STRATEGY` | `"envvar"`      |
-| `--device-id-strategy`   | `$DEVICE_ID_STRATEGY`   | `"uuid"`        |
-| `--config-file`          | `$CONFIG_FILE`          | `""`            |
+| Flag                            | Envvar                         | Default Value |
+|---------------------------------|--------------------------------|---------------|
+| `--mig-strategy`                | `$MIG_STRATEGY`                | `"none"`      |
+| `--fail-on-init-error`          | `$FAIL_ON_INIT_ERROR`          | `true`        |
+| `--restart-on-device-unhealthy` | `$RESTART_ON_DEVICE_UNHEALTHY` | `false`       |
+| `--nvidia-driver-root`          | `$NVIDIA_DRIVER_ROOT`          | `"/"`         |
+| `--pass-device-specs`           | `$PASS_DEVICE_SPECS`           | `false`       |
+| `--device-list-strategy`        | `$DEVICE_LIST_STRATEGY`        | `"envvar"`    |
+| `--device-id-strategy`          | `$DEVICE_ID_STRATEGY`          | `"uuid"`      |
+| `--config-file`                 | `$CONFIG_FILE`                 | `""`          |
 
 ### As a configuration file
 ```
@@ -198,6 +199,7 @@ version: v1
 flags:
   migStrategy: "none"
   failOnInitError: true
+  restartOnDeviceUnhealthy: false
   nvidiaDriverRoot: "/"
   plugin:
     passDeviceSpecs: false
@@ -524,6 +526,7 @@ version: v1
 flags:
   migStrategy: "none"
   failOnInitError: true
+  restartOnDeviceUnhealthy: false
   nvidiaDriverRoot: "/"
   plugin:
     passDeviceSpecs: false
@@ -574,6 +577,7 @@ version: v1
 flags:
   migStrategy: "mixed" # Only change from config0.yaml
   failOnInitError: true
+  restartOnDeviceUnhealthy: false
   nvidiaDriverRoot: "/"
   plugin:
     passDeviceSpecs: false
@@ -658,6 +662,10 @@ These values are as follows:
   failOnInitError:
       fail the plugin if an error is encountered during initialization, otherwise block indefinitely
       (default 'true')
+  restartOnDeviceUnhealthy:
+      trigger plugin k8s container health check failure (and, as a consequence, container restart)
+      if at least one device is marked as unhealthy
+      (default 'false')
   compatWithCPUManager:
       run with escalated privileges to be compatible with the static CPUManager policy
       (default 'false')

--- a/api/config/v1/flags.go
+++ b/api/config/v1/flags.go
@@ -48,13 +48,14 @@ type Flags struct {
 
 // CommandLineFlags holds the list of command line flags used to configure the device plugin and GFD.
 type CommandLineFlags struct {
-	MigStrategy      *string                 `json:"migStrategy"                yaml:"migStrategy"`
-	FailOnInitError  *bool                   `json:"failOnInitError"            yaml:"failOnInitError"`
-	NvidiaDriverRoot *string                 `json:"nvidiaDriverRoot,omitempty" yaml:"nvidiaDriverRoot,omitempty"`
-	GDSEnabled       *bool                   `json:"gdsEnabled"                 yaml:"gdsEnabled"`
-	MOFEDEnabled     *bool                   `json:"mofedEnabled"               yaml:"mofedEnabled"`
-	Plugin           *PluginCommandLineFlags `json:"plugin,omitempty"           yaml:"plugin,omitempty"`
-	GFD              *GFDCommandLineFlags    `json:"gfd,omitempty"              yaml:"gfd,omitempty"`
+	MigStrategy              *string                 `json:"migStrategy"                yaml:"migStrategy"`
+	FailOnInitError          *bool                   `json:"failOnInitError"            yaml:"failOnInitError"`
+	RestartOnDeviceUnhealthy *bool                   `json:"restartOnDeviceUnhealthy"   yaml:"restartOnDeviceUnhealthy"`
+	NvidiaDriverRoot         *string                 `json:"nvidiaDriverRoot,omitempty" yaml:"nvidiaDriverRoot,omitempty"`
+	GDSEnabled               *bool                   `json:"gdsEnabled"                 yaml:"gdsEnabled"`
+	MOFEDEnabled             *bool                   `json:"mofedEnabled"               yaml:"mofedEnabled"`
+	Plugin                   *PluginCommandLineFlags `json:"plugin,omitempty"           yaml:"plugin,omitempty"`
+	GFD                      *GFDCommandLineFlags    `json:"gfd,omitempty"              yaml:"gfd,omitempty"`
 }
 
 // PluginCommandLineFlags holds the list of command line flags specific to the device plugin.
@@ -86,6 +87,8 @@ func (f *Flags) UpdateFromCLIFlags(c *cli.Context, flags []cli.Flag) {
 				updateFromCLIFlag(&f.MigStrategy, c, n)
 			case "fail-on-init-error":
 				updateFromCLIFlag(&f.FailOnInitError, c, n)
+			case "restart-on-device-unhealthy":
+				updateFromCLIFlag(&f.RestartOnDeviceUnhealthy, c, n)
 			case "nvidia-driver-root":
 				updateFromCLIFlag(&f.NvidiaDriverRoot, c, n)
 			case "gds-enabled":

--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -58,6 +58,12 @@ func main() {
 			Usage:   "fail the plugin if an error is encountered during initialization, otherwise block indefinitely",
 			EnvVars: []string{"FAIL_ON_INIT_ERROR"},
 		},
+		&cli.BoolFlag{
+			Name:    "restart-on-device-unhealthy",
+			Value:   false,
+			Usage:   "trigger the plugin container restart if at least one device is unhealthy",
+			EnvVars: []string{"RESTART_ON_DEVICE_UNHEALTHY"},
+		},
 		&cli.StringFlag{
 			Name:    "nvidia-driver-root",
 			Value:   "/",

--- a/deployments/helm/nvidia-device-plugin/Chart.yaml
+++ b/deployments/helm/nvidia-device-plugin/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nvidia-device-plugin
 type: application
 description: A Helm chart for the nvidia-device-plugin on Kubernetes
-version: "0.14.0"
-appVersion: "0.14.0"
+version: "0.14.1"
+appVersion: "0.14.1"
 kubeVersion: ">= 1.10.0-0"
 home: https://github.com/NVIDIA/k8s-device-plugin
 

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset.yml
@@ -144,6 +144,10 @@ spec:
           - name: FAIL_ON_INIT_ERROR
             value: "{{ .Values.failOnInitError }}"
         {{- end }}
+        {{- if typeIs "bool" .Values.restartOnDeviceUnhealthy }}
+        - name: RESTART_ON_DEVICE_UNHEALTHY
+          value: "{{ .Values.restartOnDeviceUnhealthy }}"
+        {{- end }}
         {{- if typeIs "bool" .Values.compatWithCPUManager }}
           - name: PASS_DEVICE_SPECS
             value: "{{ .Values.compatWithCPUManager }}"
@@ -191,6 +195,12 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 5000
+          initialDelaySeconds: 3
+          periodSeconds: 3
       volumes:
         - name: device-plugin
           hostPath:

--- a/deployments/helm/nvidia-device-plugin/templates/gfd.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/gfd.yml
@@ -138,6 +138,10 @@ spec:
             - name: GFD_FAIL_ON_INIT_ERROR
               value: "{{ $root.Values.failOnInitError }}"
           {{- end }}
+          {{- if typeIs "bool" $root.Values.restartOnDeviceUnhealthy }}
+            - name: RESTART_ON_DEVICE_UNHEALTHY
+              value: "{{ .Values.restartOnDeviceUnhealthy }}"
+          {{- end }}
           {{- if typeIs "string" $root.Values.migStrategy }}
             - name: GFD_MIG_STRATEGY
               value: "{{ $root.Values.migStrategy }}"
@@ -175,6 +179,12 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 5000
+            initialDelaySeconds: 3
+            periodSeconds: 3
       volumes:
         - name: output-dir
           hostPath:

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -31,6 +31,7 @@ legacyDaemonsetAPI: null
 compatWithCPUManager: null
 migStrategy: null
 failOnInitError: null
+restartOnDeviceUnhealthy: null
 deviceListStrategy: null
 deviceIDStrategy: null
 nvidiaDriverRoot: null

--- a/nvidia-device-plugin.yml
+++ b/nvidia-device-plugin.yml
@@ -38,7 +38,7 @@ spec:
       # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
       priorityClassName: "system-node-critical"
       containers:
-      - image: nvcr.io/nvidia/k8s-device-plugin:v0.14.0
+      - image: nvcr.io/nvidia/k8s-device-plugin:v0.14.1
         name: nvidia-device-plugin-ctr
         env:
           - name: FAIL_ON_INIT_ERROR
@@ -50,6 +50,12 @@ spec:
         volumeMounts:
         - name: device-plugin
           mountPath: /var/lib/kubelet/device-plugins
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 5000
+          initialDelaySeconds: 3
+          periodSeconds: 3
       volumes:
       - name: device-plugin
         hostPath:


### PR DESCRIPTION
We started to use the plugin on our gpu kubelets - while it's working correctly and does exactly what we need, sometimes we encountered the weird "unknown error" coming from device. This marks device as unhealthy, plugin passes the unhealthy status as gpu resource status to k8s, resource stops to be available and it gets stuck in this state for days.

While we don't really know the cause of this "unknown error", we observed that a simple plugin container restart fixes the issue completely and it runs just fine until the next "unknown error" occurs. So the proposed change is to provide ability to restart container when device is marked unhealthy - with help of k8s healthchecks.

This change is already in use in our production for around a month (deployed via custom docker image build) - we don't see any issues and it works as expected (restarts container on device failures).