### PR TITLE
Fix mps deployment

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -186,7 +186,6 @@ spec:
           # This is required for CDI detection to work correctly.
           - name: driver-root
             mountPath: /driver-root
-            readOnly: true
         {{- end }}
           # The MPS /dev/shm is needed to allow for MPS daemon health-checking.
           - name: mps-shm
@@ -213,6 +212,7 @@ spec:
           hostPath:
           # TODO: This should be /var/run/nvidia/mps
             path: /var/lib/kubelet/device-plugins/mps
+            type: DirectoryOrCreate
         - name: mps-shm
           hostPath:
             path: /var/lib/kubelet/device-plugins/mps/shm

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+{{- if .Values.devicePlugin.enabled }}
 ---
 {{- $hasConfigMap := (include "nvidia-device-plugin.hasConfigMap" .) | trim }}
 {{- $configMapName := (include "nvidia-device-plugin.configMapName" .) | trim }}
@@ -224,3 +225,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}


### PR DESCRIPTION
When deployed without MPS enabled, the device plugin fails due to mounts not being creatable.