### PR TITLE
clean up replace directives in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,34 +4,6 @@ go 1.21.3
 
 toolchain go1.21.5
 
-replace (
-	k8s.io/api => k8s.io/api v0.29.2
-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.29.2
-	k8s.io/apimachinery => k8s.io/apimachinery v0.29.2
-	k8s.io/apiserver => k8s.io/apiserver v0.29.2
-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.29.2
-	k8s.io/client-go => k8s.io/client-go v0.29.2
-	k8s.io/cloud-provider => k8s.io/cloud-provider v0.29.2
-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.29.2
-	k8s.io/code-generator => k8s.io/code-generator v0.29.2
-	k8s.io/component-base => k8s.io/component-base v0.29.2
-	k8s.io/component-helpers => k8s.io/component-helpers v0.29.2
-	k8s.io/controller-manager => k8s.io/controller-manager v0.29.2
-	k8s.io/cri-api => k8s.io/cri-api v0.29.2
-	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.29.2
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.29.2
-	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.29.2
-	k8s.io/kube-proxy => k8s.io/kube-proxy v0.29.2
-	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.29.2
-	k8s.io/kubectl => k8s.io/kubectl v0.29.2
-	k8s.io/kubelet => k8s.io/kubelet v0.29.2
-	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.29.2
-	k8s.io/metrics => k8s.io/metrics v0.29.2
-	k8s.io/mount-utils => k8s.io/mount-utils v0.29.2
-	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.29.2
-	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.29.2
-)
-
 require (
 	github.com/NVIDIA/go-gpuallocator v0.3.2
 	github.com/NVIDIA/go-nvlib v0.0.0-20240109130712-11603560817a
@@ -54,7 +26,7 @@ require (
 	k8s.io/client-go v0.29.2
 	k8s.io/klog/v2 v2.120.1
 	k8s.io/kubelet v0.29.2
-	k8s.io/mount-utils v0.25.0
+	k8s.io/mount-utils v0.29.2
 	sigs.k8s.io/node-feature-discovery v0.15.1
 	sigs.k8s.io/yaml v1.4.0
 	tags.cncf.io/container-device-interface v0.6.2

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -757,7 +757,7 @@ helm.sh/helm/v3/pkg/storage/driver
 helm.sh/helm/v3/pkg/strvals
 helm.sh/helm/v3/pkg/time
 helm.sh/helm/v3/pkg/uploader
-# k8s.io/api v0.29.2 => k8s.io/api v0.29.2
+# k8s.io/api v0.29.2
 ## explicit; go 1.21
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
@@ -814,7 +814,7 @@ k8s.io/api/scheduling/v1beta1
 k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
-# k8s.io/apiextensions-apiserver v0.29.2 => k8s.io/apiextensions-apiserver v0.29.2
+# k8s.io/apiextensions-apiserver v0.29.2
 ## explicit; go 1.21
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
@@ -825,7 +825,7 @@ k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1
-# k8s.io/apimachinery v0.29.2 => k8s.io/apimachinery v0.29.2
+# k8s.io/apimachinery v0.29.2
 ## explicit; go 1.21
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
@@ -885,16 +885,16 @@ k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/netutil
 k8s.io/apimachinery/third_party/forked/golang/reflect
-# k8s.io/apiserver v0.29.2 => k8s.io/apiserver v0.29.2
+# k8s.io/apiserver v0.29.2
 ## explicit; go 1.21
 k8s.io/apiserver/pkg/endpoints/deprecation
-# k8s.io/cli-runtime v0.29.2 => k8s.io/cli-runtime v0.29.2
+# k8s.io/cli-runtime v0.29.2
 ## explicit; go 1.21
 k8s.io/cli-runtime/pkg/genericclioptions
 k8s.io/cli-runtime/pkg/genericiooptions
 k8s.io/cli-runtime/pkg/printers
 k8s.io/cli-runtime/pkg/resource
-# k8s.io/client-go v0.29.2 => k8s.io/client-go v0.29.2
+# k8s.io/client-go v0.29.2
 ## explicit; go 1.21
 k8s.io/client-go/applyconfigurations/admissionregistration/v1
 k8s.io/client-go/applyconfigurations/admissionregistration/v1alpha1
@@ -1045,7 +1045,7 @@ k8s.io/client-go/util/homedir
 k8s.io/client-go/util/jsonpath
 k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/workqueue
-# k8s.io/component-base v0.29.2 => k8s.io/component-base v0.29.2
+# k8s.io/component-base v0.29.2
 ## explicit; go 1.21
 k8s.io/component-base/version
 # k8s.io/klog/v2 v2.120.1
@@ -1069,7 +1069,7 @@ k8s.io/kube-openapi/pkg/spec3
 k8s.io/kube-openapi/pkg/util/proto
 k8s.io/kube-openapi/pkg/util/proto/validation
 k8s.io/kube-openapi/pkg/validation/spec
-# k8s.io/kubectl v0.29.2 => k8s.io/kubectl v0.29.2
+# k8s.io/kubectl v0.29.2
 ## explicit; go 1.21
 k8s.io/kubectl/pkg/cmd/util
 k8s.io/kubectl/pkg/scheme
@@ -1079,10 +1079,10 @@ k8s.io/kubectl/pkg/util/openapi
 k8s.io/kubectl/pkg/util/templates
 k8s.io/kubectl/pkg/util/term
 k8s.io/kubectl/pkg/validation
-# k8s.io/kubelet v0.29.2 => k8s.io/kubelet v0.29.2
+# k8s.io/kubelet v0.29.2
 ## explicit; go 1.21
 k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1
-# k8s.io/mount-utils v0.25.0 => k8s.io/mount-utils v0.29.2
+# k8s.io/mount-utils v0.29.2
 ## explicit; go 1.21
 k8s.io/mount-utils
 # k8s.io/utils v0.0.0-20240102154912-e7106e64919e
@@ -1228,28 +1228,3 @@ tags.cncf.io/container-device-interface/pkg/parser
 # tags.cncf.io/container-device-interface/specs-go v0.6.0
 ## explicit; go 1.19
 tags.cncf.io/container-device-interface/specs-go
-# k8s.io/api => k8s.io/api v0.29.2
-# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.29.2
-# k8s.io/apimachinery => k8s.io/apimachinery v0.29.2
-# k8s.io/apiserver => k8s.io/apiserver v0.29.2
-# k8s.io/cli-runtime => k8s.io/cli-runtime v0.29.2
-# k8s.io/client-go => k8s.io/client-go v0.29.2
-# k8s.io/cloud-provider => k8s.io/cloud-provider v0.29.2
-# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.29.2
-# k8s.io/code-generator => k8s.io/code-generator v0.29.2
-# k8s.io/component-base => k8s.io/component-base v0.29.2
-# k8s.io/component-helpers => k8s.io/component-helpers v0.29.2
-# k8s.io/controller-manager => k8s.io/controller-manager v0.29.2
-# k8s.io/cri-api => k8s.io/cri-api v0.29.2
-# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.29.2
-# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.29.2
-# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.29.2
-# k8s.io/kube-proxy => k8s.io/kube-proxy v0.29.2
-# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.29.2
-# k8s.io/kubectl => k8s.io/kubectl v0.29.2
-# k8s.io/kubelet => k8s.io/kubelet v0.29.2
-# k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.29.2
-# k8s.io/metrics => k8s.io/metrics v0.29.2
-# k8s.io/mount-utils => k8s.io/mount-utils v0.29.2
-# k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.29.2
-# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.29.2


### PR DESCRIPTION
The replace directives aren't needed. This change does not alter the `go.sum` checksums, so the dependency tree is maintained as-is

This improves readability of the go.mod and makes it easier for others to discern the dependency tree of k8s-device-plugin