### PR TITLE
Fix k8s device plugin README location

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The NVIDIA device plugin for Kubernetes is a Daemonset that allows you to automa
 - Keep track of the health of your GPUs
 - Run GPU enabled containers in your Kubernetes cluster.
 
-This repository contains NVIDIA's official implementation of the [Kubernetes device plugin](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-management/device-plugin.md).
+This repository contains NVIDIA's official implementation of the [Kubernetes device plugin](https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/3573-device-plugin/README.md).
 
 Please note that:
 - The NVIDIA device plugin API is beta as of Kubernetes v1.10.


### PR DESCRIPTION
The current link yields a 404 because it has moved from kubernetes/community to kubernetes/enhancements

// Edit: I just noticed this is a read-only mirror. Re-opened the PR on GitLab: https://gitlab.com/nvidia/kubernetes/device-plugin/-/merge_requests/295 