### PR TITLE
Use github image as staging image

### DIFF
--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -33,7 +33,7 @@ variables:
   # On the multi-arch builder we don't need the qemu setup.
   SKIP_QEMU_SETUP: "1"
   # Define the public staging registry
-  STAGING_REGISTRY: registry.gitlab.com/nvidia/kubernetes/device-plugin/staging
+  STAGING_REGISTRY: ghcr.io/nvidia/k8s-device-plugin
   STAGING_VERSION: ${CI_COMMIT_SHORT_SHA}
 
 .image-pull:


### PR DESCRIPTION
This change pulls the ghcr.io image instead of the GitLab image.