### PR TITLE
Extract GOLANG_VERSION from versions.mk

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -45,6 +45,8 @@ jobs:
         version: latest
         args: -v --timeout 5m
         skip-cache: true
+    - name: Check golang modules
+      run: make check-vendor
   test:
       name: Unit test
       runs-on: ubuntu-latest

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -30,10 +30,15 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       name: Checkout code
+    - name: Get Golang version
+      id: vars
+      run: |
+        GOLANG_VERSION=$( grep "GOLANG_VERSION ?=" versions.mk )
+        echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION ?= }" >> $GITHUB_ENV
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'go.mod'
+        go-version: ${{ env.GOLANG_VERSION }}
     - name: Lint
       uses: golangci/golangci-lint-action@v4
       with:
@@ -46,10 +51,15 @@ jobs:
       steps:
         - name: Checkout code
           uses: actions/checkout@v4
+        - name: Get Golang version
+          id: vars
+          run: |
+            GOLANG_VERSION=$( grep "GOLANG_VERSION ?=" versions.mk )
+            echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION ?= }" >> $GITHUB_ENV
         - name: Install Go
           uses: actions/setup-go@v5
           with:
-            go-version-file: 'go.mod'
+            go-version: ${{ env.GOLANG_VERSION }}
         - run: make test
   build:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ CMDS := $(patsubst ./cmd/%/,%,$(sort $(dir $(wildcard ./cmd/*/))))
 CMD_TARGETS := $(patsubst %,cmd-%, $(CMDS))
 
 CHECK_TARGETS := lint
-MAKE_TARGETS := binaries build check fmt lint-internal test examples cmds coverage generate $(CHECK_TARGETS)
+MAKE_TARGETS := binaries build check fmt lint-internal test examples cmds coverage generate vendor check-vendor $(CHECK_TARGETS)
 
 TARGETS := $(MAKE_TARGETS) $(EXAMPLE_TARGETS) $(CMD_TARGETS)
 
@@ -75,6 +75,14 @@ goimports:
 
 lint:
 	golangci-lint run ./...
+
+vendor:
+	go mod tidy
+	go mod vendor
+	go mod verify
+
+check-vendor: vendor
+	git diff --quiet HEAD -- go.mod go.sum vendor
 
 COVERAGE_FILE := coverage.out
 test: build cmds

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/NVIDIA/k8s-device-plugin
 
-go 1.21
+go 1.21.3
+
+toolchain go1.21.5
 
 replace (
 	k8s.io/api => k8s.io/api v0.29.2

--- a/versions.mk
+++ b/versions.mk
@@ -23,7 +23,7 @@ VERSION  ?= v0.15.0-rc.1
 vVERSION := v$(VERSION:v%=%)
 
 CUDA_VERSION ?= 12.3.1
-GOLANG_VERSION ?= 1.20.5
+GOLANG_VERSION ?= 1.21.5
 
 BUILDIMAGE_TAG ?= devel-go$(GOLANG_VERSION)
 BUILDIMAGE ?=  ghcr.io/nvidia/k8s-test-infra:$(BUILDIMAGE_TAG)


### PR DESCRIPTION
This PR updates the golang actions to use the GOLANG_VERSION defined in versions.mk

This ensures consistency between what is built for the images and what is tested in CI. 

It also adds a `vendor` and `check-vendor` make target to ensure that the local go module files are up to date.