### PR TITLE
Update k8s.io dependencies as a group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,12 @@ updates:
       day: "sunday"
     labels:
     - dependencies
+    groups:
+      k8sio:
+        patterns:
+        - k8s.io/*
+        exclude-patterns:
+        - k8s.io/klog/*
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
See also https://github.com/helm/helm/pull/12356 where this was changed to list the dependencies explicitly.