### PR TITLE
Simplify and improve compatibility of PCI device classes for NFD workers

### DIFF
--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -139,10 +139,7 @@ nfd:
         pci:
           deviceClassWhitelist:
           - "02"
-          - "0200"
-          - "0207"
-          - "0300"
-          - "0302"
+          - "03"
           deviceLabelFields:
           - vendor
 


### PR DESCRIPTION
Refer to https://kubernetes-sigs.github.io/node-feature-discovery/v0.15/reference/worker-configuration-reference#sourcespci

"02" means "02*" so the other entries starting with 02 are redundant.

Also improve compatibility by detecting all "03" types of display controllers, not just "0302". Refer to: https://admin.pci-ids.ucw.cz/read/PD/03

Also note that the default value of upstream NFD includes "03", as in this merge request. So this will improve compatibility and bring the behaviour in line with the standard defaults of upstream NFD. This way users can have the same standard expected behaviour whether they use NFD which is bundled in the NVIDIA device plugin, or upstream NFD.