### PR TITLE
[golangci-lint] fix implicit memory aliasing in for loop 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 10m
+  timeout: 10m
 
 linters:
   enable:
@@ -28,11 +28,6 @@ issues:
     linters:
     - gosec
     text: "G404"
-  # We disable the memory aliasing checks in tests
-  - path: ".*_test.go"
-    linters:
-    - gosec
-    text: "G601: Implicit memory aliasing in for loop"
   # We create world-readable files in tests.
   - path: ".*_test.go"
     linters:

--- a/internal/plugin/server_test.go
+++ b/internal/plugin/server_test.go
@@ -131,7 +131,8 @@ func TestCDIAllocateResponse(t *testing.T) {
 		},
 	}
 
-	for _, tc := range testCases {
+	for i := range testCases {
+		tc := testCases[i]
 		t.Run(tc.description, func(t *testing.T) {
 			deviceListStrategies, _ := v1.NewDeviceListStrategies(tc.deviceListStrategies)
 			plugin := NvidiaDevicePlugin{

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -18,10 +18,8 @@ package e2e
 
 import (
 	"flag"
-	"math/rand"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -52,7 +50,6 @@ func TestMain(m *testing.M) {
 		e2elog.Failf("Required flags not set. Please set -image.repo, -image.tag and -helm-chart")
 	}
 
-	rand.New(rand.NewSource(time.Now().UnixNano()))
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
To get more details on these why fixes were implemented: https://husni.dev/beware-of-implicit-memory-aliasing-in-go-foor-loop/