### PR TITLE
Fix error message when creating labeler

### DIFF
--- a/internal/lm/labeler.go
+++ b/internal/lm/labeler.go
@@ -31,13 +31,13 @@ type Labeler interface {
 
 // NewLabelers constructs the required labelers from the specified config
 func NewLabelers(manager resource.Manager, vgpu vgpu.Interface, config *spec.Config) (Labeler, error) {
-	nvmlLabeler, err := NewNVMLLabeler(manager, config)
+	deviceLabeler, err := NewDeviceLabeler(manager, config)
 	if err != nil {
-		return nil, fmt.Errorf("error creating NVML labeler: %v", err)
+		return nil, fmt.Errorf("error creating labeler: %v", err)
 	}
 
 	l := Merge(
-		nvmlLabeler,
+		deviceLabeler,
 		NewVGPULabeler(vgpu),
 	)
 

--- a/internal/lm/nvml.go
+++ b/internal/lm/nvml.go
@@ -27,10 +27,10 @@ import (
 	"github.com/NVIDIA/k8s-device-plugin/internal/resource"
 )
 
-// NewNVMLLabeler creates a new NVML-based labeler using the provided NVML library and config.
-func NewNVMLLabeler(manager resource.Manager, config *spec.Config) (Labeler, error) {
+// NewDeviceLabeler creates a new labeler for the specified resource manager.
+func NewDeviceLabeler(manager resource.Manager, config *spec.Config) (Labeler, error) {
 	if err := manager.Init(); err != nil {
-		return nil, fmt.Errorf("failed to initialize NVML: %v", err)
+		return nil, fmt.Errorf("failed to initialize resource manager: %v", err)
 	}
 	defer func() {
 		_ = manager.Shutdown()


### PR DESCRIPTION
The function name and error messages when creating a device labeller mentions NVML -- although NVML may not be used. This change renames the function and also makes the error message more generic.