### PR TITLE
Added documentation for usage with the CRI-O container engine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,38 @@ And then restart `containerd`:
 $ sudo systemctl restart containerd
 ```
 
+##### Configure `CRI-O`
+When running `kubernetes` with `CRI-O`, add the config file to set the
+`nvidia-container-runtime` as the default low-level OCI runtime under
+`/etc/crio/crio.conf.d/99-nvidia.conf`. This will take priority over the default
+`crun` config file at `/etc/crio/crio.conf.d/10-crun.conf`:
+```
+[crio]
+
+  [crio.runtime]
+    default_runtime = "nvidia"
+
+    [crio.runtime.runtimes]
+
+      [crio.runtime.runtimes.nvidia]
+        runtime_path = "/usr/bin/nvidia-container-runtime"
+        runtime_type = "oci"
+```
+This file can automatically be generated with the nvidia-ctk command:
+```
+$ sudo nvidia-ctk runtime configure --runtime=crio --nvidia-set-as-default --config=/etc/crio/crio.conf.d/99-nvidia.conf
+```
+`CRI-O` uses `crun` as default low-level OCI runtime so `crun` needs to be added
+to the runtimes of the `nvidia-container-runtime` in the config file at `/etc/nvidia-container-runtime/config.toml`:
+```
+[nvidia-container-runtime]
+runtimes = ["crun", "docker-runc", "runc"]
+```
+And then restart `CRI-O`:
+```
+$ sudo systemctl restart crio
+```
+
 ### Enabling GPU Support in Kubernetes
 
 Once you have configured the options above on all the GPU nodes in your


### PR DESCRIPTION
Added a section to the README.md, providing documentation for the CRI-O Container Engine. This includes the command to automatically generate the Nvidia-runtime config file for CRI-O using Nvidia-ctk. Since CRI-O moved from the OBS repo to the Kubernetes repo, the default configuration is now in-memory, eliminating the need to modify the /etc/crio/crio.conf file.

Note that CRI-O uses crun as the default OCI container runtime, and the Nvidia-container-runtime config file is located at /etc/nvidia-container-runtime/config.toml. However, crun is not set in the list with runtimes in the configuration. Therefore, crun must be added to the list of runtimes in the nvidia-container-runtime config file.

Signed-off-by: Indy Van Mol <indy.van.mol@endstra.dev>