### PR TITLE
Return all available directly if preferred allocating all

### DIFF
--- a/internal/rm/nvml_manager.go
+++ b/internal/rm/nvml_manager.go
@@ -112,6 +112,11 @@ func (r *nvmlResourceManager) getPreferredAllocation(available, required []strin
 // alignedAlloc shells out to the alignedAllocationPolicy that is set in
 // order to calculate the preferred allocation.
 func (r *nvmlResourceManager) alignedAlloc(available, required []string, size int) ([]string, error) {
+	// return all available directly if allocating all available devices
+	if len(available) == size {
+		return available, nil
+	}
+
 	var devices []string
 
 	linkedDevices, err := gpuallocator.NewDevices(


### PR DESCRIPTION
We found retrieving all GPU statuses will take seconds in nodes with multiple GPUs when kubelet calls `GetPreferredAllocation`.

and if the available ones are all the kubelet requesting, maybe the device plugins can return the available ones directly.

we made some changes and found it was working as expected much faster.

so we are raising up this PR to discuss this solution:

1. is it ok to skip the following nvml detections in `GetPreferredAllocation`?
2. are there any other things we need to consider before adding this change?