### PR TITLE
Fix mps control daemon crashloop

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -149,7 +149,7 @@ spec:
             exec:
               command:
               - cat
-              - /mps/nvidia.com/gpu/.started
+              - /mps/.ready
             initialDelaySeconds: 1
             periodSeconds: 1
           env:

--- a/internal/rm/rm.go
+++ b/internal/rm/rm.go
@@ -113,6 +113,9 @@ func (r *resourceManager) Devices() Devices {
 // AddDefaultResourcesToConfig adds default resource matching rules to config.Resources
 func AddDefaultResourcesToConfig(config *spec.Config) error {
 	_ = config.Resources.AddGPUResource("*", "gpu")
+	if config.Flags.MigStrategy == nil {
+		return nil
+	}
 	switch *config.Flags.MigStrategy {
 	case spec.MigStrategySingle:
 		return config.Resources.AddMIGResource("*", "gpu")


### PR DESCRIPTION
This PR makes the following changes:

* Fixes a bug in the `AddDefaultResourcesToConfig` option to handle the case where the `mig-strategy` is not set. This happens in the case of the MPS control daemon daemonset when a `nvidia.com/sharing.mps.enabled=true` label is present, but no config map is used.
* Fixes a crashloop in the MPS control daemon due to a failing startup probe when no MPS devices are present. This switches to a global `.ready` file for indicating readiness instead of a per-resource file.
