### PR TITLE
Add log tailer for MPS control logs

### DIFF
--- a/cmd/mps-control-daemon/mps/log-tailer.go
+++ b/cmd/mps-control-daemon/mps/log-tailer.go
@@ -1,0 +1,69 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package mps
+
+import (
+	"context"
+	"os"
+	"os/exec"
+)
+
+// tailer tails the contents of a file.
+type tailer struct {
+	filename string
+	cmd      *exec.Cmd
+	cancel   context.CancelFunc
+}
+
+// newTailer creates a tailer.
+func newTailer(filename string) *tailer {
+	return &tailer{
+		filename: filename,
+	}
+}
+
+// Start starts tailing the specified filename.
+func (t *tailer) Start() error {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.cancel = cancel
+
+	//nolint:gosec // G204: Subprocess launched with a potential tainted input or cmd arguments (gosec)
+	cmd := exec.CommandContext(ctx, "tail", "-n", "+1", "-f", t.filename)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	t.cmd = cmd
+	return nil
+}
+
+// Stop stops the tailer.
+// The associated cancel function is called after which the command wait is
+// called -- if applicable.
+func (t *tailer) Stop() error {
+	if t.cancel != nil {
+		t.cancel()
+	}
+
+	if t.cmd == nil {
+		return nil
+	}
+
+	return t.cmd.Wait()
+}


### PR DESCRIPTION
This change adds a background `tail -n +1 -f` command for the `control.log` associated with an MPS daemon.

This is outputed to stdout to ensure that MPS control daemon logs are also available in the `kubectl logs` output.

```
I0313 19:23:55.081285      69 daemon.go:131] "Starting log tailer" resource="nvidia.com/gpu"
[2024-03-13 19:23:55.063 Control    98] Starting control daemon using socket /mps/nvidia.com/gpu/pipe/control
[2024-03-13 19:23:55.063 Control    98] To connect CUDA applications to this daemon, set env CUDA_MPS_PIPE_DIRECTORY=/mps/nvidia.com/gpu/pipe
...
[2024-03-13 19:24:23.903 Control    98] NEW UI
[2024-03-13 19:24:23.903 Control    98] Cmd:get_default_active_thread_percentage
[2024-03-13 19:24:23.903 Control    98] 10.0
[2024-03-13 19:24:23.903 Control    98] UI closed
I0313 19:24:40.850399      69 main.go:144] Received signal "terminated", shutting down.
I0313 19:24:40.850462      69 main.go:214] Stopping MPS daemons.
[2024-03-13 19:24:40.870 Control    98] Accepting connection...
[2024-03-13 19:24:40.870 Control    98] NEW UI
[2024-03-13 19:24:40.871 Control    98] Cmd:quit
[2024-03-13 19:24:40.871 Control    98] Exit with status 0
I0313 19:24:40.871316      69 daemon.go:145] "Stopped MPS control daemon" resource="nvidia.com/gpu"
I0313 19:24:40.886798      69 daemon.go:148] "Stopped log tailer" resource="nvidia.com/gpu" error="signal: killed"
```