### PR TITLE
Set MPS limits using per-container envvars

### DIFF
--- a/internal/rm/device_map.go
+++ b/internal/rm/device_map.go
@@ -314,6 +314,7 @@ func updateDeviceMapWithReplicas(replicatedResources *spec.ReplicatedResources, 
 				annotatedID := string(NewAnnotatedID(id, i))
 				replicatedDevice := *(oDevices[r.Name][id])
 				replicatedDevice.ID = annotatedID
+				replicatedDevice.Replicas = r.Replicas
 				devices.insert(name, &replicatedDevice)
 			}
 		}

--- a/internal/rm/devices.go
+++ b/internal/rm/devices.go
@@ -29,6 +29,7 @@ type Device struct {
 	pluginapi.Device
 	Paths       []string
 	Index       string
+	Replicas    int
 	TotalMemory uint64
 }
 
@@ -224,6 +225,14 @@ func (d Device) IsMigDevice() bool {
 // GetUUID returns the UUID for the device from the annotated ID.
 func (d Device) GetUUID() string {
 	return AnnotatedID(d.ID).GetID()
+}
+
+// MemoryPerReplica returns the memory per replica for a given device.
+func (d Device) MemoryPerReplica() uint64 {
+	if d.Replicas < 2 {
+		return d.TotalMemory
+	}
+	return d.TotalMemory / uint64(d.Replicas)
 }
 
 // NewAnnotatedID creates a new AnnotatedID from an ID and a replica number.


### PR DESCRIPTION
This change switches from setting MPS limits a-priory to using per-container envvars to set MPS limits. This also avoids issues with setting these by UUID and allows for "merging" of slices on the same device.

This aligns with what is done for the GKE device plugin: https://github.com/GoogleCloudPlatform/container-engine-accelerators/blob/cf2cc6e7a7d0ed2c2d2c2373fcc7fad7233b8be6/pkg/gpu/nvidia/manager.go#L312