### PR TITLE
Enforce maximum MPS replicas

### DIFF
--- a/cmd/mps-control-daemon/mps/device.go
+++ b/cmd/mps-control-daemon/mps/device.go
@@ -1,0 +1,55 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package mps
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"golang.org/x/mod/semver"
+
+	"github.com/NVIDIA/k8s-device-plugin/internal/rm"
+)
+
+var errInvalidDevice = errors.New("invalid device")
+
+// device represents an MPS-specific alias for an rm.Device.
+type device rm.Device
+
+// assertReplicas checks whether the number of replicas specified is valid.
+func (d *device) assertReplicas() error {
+	maxClients := d.maxClients()
+	if d.Replicas > maxClients {
+		return fmt.Errorf("%w maximum allowed replicas exceeded: %d > %d", errInvalidDevice, d.Replicas, maxClients)
+	}
+	return nil
+}
+
+// maxClients returns the maximum number of clients supported by an MPS server.
+func (d *device) maxClients() int {
+	if d.isAtLeastVolta() {
+		return 48
+	}
+	return 16
+}
+
+// isAtLeastVolta checks whether the specified device is a volta device or newer.
+func (d *device) isAtLeastVolta() bool {
+	vCc := "v" + strings.TrimPrefix(d.ComputeCapability, "v")
+	return semver.Compare(semver.Canonical(vCc), semver.Canonical("v7.5")) >= 0
+}

--- a/cmd/mps-control-daemon/mps/device_test.go
+++ b/cmd/mps-control-daemon/mps/device_test.go
@@ -1,0 +1,112 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package mps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDevice(t *testing.T) {
+	testCases := []struct {
+		description            string
+		input                  device
+		expectedIsAtLeastVolta bool
+		expectedMaxClients     int
+		expectedAssertReplicas error
+	}{
+		{
+			description: "leading v ignored",
+			input: device{
+				ComputeCapability: "v7.5",
+			},
+			expectedIsAtLeastVolta: true,
+			expectedMaxClients:     48,
+		},
+		{
+			description: "no-leading v supported",
+			input: device{
+				ComputeCapability: "7.5",
+			},
+			expectedIsAtLeastVolta: true,
+			expectedMaxClients:     48,
+		},
+		{
+			description: "pre-volta clients",
+			input: device{
+				ComputeCapability: "7.0",
+			},
+			expectedIsAtLeastVolta: false,
+			expectedMaxClients:     16,
+		},
+		{
+			description: "post-volta clients",
+			input: device{
+				ComputeCapability: "9.0",
+			},
+			expectedIsAtLeastVolta: true,
+			expectedMaxClients:     48,
+		},
+		{
+			description: "pre-volta clients exceeded",
+			input: device{
+				ComputeCapability: "7.0",
+				Replicas:          29,
+			},
+			expectedIsAtLeastVolta: false,
+			expectedMaxClients:     16,
+			expectedAssertReplicas: errInvalidDevice,
+		},
+		{
+			description: "post-volta clients exceeded",
+			input: device{
+				ComputeCapability: "9.0",
+				Replicas:          49,
+			},
+			expectedIsAtLeastVolta: true,
+			expectedMaxClients:     48,
+			expectedAssertReplicas: errInvalidDevice,
+		},
+		{
+			description: "pre-volta clients max",
+			input: device{
+				ComputeCapability: "7.0",
+				Replicas:          16,
+			},
+			expectedIsAtLeastVolta: false,
+			expectedMaxClients:     16,
+		},
+		{
+			description: "post-volta clients max",
+			input: device{
+				ComputeCapability: "9.0",
+				Replicas:          48,
+			},
+			expectedIsAtLeastVolta: true,
+			expectedMaxClients:     48,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			require.Equal(t, tc.expectedIsAtLeastVolta, tc.input.isAtLeastVolta())
+			require.Equal(t, tc.expectedMaxClients, tc.input.maxClients())
+			require.ErrorIs(t, tc.input.assertReplicas(), tc.expectedAssertReplicas)
+		})
+	}
+}

--- a/cmd/mps-control-daemon/mps/manager.go
+++ b/cmd/mps-control-daemon/mps/manager.go
@@ -86,10 +86,13 @@ func (m *manager) Daemons() ([]*Daemon, error) {
 			continue
 		}
 		// Check if MIG devices are included.
-		for _, device := range resourceManager.Devices() {
-			if device.IsMigDevice() {
+		for _, rmDevice := range resourceManager.Devices() {
+			if rmDevice.IsMigDevice() {
 				klog.Warning("MPS sharing is not supported for MIG devices; skipping daemon creation")
 				continue
+			}
+			if err := (*device)(rmDevice).assertReplicas(); err != nil {
+				return nil, fmt.Errorf("invalid MPS configuration: %w", err)
 			}
 		}
 		daemon := NewDaemon(resourceManager, ContainerRoot)

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.27.1
+	golang.org/x/mod v0.15.0
 	golang.org/x/net v0.22.0
 	google.golang.org/grpc v1.62.1
 	k8s.io/api v0.29.2
@@ -143,7 +144,6 @@ require (
 	go.starlark.net v0.0.0-20240123142251-f86470692795 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 // indirect
-	golang.org/x/mod v0.15.0 // indirect
 	golang.org/x/oauth2 v0.17.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.18.0 // indirect

--- a/internal/rm/device_map.go
+++ b/internal/rm/device_map.go
@@ -314,6 +314,7 @@ func updateDeviceMapWithReplicas(replicatedResources *spec.ReplicatedResources, 
 				annotatedID := string(NewAnnotatedID(id, i))
 				replicatedDevice := *(oDevices[r.Name][id])
 				replicatedDevice.ID = annotatedID
+				replicatedDevice.Replicas = r.Replicas
 				devices.insert(name, &replicatedDevice)
 			}
 		}

--- a/internal/rm/nvml_devices.go
+++ b/internal/rm/nvml_devices.go
@@ -84,6 +84,24 @@ func (d nvmlDevice) GetPaths() ([]string, error) {
 	return []string{path}, nil
 }
 
+// GetComputeCapability returns the CUDA Compute Capability for the device.
+func (d nvmlDevice) GetComputeCapability() (string, error) {
+	major, minor, ret := d.Device.GetCudaComputeCapability()
+	if ret != nvml.SUCCESS {
+		return "", ret
+	}
+	return fmt.Sprintf("%d.%d", major, minor), nil
+}
+
+// GetComputeCapability returns the CUDA Compute Capability for the device.
+func (d nvmlMigDevice) GetComputeCapability() (string, error) {
+	parent, ret := d.Device.GetDeviceHandleFromMigDeviceHandle()
+	if ret != nvml.SUCCESS {
+		return "", fmt.Errorf("failed to get parent device: %w", ret)
+	}
+	return nvmlDevice{parent}.GetComputeCapability()
+}
+
 // GetPaths returns the paths for a MIG device
 func (d nvmlMigDevice) GetPaths() ([]string, error) {
 	capDevicePaths, err := mig.GetMigCapabilityDevicePaths()

--- a/internal/rm/tegra_devices.go
+++ b/internal/rm/tegra_devices.go
@@ -72,3 +72,8 @@ func (d *tegraDevice) GetNumaNode() (bool, int, error) {
 func (d *tegraDevice) GetTotalMemory() (uint64, error) {
 	return 0, nil
 }
+
+// GetComputeCapability is unimplemented for a Tegra device.
+func (d *tegraDevice) GetComputeCapability() (string, error) {
+	return "0.0", nil
+}

--- a/internal/rm/wsl_devices.go
+++ b/internal/rm/wsl_devices.go
@@ -39,3 +39,8 @@ func (d wslDevice) GetNumaNode() (bool, int, error) {
 func (d wslDevice) GetTotalMemory() (uint64, error) {
 	return nvmlDevice(d).GetTotalMemory()
 }
+
+// GetComputeCapability returns the CUDA compute capability for the device.
+func (d wslDevice) GetComputeCapability() (string, error) {
+	return nvmlDevice(d).GetComputeCapability()
+}


### PR DESCRIPTION
This change ensures that the maximum number of replicase for MPS is:
* 48 on Volta or newer systems.
* 16 on older systems.
