### PR TITLE
Add syncronization between the MPS control daemon and the device plugin

### DIFF
--- a/cmd/mps-control-daemon/mps/manager.go
+++ b/cmd/mps-control-daemon/mps/manager.go
@@ -17,7 +17,10 @@
 package mps
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"reflect"
 
 	"github.com/NVIDIA/go-nvlib/pkg/nvml"
 	"k8s.io/klog/v2"
@@ -28,6 +31,7 @@ import (
 
 type Manager interface {
 	Daemons() ([]*Daemon, error)
+	AssertReady() error
 }
 
 type manager struct {
@@ -102,7 +106,30 @@ func (m *manager) Daemons() ([]*Daemon, error) {
 	return daemons, nil
 }
 
+func (m *manager) AssertReady() error {
+	readyFile, err := os.Open("/mps/.ready")
+	if err != nil {
+		return fmt.Errorf("failed to process .ready file: %w", err)
+	}
+	defer readyFile.Close()
+
+	var mpsConfig spec.ReplicatedResources
+	if err := json.NewDecoder(readyFile).Decode(&mpsConfig); err != nil {
+		return fmt.Errorf("failed to load .ready config: %w", err)
+	}
+	if !reflect.DeepEqual(mpsConfig, *m.config.Sharing.MPS) {
+		klog.InfoS("mismatched sharing configs", "config", mpsConfig)
+		return fmt.Errorf("mismatched sharing config; assuming MPS is not ready")
+	}
+	return nil
+}
+
 // Daemons always returns an empty slice for a nullManager.
 func (m *nullManager) Daemons() ([]*Daemon, error) {
 	return nil, nil
+}
+
+// AssertReady always returns nil for a nullManager.
+func (m *nullManager) AssertReady() error {
+	return nil
 }

--- a/cmd/mps-control-daemon/mps/ready.go
+++ b/cmd/mps-control-daemon/mps/ready.go
@@ -61,14 +61,14 @@ func (f ReadyFile) Save(config *spec.Config) error {
 }
 
 // Load loads the contents of th read file.
-func (f ReadyFile) Load() (*spec.Config, error) {
+func (f ReadyFile) Load() (*spec.ReplicatedResources, error) {
 	readyFile, err := os.Open(ReadyFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open .ready file: %w", err)
 	}
 	defer readyFile.Close()
 
-	var readyConfig spec.Config
+	var readyConfig spec.ReplicatedResources
 	if err := json.NewDecoder(readyFile).Decode(&readyConfig); err != nil {
 		return nil, fmt.Errorf("faled to load .ready config: %w", err)
 	}
@@ -87,5 +87,5 @@ func (f ReadyFile) Matches(config *spec.Config) (bool, error) {
 	if readyConfig == nil {
 		return false, nil
 	}
-	return reflect.DeepEqual(config.Sharing.MPS, readyConfig.Sharing.MPS), nil
+	return reflect.DeepEqual(config.Sharing.MPS, readyConfig), nil
 }

--- a/cmd/mps-control-daemon/mps/ready.go
+++ b/cmd/mps-control-daemon/mps/ready.go
@@ -1,0 +1,91 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package mps
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+
+	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
+)
+
+const (
+	ReadyFilePath = "/mps/.ready"
+)
+
+// ReadyFile represents a file used to store readyness of the MPS daemon.
+type ReadyFile struct{}
+
+// Remove the ready file.
+func (f ReadyFile) Remove() error {
+	err := os.Remove(ReadyFilePath)
+	if err == nil || errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+// Save writes the specified config to the ready file.
+func (f ReadyFile) Save(config *spec.Config) error {
+	readyFile, err := os.Create(ReadyFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to create .ready file: %w", err)
+	}
+	defer readyFile.Close()
+
+	data := &spec.ReplicatedResources{}
+	if config != nil && config.Sharing.MPS != nil {
+		data = config.Sharing.MPS
+	}
+	if err := json.NewEncoder(readyFile).Encode(data); err != nil {
+		return fmt.Errorf("failed to write .ready file: %w", err)
+	}
+	return nil
+}
+
+// Load loads the contents of th read file.
+func (f ReadyFile) Load() (*spec.Config, error) {
+	readyFile, err := os.Open(ReadyFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open .ready file: %w", err)
+	}
+	defer readyFile.Close()
+
+	var readyConfig spec.Config
+	if err := json.NewDecoder(readyFile).Decode(&readyConfig); err != nil {
+		return nil, fmt.Errorf("faled to load .ready config: %w", err)
+	}
+	return &readyConfig, nil
+}
+
+// Matches checks whether the contents of the ready file matches the specified config.
+func (f ReadyFile) Matches(config *spec.Config) (bool, error) {
+	readyConfig, err := f.Load()
+	if err != nil {
+		return false, err
+	}
+	if config == nil {
+		return readyConfig == nil, nil
+	}
+	if readyConfig == nil {
+		return false, nil
+	}
+	return reflect.DeepEqual(config.Sharing.MPS, readyConfig.Sharing.MPS), nil
+}

--- a/cmd/mps-control-daemon/wait/wait.go
+++ b/cmd/mps-control-daemon/wait/wait.go
@@ -23,13 +23,14 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/urfave/cli/v2"
+	"k8s.io/klog/v2"
+
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 	"github.com/NVIDIA/k8s-device-plugin/cmd/mps-control-daemon/mps"
 	"github.com/NVIDIA/k8s-device-plugin/internal/logger"
 	"github.com/NVIDIA/k8s-device-plugin/internal/rm"
 	"github.com/NVIDIA/k8s-device-plugin/internal/watch"
-	"github.com/urfave/cli/v2"
-	"k8s.io/klog/v2"
 )
 
 // NewCommand constructs a mount command.

--- a/cmd/mps-control-daemon/wait/wait.go
+++ b/cmd/mps-control-daemon/wait/wait.go
@@ -39,7 +39,7 @@ func NewCommand() *cli.Command {
 		Name:  "wait",
 		Usage: "Waits for the mps-daemon(s) to be ready",
 		Action: func(ctx *cli.Context) error {
-			return waitForMps(ctx, ctx.Command.Flags)
+			return waitForMps(ctx, append(ctx.Command.Flags, ctx.App.Flags...))
 		},
 	}
 }

--- a/cmd/mps-control-daemon/wait/wait.go
+++ b/cmd/mps-control-daemon/wait/wait.go
@@ -1,0 +1,159 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package wait
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"syscall"
+	"time"
+
+	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
+	"github.com/NVIDIA/k8s-device-plugin/cmd/mps-control-daemon/mps"
+	"github.com/NVIDIA/k8s-device-plugin/internal/logger"
+	"github.com/NVIDIA/k8s-device-plugin/internal/rm"
+	"github.com/NVIDIA/k8s-device-plugin/internal/watch"
+	"github.com/urfave/cli/v2"
+	"k8s.io/klog/v2"
+)
+
+// NewCommand constructs a mount command.
+func NewCommand() *cli.Command {
+	// Create the 'generate-cdi' command
+	return &cli.Command{
+		Name:  "wait",
+		Usage: "Waits for the mps-daemon(s) to be ready",
+		Action: func(ctx *cli.Context) error {
+			return waitForMps(ctx, ctx.Command.Flags)
+		},
+	}
+}
+
+func validateFlags(config *spec.Config) error {
+	return nil
+}
+
+func loadConfig(c *cli.Context, flags []cli.Flag) (*spec.Config, error) {
+	config, err := spec.NewConfig(c, flags)
+	if err != nil {
+		return nil, fmt.Errorf("unable to finalize config: %v", err)
+	}
+	err = validateFlags(config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to validate flags: %v", err)
+	}
+	config.Flags.GFD = nil
+	return config, nil
+}
+
+// waitForMps waits for an MPS daemon to be ready.
+func waitForMps(c *cli.Context, flags []cli.Flag) error {
+	config, err := getConfig(c, flags)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if config.Sharing.SharingStrategy() != spec.SharingStrategyMPS {
+		klog.InfoS("MPS sharing not enabled; exiting", "strategy", config.Sharing.SharingStrategy())
+		return nil
+	}
+
+	klog.Info("Starting OS watcher.")
+	sigs := watch.Signals(syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+
+	var retry <-chan time.Time
+
+restart:
+	err = assertMpsIsReady(config)
+	if err == nil {
+		klog.Infof("MPS is ready")
+		return nil
+	}
+	klog.ErrorS(err, "MPS is not ready; retrying ...")
+	retry = time.After(30 * time.Second)
+
+	for {
+		select {
+		case <-retry:
+			goto restart
+			// Watch for any signals from the OS. On SIGHUP, restart this loop,
+			// restarting all of the plugins in the process. On all other
+			// signals, exit the loop and exit the program.
+		case s := <-sigs:
+			switch s {
+			case syscall.SIGHUP:
+				klog.Info("Received SIGHUP, restarting.")
+				goto restart
+			default:
+				klog.Infof("Received signal \"%v\", shutting down.", s)
+				goto exit
+			}
+		}
+
+	}
+exit:
+	return nil
+}
+
+func assertMpsIsReady(config *spec.Config) error {
+	mpsManager, err := mps.New(
+		mps.WithConfig(config),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create MPS manager: %w", err)
+	}
+	if err := mpsManager.AssertReady(); err != nil {
+		return fmt.Errorf("mps manager is not ready: %w", err)
+	}
+	mpsDaemons, err := mpsManager.Daemons()
+	if err != nil {
+		return fmt.Errorf("failed to get MPS daemons: %w", err)
+	}
+
+	var daemonErrors error
+	for _, mpsDaemon := range mpsDaemons {
+		err := mpsDaemon.AssertHealthy()
+		daemonErrors = errors.Join(daemonErrors, err)
+	}
+	return daemonErrors
+}
+
+func getConfig(c *cli.Context, flags []cli.Flag) (*spec.Config, error) {
+	// Load the configuration file
+	klog.Info("Loading configuration.")
+	config, err := loadConfig(c, flags)
+	if err != nil {
+		return nil, fmt.Errorf("unable to load config: %v", err)
+	}
+	spec.DisableResourceNamingInConfig(logger.ToKlog, config)
+
+	// Update the configuration file with default resources.
+	klog.Info("Updating config with default resource matching patterns.")
+	err = rm.AddDefaultResourcesToConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to add default resources to config: %v", err)
+	}
+
+	// Print the config to the output.
+	configJSON, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal config to JSON: %v", err)
+	}
+	klog.Infof("\nRunning with config:\n%v", string(configJSON))
+	return config, nil
+}

--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -176,9 +176,9 @@ func loadConfig(c *cli.Context, flags []cli.Flag) (*spec.Config, error) {
 
 func start(c *cli.Context, flags []cli.Flag) error {
 	klog.Info("Starting FS watcher.")
-	watcher, err := watch.Files(pluginapi.DevicePluginPath)
+	watcher, err := watch.Files(pluginapi.DevicePluginPath, "/mps")
 	if err != nil {
-		return fmt.Errorf("failed to create FS watcher for %s: %v", pluginapi.DevicePluginPath, err)
+		return fmt.Errorf("failed to create FS watcher: %v", err)
 	}
 	defer watcher.Close()
 
@@ -198,7 +198,7 @@ restart:
 	}
 
 	klog.Info("Starting Plugins.")
-	plugins, restartPlugins, err := startPlugins(c, flags)
+	plugins, config, restartPlugins, err := startPlugins(c, flags)
 	if err != nil {
 		return fmt.Errorf("error starting plugins: %v", err)
 	}
@@ -221,9 +221,24 @@ restart:
 		// 'pluginapi.KubeletSocket' file. When this occurs, restart this loop,
 		// restarting all of the plugins in the process.
 		case event := <-watcher.Events:
+			klog.InfoS("processing watcher event", "event", event)
 			if event.Name == pluginapi.KubeletSocket && event.Op&fsnotify.Create == fsnotify.Create {
 				klog.Infof("inotify: %s created, restarting.", pluginapi.KubeletSocket)
 				goto restart
+			}
+			if event.Name == "/mps/.ready" {
+				if config == nil || config.Sharing.SharingStrategy() != spec.SharingStrategyMPS {
+					klog.InfoS("Ignoring /mps/.ready event", "event", event)
+					continue
+				}
+				switch {
+				case event.Op&fsnotify.Create == fsnotify.Create:
+					klog.Infof("/mps/.ready created; restarting")
+					goto restart
+				case event.Op&fsnotify.Remove == fsnotify.Remove:
+					klog.Infof("/mps/.ready removed; restarting")
+					goto restart
+				}
 			}
 
 		// Watch for any other fs errors and log them.
@@ -252,12 +267,12 @@ exit:
 	return nil
 }
 
-func startPlugins(c *cli.Context, flags []cli.Flag) ([]plugin.Interface, bool, error) {
+func startPlugins(c *cli.Context, flags []cli.Flag) ([]plugin.Interface, *spec.Config, bool, error) {
 	// Load the configuration file
 	klog.Info("Loading configuration.")
 	config, err := loadConfig(c, flags)
 	if err != nil {
-		return nil, false, fmt.Errorf("unable to load config: %v", err)
+		return nil, nil, false, fmt.Errorf("unable to load config: %v", err)
 	}
 	spec.DisableResourceNamingInConfig(logger.ToKlog, config)
 
@@ -265,13 +280,13 @@ func startPlugins(c *cli.Context, flags []cli.Flag) ([]plugin.Interface, bool, e
 	klog.Info("Updating config with default resource matching patterns.")
 	err = rm.AddDefaultResourcesToConfig(config)
 	if err != nil {
-		return nil, false, fmt.Errorf("unable to add default resources to config: %v", err)
+		return nil, nil, false, fmt.Errorf("unable to add default resources to config: %v", err)
 	}
 
 	// Print the config to the output.
 	configJSON, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
-		return nil, false, fmt.Errorf("failed to marshal config to JSON: %v", err)
+		return nil, nil, false, fmt.Errorf("failed to marshal config to JSON: %v", err)
 	}
 	klog.Infof("\nRunning with config:\n%v", string(configJSON))
 
@@ -279,11 +294,11 @@ func startPlugins(c *cli.Context, flags []cli.Flag) ([]plugin.Interface, bool, e
 	klog.Info("Retrieving plugins.")
 	pluginManager, err := NewPluginManager(config)
 	if err != nil {
-		return nil, false, fmt.Errorf("error creating plugin manager: %v", err)
+		return nil, nil, false, fmt.Errorf("error creating plugin manager: %v", err)
 	}
 	plugins, err := pluginManager.GetPlugins()
 	if err != nil {
-		return nil, false, fmt.Errorf("error getting plugins: %v", err)
+		return nil, nil, false, fmt.Errorf("error getting plugins: %v", err)
 	}
 
 	// Loop through all plugins, starting them if they have any devices
@@ -299,7 +314,7 @@ func startPlugins(c *cli.Context, flags []cli.Flag) ([]plugin.Interface, bool, e
 		// Start the gRPC server for plugin p and connect it with the kubelet.
 		if err := p.Start(); err != nil {
 			klog.Errorf("Failed to start plugin: %v", err)
-			return plugins, true, nil
+			return plugins, nil, true, nil
 		}
 		started++
 	}
@@ -308,7 +323,7 @@ func startPlugins(c *cli.Context, flags []cli.Flag) ([]plugin.Interface, bool, e
 		klog.Info("No devices found. Waiting indefinitely.")
 	}
 
-	return plugins, false, nil
+	return plugins, config, false, nil
 }
 
 func stopPlugins(plugins []plugin.Interface) error {

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -109,6 +109,8 @@ spec:
             mountPath: /mps
           - name: cdi-root
             mountPath: /var/run/cdi
+          - name: available-configs
+            mountPath: /available-configs
           - name: config
             mountPath: /config
       {{- end }}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -92,6 +92,25 @@ spec:
             mountPath: /available-configs
           - name: config
             mountPath: /config
+      - image: {{ include "nvidia-device-plugin.fullimage" . }}
+        name: nvidia-device-plugin-mps-sync
+        command:
+        - mps-control-daemon
+        - wait
+        env:
+          - name: CONFIG_FILE
+            value: /config/config.yaml
+        securityContext:
+          {{- include "nvidia-device-plugin.securityContext" . | nindent 10 }}
+        volumeMounts:
+          - name: mps-shm
+            mountPath: /dev/shm
+          - name: mps-root
+            mountPath: /mps
+          - name: cdi-root
+            mountPath: /var/run/cdi
+          - name: config
+            mountPath: /config
       {{- end }}
       containers:
       {{- if eq $hasConfigMap "true" }}

--- a/internal/plugin/server.go
+++ b/internal/plugin/server.go
@@ -17,14 +17,12 @@
 package plugin
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"time"
 
@@ -170,28 +168,21 @@ func (plugin *NvidiaDevicePlugin) waitForMPSDaemon() error {
 	if plugin.config.Sharing.SharingStrategy() != spec.SharingStrategyMPS {
 		return nil
 	}
+
+	readyFile := mps.ReadyFile{}
+	matches, err := readyFile.Matches(plugin.config)
+	if err != nil {
+		return fmt.Errorf("failed to load .ready config: %w", err)
+	}
+	if !matches {
+		klog.InfoS("mismatched sharing configs", "config", plugin.config)
+		return fmt.Errorf("mismatched sharing config; assuming MPS is not ready")
+	}
 	// TODO: Have some retry strategy here.
 	if err := plugin.mpsDaemon.AssertHealthy(); err != nil {
 		return fmt.Errorf("error checking MPS daemon health: %w", err)
 	}
 	klog.InfoS("MPS daemon is healthy", "resource", plugin.rm.Resource())
-
-	// TODO: Check the .ready file here.
-	readyFile, err := os.Open("/mps/.ready")
-	if err != nil {
-		return fmt.Errorf("failed to process .ready file: %w", err)
-	}
-	defer readyFile.Close()
-
-	var mpsConfig spec.ReplicatedResources
-	if err := json.NewDecoder(readyFile).Decode(&mpsConfig); err != nil {
-		return fmt.Errorf("failed to load .ready config: %w", err)
-	}
-	if !reflect.DeepEqual(mpsConfig, *plugin.config.Sharing.MPS) {
-		klog.InfoS("mismatched sharing configs", "config", mpsConfig)
-		return fmt.Errorf("mismatched sharing config; assuming MPS is not ready")
-	}
-
 	return nil
 }
 

--- a/internal/watch/watchers.go
+++ b/internal/watch/watchers.go
@@ -16,6 +16,7 @@
 package watch
 
 import (
+	"fmt"
 	"os"
 	"os/signal"
 
@@ -33,7 +34,7 @@ func Files(files ...string) (*fsnotify.Watcher, error) {
 		err = watcher.Add(f)
 		if err != nil {
 			watcher.Close()
-			return nil, err
+			return nil, fmt.Errorf("failed to add file %v: %w", f, err)
 		}
 	}
 


### PR DESCRIPTION
This change adds an init-container to the device plugin to ensure that the MPS daemon with the correct config has been started *before* the device plugin starts.

This init container logs:
```
I0319 13:48:40.749279      28 wait.go:76] Starting OS watcher.
E0319 13:48:40.749531      28 wait.go:87] "MPS is not ready; retrying ..." err="mps manager is not ready: failed to load .ready config: failed to open .ready file: open /mps/.ready: no such file or directory"
I0319 13:49:10.871775      28 wait.go:84] MPS is ready
```
