### PR TITLE
Set mps device memory limit by index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Bump CUDA base image version to 12.3.2
 - Add `cdi-cri` device list strategy. This uses the CDIDevices CRI field to request CDI devices instead of annotations.
+- Set MPS memory limit by device index and not device UUID. This is a workaround for an issue where
+  these limits are not applied for devices if set by UUID.
 
 ### Version v0.15.0-rc.1
 - Import GPU Feature Discovery into the GPU Device Plugin repo. This means that

--- a/cmd/mps-control-daemon/mps/daemon.go
+++ b/cmd/mps-control-daemon/mps/daemon.go
@@ -105,10 +105,10 @@ func (d *Daemon) Start() error {
 		return err
 	}
 
-	for uuid, limit := range d.perDevicePinnedDeviceMemoryLimits() {
-		_, err := d.EchoPipeToControl(fmt.Sprintf("set_default_device_pinned_mem_limit %s %s", uuid, limit))
+	for index, limit := range d.perDevicePinnedDeviceMemoryLimits() {
+		_, err := d.EchoPipeToControl(fmt.Sprintf("set_default_device_pinned_mem_limit %s %s", index, limit))
 		if err != nil {
-			return fmt.Errorf("error setting pinned memory limit for device %v: %w", uuid, err)
+			return fmt.Errorf("error setting pinned memory limit for device %v: %w", index, err)
 		}
 	}
 	if threadPercentage := d.activeThreadPercentage(); threadPercentage != "" {
@@ -216,18 +216,18 @@ func (m *Daemon) perDevicePinnedDeviceMemoryLimits() map[string]string {
 	totalMemoryInBytesPerDevice := make(map[string]uint64)
 	replicasPerDevice := make(map[string]uint64)
 	for _, device := range m.Devices() {
-		uuid := device.GetUUID()
-		totalMemoryInBytesPerDevice[uuid] = device.TotalMemory
-		replicasPerDevice[uuid] += 1
+		index := device.Index
+		totalMemoryInBytesPerDevice[index] = device.TotalMemory
+		replicasPerDevice[index] += 1
 	}
 
 	limits := make(map[string]string)
-	for uuid, totalMemory := range totalMemoryInBytesPerDevice {
+	for index, totalMemory := range totalMemoryInBytesPerDevice {
 		if totalMemory == 0 {
 			continue
 		}
-		replicas := replicasPerDevice[uuid]
-		limits[uuid] = fmt.Sprintf("%vM", totalMemory/replicas/1024/1024)
+		replicas := replicasPerDevice[index]
+		limits[index] = fmt.Sprintf("%vM", totalMemory/replicas/1024/1024)
 	}
 	return limits
 }


### PR DESCRIPTION
This change switches to setting MPS memory limits by index instead of UUID.

The `nvidia-cuda-mps-control` daemon does not seem to handle the case where the NVML UUID is used to set these limits.