### PR TITLE
Remove requirement to use CDI for MPS injection

### DIFF
--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -142,20 +142,6 @@ func validateFlags(config *spec.Config) error {
 		if *config.Flags.MigStrategy == spec.MigStrategyMixed {
 			return fmt.Errorf("using --mig-strategy=mixed is not supported with MPS")
 		}
-
-		deviceListStrategies, err := spec.NewDeviceListStrategies(*config.Flags.Plugin.DeviceListStrategy)
-		if err != nil {
-			return err
-		}
-		if !deviceListStrategies.IsCDIEnabled() {
-			return fmt.Errorf("using MPS requires CDI")
-		}
-		if deviceListStrategies.Includes(spec.DeviceListStrategyEnvvar) {
-			return fmt.Errorf("using MPS is incompatible with --device-list-strategy=" + spec.DeviceListStrategyEnvvar)
-		}
-		if deviceListStrategies.Includes(spec.DeviceListStrategyVolumeMounts) {
-			return fmt.Errorf("using MPS is incompatible with --device-list-strategy=" + spec.DeviceListStrategyVolumeMounts)
-		}
 	}
 
 	return nil

--- a/cmd/nvidia-device-plugin/plugin-manager.go
+++ b/cmd/nvidia-device-plugin/plugin-manager.go
@@ -44,10 +44,8 @@ func NewPluginManager(config *spec.Config) (manager.Interface, error) {
 		return nil, fmt.Errorf("invalid device list strategy: %v", err)
 	}
 
-	cdiEnabled := deviceListStrategies.IsCDIEnabled()
-
 	cdiHandler, err := cdi.New(
-		cdi.WithEnabled(cdiEnabled),
+		cdi.WithDeviceListStrategies(deviceListStrategies),
 		cdi.WithDriverRoot(*config.Flags.Plugin.ContainerDriverRoot),
 		cdi.WithTargetDriverRoot(*config.Flags.NvidiaDriverRoot),
 		cdi.WithNvidiaCTKPath(*config.Flags.Plugin.NvidiaCTKPath),
@@ -63,7 +61,6 @@ func NewPluginManager(config *spec.Config) (manager.Interface, error) {
 
 	m, err := manager.New(
 		manager.WithNVML(nvmllib),
-		manager.WithCDIEnabled(cdiEnabled),
 		manager.WithCDIHandler(cdiHandler),
 		manager.WithConfig(config),
 		manager.WithFailOnInitError(*config.Flags.FailOnInitError),

--- a/internal/cdi/cdi.go
+++ b/internal/cdi/cdi.go
@@ -27,6 +27,8 @@ import (
 	"github.com/sirupsen/logrus"
 	cdiapi "tags.cncf.io/container-device-interface/pkg/cdi"
 	cdiparser "tags.cncf.io/container-device-interface/pkg/parser"
+
+	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 )
 
 const (
@@ -44,7 +46,8 @@ type cdiHandler struct {
 	vendor           string
 	deviceIDStrategy string
 
-	enabled      bool
+	deviceListStrategies spec.DeviceListStrategies
+
 	gdsEnabled   bool
 	mofedEnabled bool
 
@@ -60,7 +63,7 @@ func newHandler(opts ...Option) (Interface, error) {
 		opt(c)
 	}
 
-	if !c.enabled {
+	if !c.deviceListStrategies.IsCDIEnabled() {
 		return &null{}, nil
 	}
 

--- a/internal/cdi/options.go
+++ b/internal/cdi/options.go
@@ -18,15 +18,17 @@ package cdi
 
 import (
 	"github.com/NVIDIA/go-nvlib/pkg/nvml"
+
+	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 )
 
 // Option defines a function for passing options to the New() call
 type Option func(*cdiHandler)
 
-// WithEnabled provides an Option to set the enabled flag used by the 'cdi' interface
-func WithEnabled(enabled bool) Option {
+// WithDeviceListStrategies provides an Option to set the enabled flag used by the 'cdi' interface
+func WithDeviceListStrategies(deviceListStrategies spec.DeviceListStrategies) Option {
 	return func(c *cdiHandler) {
-		c.enabled = enabled
+		c.deviceListStrategies = deviceListStrategies
 	}
 }
 

--- a/internal/plugin/manager/factory.go
+++ b/internal/plugin/manager/factory.go
@@ -33,7 +33,6 @@ type manager struct {
 	nvmllib         nvml.Interface
 
 	cdiHandler cdi.Interface
-	cdiEnabled bool
 	config     *spec.Config
 	infolib    info.Interface
 }
@@ -50,21 +49,17 @@ func New(opts ...Option) (Interface, error) {
 		return &null{}, nil
 	}
 
+	if m.cdiHandler != nil {
+		m.cdiHandler = cdi.NewNullHandler()
+	}
+
 	if m.infolib == nil {
 		m.infolib = info.New()
-	}
-	if m.cdiHandler == nil {
-		m.cdiHandler = cdi.NewNullHandler()
 	}
 
 	mode, err := m.resolveMode()
 	if err != nil {
 		return nil, err
-	}
-
-	if mode != "nvml" && m.cdiEnabled {
-		klog.Warning("CDI is not supported; disabling CDI.")
-		m.cdiEnabled = false
 	}
 
 	switch mode {

--- a/internal/plugin/manager/nvml.go
+++ b/internal/plugin/manager/nvml.go
@@ -34,7 +34,7 @@ func (m *nvmlmanager) GetPlugins() ([]plugin.Interface, error) {
 
 	var plugins []plugin.Interface
 	for _, r := range rms {
-		plugins = append(plugins, plugin.NewNvidiaDevicePlugin(m.config, r, m.cdiHandler, m.cdiEnabled))
+		plugins = append(plugins, plugin.NewNvidiaDevicePlugin(m.config, r, m.cdiHandler))
 	}
 	return plugins, nil
 }

--- a/internal/plugin/manager/options.go
+++ b/internal/plugin/manager/options.go
@@ -26,13 +26,6 @@ import (
 // Option is a function that configures a manager
 type Option func(*manager)
 
-// WithCDIEnabled sets whether CDI is enabled for the manager
-func WithCDIEnabled(enabled bool) Option {
-	return func(m *manager) {
-		m.cdiEnabled = enabled
-	}
-}
-
 // WithCDIHandler sets the CDI handler for the manager
 func WithCDIHandler(handler cdi.Interface) Option {
 	return func(m *manager) {

--- a/internal/plugin/manager/tegra.go
+++ b/internal/plugin/manager/tegra.go
@@ -34,7 +34,7 @@ func (m *tegramanager) GetPlugins() ([]plugin.Interface, error) {
 
 	var plugins []plugin.Interface
 	for _, r := range rms {
-		plugins = append(plugins, plugin.NewNvidiaDevicePlugin(m.config, r, m.cdiHandler, m.cdiEnabled))
+		plugins = append(plugins, plugin.NewNvidiaDevicePlugin(m.config, r, m.cdiHandler))
 	}
 	return plugins, nil
 }

--- a/internal/plugin/server.go
+++ b/internal/plugin/server.go
@@ -337,14 +337,14 @@ func (plugin *NvidiaDevicePlugin) getAllocateResponse(requestIds []string) (*plu
 			return nil, fmt.Errorf("failed to get allocate response for CDI: %v", err)
 		}
 	}
-	if plugin.config.Sharing.SharingStrategy() == spec.SharingStrategyMPS {
-		plugin.updateResponseForMPS(response)
-	}
 	if plugin.deviceListStrategies.Includes(spec.DeviceListStrategyEnvvar) {
 		plugin.updateResponseForDeviceListEnvvar(response, deviceIDs...)
 	}
 	if plugin.deviceListStrategies.Includes(spec.DeviceListStrategyVolumeMounts) {
 		plugin.updateResponseForDeviceMounts(response, deviceIDs...)
+	}
+	if plugin.config.Sharing.SharingStrategy() == spec.SharingStrategyMPS {
+		plugin.updateResponseForMPS(response)
 	}
 	if *plugin.config.Flags.Plugin.PassDeviceSpecs {
 		response.Devices = append(response.Devices, plugin.apiDeviceSpecs(*plugin.config.Flags.NvidiaDriverRoot, requestIds)...)

--- a/internal/plugin/server_test.go
+++ b/internal/plugin/server_test.go
@@ -44,13 +44,6 @@ func TestCDIAllocateResponse(t *testing.T) {
 			CDIEnabled:           true,
 		},
 		{
-			description:          "CDI disabled has empty response",
-			deviceIds:            []string{"gpu0"},
-			deviceListStrategies: []string{"cdi-annotations"},
-			CDIPrefix:            "cdi.k8s.io/",
-			CDIEnabled:           false,
-		},
-		{
 			description:          "single device is added to annotations",
 			deviceIds:            []string{"gpu0"},
 			deviceListStrategies: []string{"cdi-annotations"},
@@ -160,7 +153,8 @@ func TestCDIAllocateResponse(t *testing.T) {
 				cdiAnnotationPrefix:  tc.CDIPrefix,
 			}
 
-			response, err := plugin.getAllocateResponseForCDI("uuid", tc.deviceIds)
+			response := pluginapi.ContainerAllocateResponse{}
+			err := plugin.updateResponseForCDI(&response, "uuid", tc.deviceIds...)
 
 			require.Nil(t, err)
 			require.EqualValues(t, &tc.expectedResponse, &response)


### PR DESCRIPTION
This change allows MPS to be used with the `envvar` and `volumeMounts` device list strategies.