### PR TITLE
Increase operations-per-run on stale action

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -24,3 +24,4 @@ jobs:
         days-before-issue-close: 30
         days-before-pr-close: 30
         remove-stale-when-updated: true
+        operations-per-run: 300


### PR DESCRIPTION
Default is 30, our average per repo issue + PR number is around 200+ , 300 is a reasonable threshold  