### PR TITLE
Update sharing checks for MPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add `cdi-cri` device list strategy. This uses the CDIDevices CRI field to request CDI devices instead of annotations.
 - Set MPS memory limit by device index and not device UUID. This is a workaround for an issue where
   these limits are not applied for devices if set by UUID.
+- Update MPS sharing to disallow requests for multiple devices if MPS sharing is configured.
 
 ### Version v0.15.0-rc.1
 - Import GPU Feature Discovery into the GPU Device Plugin repo. This means that

--- a/api/config/v1/config.go
+++ b/api/config/v1/config.go
@@ -53,6 +53,14 @@ func NewConfig(c *cli.Context, flags []cli.Flag) (*Config, error) {
 
 	config.Flags.UpdateFromCLIFlags(c, flags)
 
+	// We explicitly set sharing.mps.failRequestsGreaterThanOne = true
+	// This can be relaxed in certain cases -- such as a single GPU -- but
+	// requires additional logic around when it's OK to combine requests and
+	// makes the semantics of a request unclear.
+	if config.Sharing.MPS != nil {
+		config.Sharing.MPS.FailRequestsGreaterThanOne = true
+	}
+
 	return config, nil
 }
 

--- a/internal/plugin/server.go
+++ b/internal/plugin/server.go
@@ -319,20 +319,9 @@ func (plugin *NvidiaDevicePlugin) GetPreferredAllocation(ctx context.Context, r 
 func (plugin *NvidiaDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
 	responses := pluginapi.AllocateResponse{}
 	for _, req := range reqs.ContainerRequests {
-		// If the devices being allocated are replicas, then (conditionally)
-		// error out if more than one resource is being allocated.
-		if plugin.config.Sharing.ReplicatedResources().FailRequestsGreaterThanOne && rm.AnnotatedIDs(req.DevicesIDs).AnyHasAnnotations() {
-			if len(req.DevicesIDs) > 1 {
-				return nil, fmt.Errorf("request for '%v: %v' too large: maximum request size for shared resources is 1", plugin.rm.Resource(), len(req.DevicesIDs))
-			}
+		if err := plugin.rm.ValidateRequest(req.DevicesIDs); err != nil {
+			return nil, fmt.Errorf("invalid allocation request for %q: %w", plugin.rm.Resource(), err)
 		}
-
-		for _, id := range req.DevicesIDs {
-			if !plugin.rm.Devices().Contains(id) {
-				return nil, fmt.Errorf("invalid allocation request for '%s': unknown device: %s", plugin.rm.Resource(), id)
-			}
-		}
-
 		response, err := plugin.getAllocateResponse(req.DevicesIDs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get allocate response: %v", err)

--- a/internal/rm/rm_test.go
+++ b/internal/rm/rm_test.go
@@ -1,0 +1,191 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package rm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
+)
+
+func TestValidateRequest(t *testing.T) {
+	testCases := []struct {
+		description       string
+		devices           Devices
+		sharing           spec.Sharing
+		requestDevicesIDs []string
+
+		expectedError error
+	}{
+		{
+			description: "valid device IDs -- no sharing",
+			devices: Devices{
+				"device0": nil,
+				"device1": nil,
+			},
+			requestDevicesIDs: []string{"device1"},
+		},
+		{
+			description: "invalid device IDs -- no sharing",
+			devices: Devices{
+				"device0": nil,
+				"device1": nil,
+			},
+			requestDevicesIDs: []string{"device1", "device2"},
+			expectedError:     errInvalidRequest,
+		},
+		{
+			description: "timeslicing with single device",
+			sharing: spec.Sharing{
+				TimeSlicing: spec.ReplicatedResources{
+					Resources: []spec.ReplicatedResource{
+						{
+							Name:     "nvidia.com/gpu",
+							Replicas: 2,
+						},
+					},
+				},
+			},
+			devices: Devices{
+				"device0::0": nil,
+				"device0::1": nil,
+				"device1::0": nil,
+				"device1::1": nil,
+			},
+			requestDevicesIDs: []string{"device0::1"},
+		},
+		{
+			description: "timeslicing with two devices",
+			sharing: spec.Sharing{
+				TimeSlicing: spec.ReplicatedResources{
+					Resources: []spec.ReplicatedResource{
+						{
+							Name:     "nvidia.com/gpu",
+							Replicas: 2,
+						},
+					},
+				},
+			},
+			devices: Devices{
+				"device0::0": nil,
+				"device0::1": nil,
+				"device1::0": nil,
+				"device1::1": nil,
+			},
+			requestDevicesIDs: []string{"device0::1", "device1::0"},
+		},
+		{
+			description: "timeslicing with two devices -- failRequestsGreaterThanOne",
+			sharing: spec.Sharing{
+				TimeSlicing: spec.ReplicatedResources{
+					FailRequestsGreaterThanOne: true,
+					Resources: []spec.ReplicatedResource{
+						{
+							Name:     "nvidia.com/gpu",
+							Replicas: 2,
+						},
+					},
+				},
+			},
+			devices: Devices{
+				"device0::0": nil,
+				"device0::1": nil,
+				"device1::0": nil,
+				"device1::1": nil,
+			},
+			requestDevicesIDs: []string{"device0::1", "device1::0"},
+			expectedError:     errInvalidRequest,
+		},
+		{
+			description: "MPS with single device",
+			sharing: spec.Sharing{
+				MPS: &spec.ReplicatedResources{
+					Resources: []spec.ReplicatedResource{
+						{
+							Name:     "nvidia.com/gpu",
+							Replicas: 2,
+						},
+					},
+				},
+			},
+			devices: Devices{
+				"device0::0": nil,
+				"device0::1": nil,
+				"device1::0": nil,
+				"device1::1": nil,
+			},
+			requestDevicesIDs: []string{"device0::1"},
+		},
+		{
+			description: "MPS with two devices",
+			sharing: spec.Sharing{
+				MPS: &spec.ReplicatedResources{
+					Resources: []spec.ReplicatedResource{
+						{
+							Name:     "nvidia.com/gpu",
+							Replicas: 2,
+						},
+					},
+				},
+			},
+			devices: Devices{
+				"device0::0": nil,
+				"device0::1": nil,
+				"device1::0": nil,
+				"device1::1": nil,
+			},
+			requestDevicesIDs: []string{"device0::1", "device1::0"},
+		},
+		{
+			description: "MPS with two devices -- failRequestsGreaterThanOne",
+			sharing: spec.Sharing{
+				MPS: &spec.ReplicatedResources{
+					FailRequestsGreaterThanOne: true,
+					Resources: []spec.ReplicatedResource{
+						{
+							Name:     "nvidia.com/gpu",
+							Replicas: 2,
+						},
+					},
+				},
+			},
+			devices: Devices{
+				"device0::0": nil,
+				"device0::1": nil,
+				"device1::0": nil,
+				"device1::1": nil,
+			},
+			requestDevicesIDs: []string{"device0::1", "device1::0"},
+			expectedError:     errInvalidRequest,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			r := resourceManager{
+				config: &spec.Config{
+					Sharing: tc.sharing,
+				},
+				devices: tc.devices,
+			}
+			err := r.ValidateRequest(tc.requestDevicesIDs)
+			require.ErrorIs(t, err, tc.expectedError)
+		})
+	}
+}

--- a/internal/rm/rm_test.go
+++ b/internal/rm/rm_test.go
@@ -151,6 +151,7 @@ func TestValidateRequest(t *testing.T) {
 				"device1::1": nil,
 			},
 			requestDevicesIDs: []string{"device0::1", "device1::0"},
+			expectedError:     errInvalidRequest,
 		},
 		{
 			description: "MPS with two devices -- failRequestsGreaterThanOne",


### PR DESCRIPTION
These changes refactor the sharing checks when processing a Allocate request.

The behaviour that allows `failRequestGreaterThanOne` to control whether multiple devices can be allocated is maintained for TimeSlicing, but this setting is ignored for MPS sharing.

This aligns with the behaviour for the GKE plugin with the exception that we do not "merge" partitions if multiples are requested in a single device. This can be added as a future extension (see https://github.com/NVIDIA/k8s-device-plugin/pull/586).

Closes https://github.com/NVIDIA/cloud-native-team/issues/48