### PR TITLE
Add dependabot config to update actions for gh-pages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    target-branch: gh-pages
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"


### PR DESCRIPTION
This upates the actions used to build the helm repo.

See https://github.com/NVIDIA/k8s-device-plugin/actions/runs/8094467127 for Nodejs deprecation warnings.