### PR TITLE
MPS cleanup

### DIFF
--- a/cmd/mps-control-daemon/mps/manager.go
+++ b/cmd/mps-control-daemon/mps/manager.go
@@ -85,6 +85,13 @@ func (m *manager) Daemons() ([]*Daemon, error) {
 			klog.InfoS("Resource is not shared", "resource", "resource", resourceManager.Resource())
 			continue
 		}
+		// Check if MIG devices are included.
+		for _, device := range resourceManager.Devices() {
+			if device.IsMigDevice() {
+				klog.Warning("MPS sharing is not supported for MIG devices; skipping daemon creation")
+				continue
+			}
+		}
 		daemon := NewDaemon(resourceManager, ContainerRoot)
 		daemons = append(daemons, daemon)
 	}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -145,13 +145,6 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: mps-control-daemon-ctr
           command: [mps-control-daemon]
-          startupProbe:
-            exec:
-              command:
-              - cat
-              - /mps/.ready
-            initialDelaySeconds: 1
-            periodSeconds: 1
           env:
           - name: NODE_NAME
             valueFrom:

--- a/internal/lm/nvml_test.go
+++ b/internal/lm/nvml_test.go
@@ -80,26 +80,26 @@ func TestMigCapabilityLabeler(t *testing.T) {
 
 func TestSharingLabeler(t *testing.T) {
 	testCases := []struct {
-		descrition     string
+		description    string
 		manager        resource.Manager
 		config         *spec.Config
 		expectedLabels map[string]string
 	}{
 		{
-			descrition: "nil config",
+			description: "nil config",
 			expectedLabels: map[string]string{
 				"nvidia.com/mps.capable": "false",
 			},
 		},
 		{
-			descrition: "empty config",
-			config:     &spec.Config{},
+			description: "empty config",
+			config:      &spec.Config{},
 			expectedLabels: map[string]string{
 				"nvidia.com/mps.capable": "false",
 			},
 		},
 		{
-			descrition: "config with timeslicing replicas",
+			description: "config with timeslicing replicas",
 			config: &spec.Config{
 				Sharing: spec.Sharing{
 					TimeSlicing: spec.ReplicatedResources{
@@ -116,7 +116,7 @@ func TestSharingLabeler(t *testing.T) {
 			},
 		},
 		{
-			descrition: "config with no mps replicas",
+			description: "config with no mps replicas",
 			config: &spec.Config{
 				Sharing: spec.Sharing{
 					MPS: &spec.ReplicatedResources{
@@ -133,7 +133,7 @@ func TestSharingLabeler(t *testing.T) {
 			},
 		},
 		{
-			descrition: "config with mps replicas no-mig-devices",
+			description: "config with mps replicas no-mig-devices",
 			manager: &resource.ManagerMock{
 				GetDevicesFunc: func() ([]resource.Device, error) {
 					devices := []resource.Device{
@@ -162,7 +162,7 @@ func TestSharingLabeler(t *testing.T) {
 			},
 		},
 		{
-			descrition: "config with mps replicas mig-devices",
+			description: "config with mps replicas mig-devices",
 			manager: &resource.ManagerMock{
 				GetDevicesFunc: func() ([]resource.Device, error) {
 					devices := []resource.Device{
@@ -193,7 +193,7 @@ func TestSharingLabeler(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.descrition, func(t *testing.T) {
+		t.Run(tc.description, func(t *testing.T) {
 			require.EqualValues(t, tc.expectedLabels, newSharingLabeler(tc.manager, tc.config))
 		})
 	}

--- a/internal/plugin/manager/nvml.go
+++ b/internal/plugin/manager/nvml.go
@@ -34,7 +34,11 @@ func (m *nvmlmanager) GetPlugins() ([]plugin.Interface, error) {
 
 	var plugins []plugin.Interface
 	for _, r := range rms {
-		plugins = append(plugins, plugin.NewNvidiaDevicePlugin(m.config, r, m.cdiHandler))
+		plugin, err := plugin.NewNvidiaDevicePlugin(m.config, r, m.cdiHandler)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create plugin: %w", err)
+		}
+		plugins = append(plugins, plugin)
 	}
 	return plugins, nil
 }

--- a/internal/plugin/manager/tegra.go
+++ b/internal/plugin/manager/tegra.go
@@ -29,12 +29,16 @@ type tegramanager manager
 func (m *tegramanager) GetPlugins() ([]plugin.Interface, error) {
 	rms, err := rm.NewTegraResourceManagers(m.config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to construct NVML resource managers: %v", err)
+		return nil, fmt.Errorf("failed to construct Tegra resource managers: %v", err)
 	}
 
 	var plugins []plugin.Interface
 	for _, r := range rms {
-		plugins = append(plugins, plugin.NewNvidiaDevicePlugin(m.config, r, m.cdiHandler))
+		plugin, err := plugin.NewNvidiaDevicePlugin(m.config, r, m.cdiHandler)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create plugin: %w", err)
+		}
+		plugins = append(plugins, plugin)
 	}
 	return plugins, nil
 }

--- a/internal/plugin/server.go
+++ b/internal/plugin/server.go
@@ -79,7 +79,7 @@ func NewNvidiaDevicePlugin(config *spec.Config, resourceManager rm.ResourceManag
 
 	var mpsDaemon *mps.Daemon
 	var mpsHostRoot mps.Root
-	if config.Sharing.SharingStrategy() != spec.SharingStrategyMPS {
+	if config.Sharing.SharingStrategy() == spec.SharingStrategyMPS {
 		mpsDaemon = mps.NewDaemon(resourceManager, mps.ContainerRoot)
 		mpsHostRoot = mps.Root(*config.Flags.CommandLineFlags.MpsRoot)
 	}

--- a/internal/plugin/server.go
+++ b/internal/plugin/server.go
@@ -375,19 +375,13 @@ func (plugin *NvidiaDevicePlugin) getAllocateResponse(requestIds []string) (*plu
 // and assumes that an MPS control daemon has already been started.
 func (plugin NvidiaDevicePlugin) updateResponseForMPS(response *pluginapi.ContainerAllocateResponse) {
 	// TODO: We should check that the deviceIDs are shared using MPS.
-	for k, v := range plugin.mpsDaemon.Envvars() {
-		response.Envs[k] = v
-	}
+	response.Envs["CUDA_MPS_PIPE_DIRECTORY"] = plugin.mpsDaemon.PipeDir()
 
 	resourceName := plugin.rm.Resource()
 	response.Mounts = append(response.Mounts,
 		&pluginapi.Mount{
 			ContainerPath: plugin.mpsDaemon.PipeDir(),
 			HostPath:      plugin.mpsHostRoot.PipeDir(resourceName),
-		},
-		&pluginapi.Mount{
-			ContainerPath: plugin.mpsDaemon.PipeDir(),
-			HostPath:      plugin.mpsHostRoot.LogDir(resourceName),
 		},
 		&pluginapi.Mount{
 			ContainerPath: plugin.mpsDaemon.ShmDir(),


### PR DESCRIPTION
This PR cleans up a number of aspects around MPS. Namely:

* Removes the MPS log dir from the workload
* Disable MPS for MIG
* Fixes an incorrect conditional check for MPS