### PR TITLE
use the helm quote function to wrap boolean values in quotes

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -78,9 +78,9 @@ spec:
         - name: CONFIG_FILE_DST
           value: "/config/config.yaml"
         - name: DEFAULT_CONFIG
-          value: "{{ .Values.config.default }}"
+          value: {{ .Values.config.default }}
         - name: FALLBACK_STRATEGIES
-          value: "{{ join "," .Values.config.fallbackStrategies }}"
+          value: {{ join "," .Values.config.fallbackStrategies }}
         - name: SEND_SIGNAL
           value: "false"
         - name: SIGNAL
@@ -114,9 +114,9 @@ spec:
         - name: CONFIG_FILE_DST
           value: "/config/config.yaml"
         - name: DEFAULT_CONFIG
-          value: "{{ .Values.config.default }}"
+          value: {{ .Values.config.default }}
         - name: FALLBACK_STRATEGIES
-          value: "{{ join "," .Values.config.fallbackStrategies }}"
+          value: {{ join "," .Values.config.fallbackStrategies }}
         - name: SEND_SIGNAL
           value: "true"
         - name: SIGNAL
@@ -137,38 +137,38 @@ spec:
         command: ["nvidia-device-plugin"]
         env:
           - name: MPS_ROOT
-            value: "{{ .Values.mps.root }}"
+            value: {{ .Values.mps.root }}
         {{- if typeIs "string" .Values.migStrategy }}
           - name: MIG_STRATEGY
-            value: "{{ .Values.migStrategy }}"
+            value: {{ .Values.migStrategy }}
         {{- end }}
         {{- if typeIs "bool" .Values.failOnInitError }}
           - name: FAIL_ON_INIT_ERROR
-            value: "{{ .Values.failOnInitError }}"
+            value: {{ .Values.failOnInitError }}
         {{- end }}
         {{- if typeIs "bool" .Values.compatWithCPUManager }}
           - name: PASS_DEVICE_SPECS
-            value: "{{ .Values.compatWithCPUManager }}"
+            value: {{ .Values.compatWithCPUManager | quote }}
         {{- end }}
         {{- if typeIs "string" .Values.deviceListStrategy }}
           - name: DEVICE_LIST_STRATEGY
-            value: "{{ .Values.deviceListStrategy }}"
+            value: {{ .Values.deviceListStrategy }}
         {{- end }}
         {{- if typeIs "string" .Values.deviceIDStrategy }}
           - name: DEVICE_ID_STRATEGY
-            value: "{{ .Values.deviceIDStrategy }}"
+            value: {{ .Values.deviceIDStrategy }}
         {{- end }}
         {{- if typeIs "string" .Values.nvidiaDriverRoot }}
           - name: NVIDIA_DRIVER_ROOT
-            value: "{{ .Values.nvidiaDriverRoot }}"
+            value: {{ .Values.nvidiaDriverRoot }}
         {{- end }}
         {{- if typeIs "bool" .Values.gdsEnabled }}
           - name: GDS_ENABLED
-            value: "{{ .Values.gdsEnabled }}"
+            value: {{ .Values.gdsEnabled | quote }}
         {{- end }}
         {{- if typeIs "bool" .Values.mofedEnabled }}
           - name: MOFED_ENABLED
-            value: "{{ .Values.mofedEnabled }}"
+            value: {{ .Values.mofedEnabled | quote }}
         {{- end }}
         {{- if eq $hasConfigMap "true" }}
           - name: CONFIG_FILE
@@ -234,7 +234,7 @@ spec:
       {{- if eq $hasConfigMap "true" }}
         - name: available-configs
           configMap:
-            name: "{{ $configMapName }}"
+            name: {{ $configMapName }}
         - name: config
           emptyDir: {}
       {{- end }}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
@@ -78,9 +78,9 @@ spec:
         - name: CONFIG_FILE_DST
           value: "/config/config.yaml"
         - name: DEFAULT_CONFIG
-          value: "{{ .Values.config.default }}"
+          value: {{ .Values.config.default }}
         - name: FALLBACK_STRATEGIES
-          value: "{{ join "," .Values.config.fallbackStrategies }}"
+          value: {{ join "," .Values.config.fallbackStrategies }}
         - name: SEND_SIGNAL
           value: "false"
         - name: SIGNAL
@@ -114,9 +114,9 @@ spec:
         - name: CONFIG_FILE_DST
           value: "/config/config.yaml"
         - name: DEFAULT_CONFIG
-          value: "{{ .Values.config.default }}"
+          value: {{ .Values.config.default }}
         - name: FALLBACK_STRATEGIES
-          value: "{{ join "," .Values.config.fallbackStrategies }}"
+          value: {{ join "," .Values.config.fallbackStrategies }}
         - name: SEND_SIGNAL
           value: "true"
         - name: SIGNAL
@@ -146,23 +146,23 @@ spec:
                 fieldPath: metadata.namespace
         {{- if typeIs "string" .Values.migStrategy }}
           - name: MIG_STRATEGY
-            value: "{{ .Values.migStrategy }}"
+            value: {{ .Values.migStrategy }}
         {{- end }}
         {{- if typeIs "bool" .Values.failOnInitError }}
           - name: FAIL_ON_INIT_ERROR
-            value: "{{ .Values.failOnInitError }}"
+            value: {{ .Values.failOnInitError | quote }}
         {{- end }}
         {{- if typeIs "bool" .Values.noTimestamp }}
           - name: GFD_NO_TIMESTAMP
-            value: "{{ .Values.noTimestamp}}"
+            value: {{ .Values.noTimestamp | quote }}
         {{- end }}
         {{- if or (typeIs "string" .Values.sleepInterval) (typeIs "int" .Values.sleepInterval) }}
           - name: GFD_SLEEP_INTERVAL
-            value: "{{ .Values.sleepInterval }}"
+            value: {{ .Values.sleepInterval | quote }}
         {{- end }}
         {{- if typeIs "bool" .Values.nfd.enableNodeFeatureApi }}
           - name: GFD_USE_NODE_FEATURE_API
-            value: "{{ .Values.nfd.enableNodeFeatureApi }}"
+            value: {{ .Values.nfd.enableNodeFeatureApi | quote }}
         {{- end }}
         {{- if eq $hasConfigMap "true" }}
           - name: CONFIG_FILE
@@ -199,7 +199,7 @@ spec:
       {{- if eq $hasConfigMap "true" }}
         - name: available-configs
           configMap:
-            name: "{{ $configMapName }}"
+            name: {{ $configMapName }}
         - name: config
           emptyDir: {}
       {{- end }}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -89,9 +89,9 @@ spec:
         - name: CONFIG_FILE_DST
           value: "/config/config.yaml"
         - name: DEFAULT_CONFIG
-          value: "{{ .Values.config.default }}"
+          value: {{ .Values.config.default }}
         - name: FALLBACK_STRATEGIES
-          value: "{{ join "," .Values.config.fallbackStrategies }}"
+          value: {{ join "," .Values.config.fallbackStrategies }}
         - name: SEND_SIGNAL
           value: "false"
         - name: SIGNAL
@@ -126,9 +126,9 @@ spec:
           - name: CONFIG_FILE_DST
             value: "/config/config.yaml"
           - name: DEFAULT_CONFIG
-            value: "{{ .Values.config.default }}"
+            value: {{ .Values.config.default }}
           - name: FALLBACK_STRATEGIES
-            value: "{{ join "," .Values.config.fallbackStrategies }}"
+            value: {{ join "," .Values.config.fallbackStrategies }}
           - name: SEND_SIGNAL
             value: "true"
           - name: SIGNAL
@@ -153,7 +153,7 @@ spec:
                 fieldPath: spec.nodeName
         {{- if typeIs "string" .Values.migStrategy }}
           - name: MIG_STRATEGY
-            value: "{{ .Values.migStrategy }}"
+            value: {{ .Values.migStrategy }}
         {{- end }}
         {{- if eq $hasConfigMap "true" }}
           - name: CONFIG_FILE
@@ -195,7 +195,7 @@ spec:
       {{- if eq $hasConfigMap "true" }}
       - name: available-configs
         configMap:
-          name: "{{ $configMapName }}"
+          name: {{ $configMapName }}
       - name: config
         emptyDir: {}
       {{- end }}


### PR DESCRIPTION
It's generally recommended to use the `quote` function instead of explicitly wrapping helm values with quotes in-line