### PR TITLE
Support non-standard driver installs

### DIFF
--- a/api/config/v1/config.go
+++ b/api/config/v1/config.go
@@ -53,6 +53,12 @@ func NewConfig(c *cli.Context, flags []cli.Flag) (*Config, error) {
 
 	config.Flags.UpdateFromCLIFlags(c, flags)
 
+	// If nvidiaDevRoot (the path to the device nodes on the host) is not set,
+	// we default to using the driver root on the host.
+	if config.Flags.NvidiaDevRoot == nil || *config.Flags.NvidiaDevRoot == "" {
+		config.Flags.NvidiaDevRoot = config.Flags.NvidiaDriverRoot
+	}
+
 	// We explicitly set sharing.mps.failRequestsGreaterThanOne = true
 	// This can be relaxed in certain cases -- such as a single GPU -- but
 	// requires additional logic around when it's OK to combine requests and

--- a/api/config/v1/flags.go
+++ b/api/config/v1/flags.go
@@ -148,7 +148,7 @@ func (f *Flags) UpdateFromCLIFlags(c *cli.Context, flags []cli.Flag) {
 				updateFromCLIFlag(&f.Plugin.DeviceIDStrategy, c, n)
 			case "cdi-annotation-prefix":
 				updateFromCLIFlag(&f.Plugin.CDIAnnotationPrefix, c, n)
-			case "nvidia-ctk-path":
+			case "nvidia-cdi-hook-path", "nvidia-ctk-path":
 				updateFromCLIFlag(&f.Plugin.NvidiaCTKPath, c, n)
 			case "container-driver-root":
 				updateFromCLIFlag(&f.Plugin.ContainerDriverRoot, c, n)

--- a/api/config/v1/flags.go
+++ b/api/config/v1/flags.go
@@ -59,6 +59,7 @@ type CommandLineFlags struct {
 	FailOnInitError         *bool                   `json:"failOnInitError"            yaml:"failOnInitError"`
 	MpsRoot                 *string                 `json:"mpsRoot,omitempty"          yaml:"mpsRoot,omitempty"`
 	NvidiaDriverRoot        *string                 `json:"nvidiaDriverRoot,omitempty" yaml:"nvidiaDriverRoot,omitempty"`
+	NvidiaDevRoot           *string                 `json:"nvidiaDevRoot,omitempty"    yaml:"nvidiaDevRoot,omitempty"`
 	GDSEnabled              *bool                   `json:"gdsEnabled"                 yaml:"gdsEnabled"`
 	MOFEDEnabled            *bool                   `json:"mofedEnabled"               yaml:"mofedEnabled"`
 	UseNodeFeatureAPI       *bool                   `json:"useNodeFeatureAPI"          yaml:"useNodeFeatureAPI"`
@@ -121,8 +122,10 @@ func (f *Flags) UpdateFromCLIFlags(c *cli.Context, flags []cli.Flag) {
 				updateFromCLIFlag(&f.FailOnInitError, c, n)
 			case "mps-root":
 				updateFromCLIFlag(&f.MpsRoot, c, n)
-			case "nvidia-driver-root":
+			case "driver-root", "nvidia-driver-root":
 				updateFromCLIFlag(&f.NvidiaDriverRoot, c, n)
+			case "dev-root", "nvidia-dev-root":
+				updateFromCLIFlag(&f.NvidiaDevRoot, c, n)
 			case "gds-enabled":
 				updateFromCLIFlag(&f.GDSEnabled, c, n)
 			case "mofed-enabled":

--- a/api/config/v1/strategy.go
+++ b/api/config/v1/strategy.go
@@ -48,12 +48,22 @@ func (s DeviceListStrategies) Includes(strategy string) bool {
 	return s[strategy]
 }
 
-// IsCDIEnabled returns whether any of the strategies being used require CDI.
-func (s DeviceListStrategies) IsCDIEnabled() bool {
+// AnyCDIEnabled returns whether any of the strategies being used require CDI.
+func (s DeviceListStrategies) AnyCDIEnabled() bool {
 	for k, v := range s {
 		if strings.HasPrefix(k, "cdi-") && v {
 			return true
 		}
 	}
 	return false
+}
+
+// AllCDIEnabled returns whether all strategies being used require CDI.
+func (s DeviceListStrategies) AllCDIEnabled() bool {
+	for k, v := range s {
+		if !strings.HasPrefix(k, "cdi-") && v {
+			return false
+		}
+	}
+	return true
 }

--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -158,7 +158,7 @@ func validateFlags(infolib nvinfo.Interface, config *spec.Config) error {
 	}
 
 	hasNvml, _ := infolib.HasNvml()
-	if deviceListStrategies.IsCDIEnabled() && !hasNvml {
+	if deviceListStrategies.AnyCDIEnabled() && !hasNvml {
 		return fmt.Errorf("CDI --device-list-strategy options are only supported on NVML-based systems")
 	}
 

--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -274,7 +274,12 @@ func startPlugins(c *cli.Context, flags []cli.Flag) ([]plugin.Interface, bool, e
 	}
 	spec.DisableResourceNamingInConfig(logger.ToKlog, config)
 
-	nvmllib := nvml.New()
+	driverRoot := root(*config.Flags.Plugin.ContainerDriverRoot)
+	// We construct an NVML library specifying the path to libnvidia-ml.so.1
+	// explicitly so that we don't have to rely on the library path.
+	nvmllib := nvml.New(
+		nvml.WithLibraryPath(driverRoot.tryResolveLibrary("libnvidia-ml.so.1")),
+	)
 	devicelib := device.New(nvmllib)
 	infolib := nvinfo.New(
 		nvinfo.WithNvmlLib(nvmllib),

--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -118,10 +118,11 @@ func main() {
 			EnvVars: []string{"CDI_ANNOTATION_PREFIX"},
 		},
 		&cli.StringFlag{
-			Name:    "nvidia-ctk-path",
+			Name:    "nvidia-cdi-hook-path",
+			Aliases: []string{"nvidia-ctk-path"},
 			Value:   spec.DefaultNvidiaCTKPath,
-			Usage:   "the path to use for the nvidia-ctk in the generated CDI specification",
-			EnvVars: []string{"NVIDIA_CTK_PATH"},
+			Usage:   "the path to use for NVIDIA CDI hooks in the generated CDI specification",
+			EnvVars: []string{"NVIDIA_CDI_HOOK_PATH", "NVIDIA_CTK_PATH"},
 		},
 		&cli.StringFlag{
 			Name:    "driver-root-ctr-path",

--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -65,10 +65,17 @@ func main() {
 			EnvVars: []string{"FAIL_ON_INIT_ERROR"},
 		},
 		&cli.StringFlag{
-			Name:    "nvidia-driver-root",
+			Name:    "driver-root",
+			Aliases: []string{"nvidia-driver-root"},
 			Value:   "/",
-			Usage:   "the root path for the NVIDIA driver installation (typical values are '/' or '/run/nvidia/driver')",
+			Usage:   "the root path for the NVIDIA driver installation on the host (typical values are '/' or '/run/nvidia/driver')",
 			EnvVars: []string{"NVIDIA_DRIVER_ROOT"},
+		},
+		&cli.StringFlag{
+			Name:    "dev-root",
+			Aliases: []string{"nvidia-dev-root"},
+			Usage:   "the root path for the NVIDIA device nodes on the host (typical values are '/' or '/run/nvidia/driver')",
+			EnvVars: []string{"NVIDIA_DEV_ROOT"},
 		},
 		&cli.BoolFlag{
 			Name:    "pass-device-specs",

--- a/cmd/nvidia-device-plugin/plugin-manager.go
+++ b/cmd/nvidia-device-plugin/plugin-manager.go
@@ -39,6 +39,9 @@ func NewPluginManager(infolib info.Interface, nvmllib nvml.Interface, devicelib 
 		return nil, fmt.Errorf("unknown strategy: %v", *config.Flags.MigStrategy)
 	}
 
+	// TODO: We could consider passing this as an argument since it should already be used to construct nvmllib.
+	driverRoot := root(*config.Flags.Plugin.ContainerDriverRoot)
+
 	deviceListStrategies, err := spec.NewDeviceListStrategies(*config.Flags.Plugin.DeviceListStrategy)
 	if err != nil {
 		return nil, fmt.Errorf("invalid device list strategy: %v", err)
@@ -46,7 +49,8 @@ func NewPluginManager(infolib info.Interface, nvmllib nvml.Interface, devicelib 
 
 	cdiHandler, err := cdi.New(infolib, nvmllib, devicelib,
 		cdi.WithDeviceListStrategies(deviceListStrategies),
-		cdi.WithDriverRoot(*config.Flags.Plugin.ContainerDriverRoot),
+		cdi.WithDriverRoot(string(driverRoot)),
+		cdi.WithDevRoot(driverRoot.getDevRoot()),
 		cdi.WithTargetDriverRoot(*config.Flags.NvidiaDriverRoot),
 		cdi.WithNvidiaCTKPath(*config.Flags.Plugin.NvidiaCTKPath),
 		cdi.WithDeviceIDStrategy(*config.Flags.Plugin.DeviceIDStrategy),

--- a/cmd/nvidia-device-plugin/plugin-manager.go
+++ b/cmd/nvidia-device-plugin/plugin-manager.go
@@ -52,6 +52,7 @@ func NewPluginManager(infolib info.Interface, nvmllib nvml.Interface, devicelib 
 		cdi.WithDriverRoot(string(driverRoot)),
 		cdi.WithDevRoot(driverRoot.getDevRoot()),
 		cdi.WithTargetDriverRoot(*config.Flags.NvidiaDriverRoot),
+		cdi.WithTargetDevRoot(*config.Flags.NvidiaDevRoot),
 		cdi.WithNvidiaCTKPath(*config.Flags.Plugin.NvidiaCTKPath),
 		cdi.WithDeviceIDStrategy(*config.Flags.Plugin.DeviceIDStrategy),
 		cdi.WithVendor("k8s.device-plugin.nvidia.com"),

--- a/cmd/nvidia-device-plugin/root.go
+++ b/cmd/nvidia-device-plugin/root.go
@@ -1,0 +1,85 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+type root string
+
+func (r root) join(parts ...string) string {
+	return filepath.Join(append([]string{string(r)}, parts...)...)
+}
+
+// getDevRoot returns the dev root associated with the root.
+// If the root is not a dev root, this defaults to "/".
+func (r root) getDevRoot() string {
+	if r.isDevRoot() {
+		return string(r)
+	}
+	return "/"
+}
+
+// isDevRoot checks whether the specified root is a dev root.
+// A dev root is defined as a root containing a /dev folder.
+func (r root) isDevRoot() bool {
+	stat, err := os.Stat(filepath.Join(string(r), "dev"))
+	if err != nil {
+		return false
+	}
+	return stat.IsDir()
+}
+
+func (r root) tryResolveLibrary(libraryName string) string {
+	if r == "" || r == "/" {
+		return libraryName
+	}
+
+	librarySearchPaths := []string{
+		"/usr/lib64",
+		"/usr/lib/x86_64-linux-gnu",
+		"/usr/lib/aarch64-linux-gnu",
+		"/lib64",
+		"/lib/x86_64-linux-gnu",
+		"/lib/aarch64-linux-gnu",
+	}
+
+	for _, d := range librarySearchPaths {
+		l := r.join(d, libraryName)
+		resolved, err := resolveLink(l)
+		if err != nil {
+			continue
+		}
+		return resolved
+	}
+
+	return libraryName
+}
+
+// resolveLink finds the target of a symlink or the file itself in the
+// case of a regular file.
+// This is equivalent to running `readlink -f ${l}`.
+func resolveLink(l string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(l)
+	if err != nil {
+		return "", fmt.Errorf("error resolving link '%v': %w", l, err)
+	}
+	return resolved, nil
+}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -161,6 +161,10 @@ spec:
           - name: NVIDIA_DRIVER_ROOT
             value: {{ .Values.nvidiaDriverRoot }}
         {{- end }}
+        {{- if typeIs "string" .Values.nvidiaDevRoot }}
+          - name: NVIDIA_DEV_ROOT
+            value: "{{ .Values.nvidiaDevRoot }}"
+        {{- end }}
         {{- if typeIs "bool" .Values.gdsEnabled }}
           - name: GDS_ENABLED
             value: {{ .Values.gdsEnabled | quote }}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -165,6 +165,10 @@ spec:
           - name: NVIDIA_DEV_ROOT
             value: "{{ .Values.nvidiaDevRoot }}"
         {{- end }}
+        {{- if typeIs "string" .Values.cdi.nvidiaHookPath }}
+          - name: NVIDIA_CDI_HOOK_PATH
+            value: {{ .Values.cdi.nvidiaHookPath }}
+        {{- end }}
         {{- if typeIs "bool" .Values.gdsEnabled }}
           - name: GDS_ENABLED
             value: {{ .Values.gdsEnabled | quote }}

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -150,3 +150,9 @@ mps:
   # directories.
   # Pipe directories will be created at {{ mps.root }}/{{ .ResourceName }}
   root: "/run/nvidia/mps"
+
+
+cdi:
+  # nvidiaHookPath specifies the path to the nvidia-cdi-hook or nvidia-ctk executables on the host.
+  # This is required to ensure that the generated CDI specification refers to the correct CDI hooks.
+  nvidiaHookPath: null

--- a/internal/cdi/cdi.go
+++ b/internal/cdi/cdi.go
@@ -45,6 +45,7 @@ type cdiHandler struct {
 
 	logger           *logrus.Logger
 	driverRoot       string
+	devRoot          string
 	targetDriverRoot string
 	nvidiaCTKPath    string
 	vendor           string
@@ -83,11 +84,11 @@ func New(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interf
 	if c.logger == nil {
 		c.logger = logrus.StandardLogger()
 	}
-	if c.deviceIDStrategy == "" {
-		c.deviceIDStrategy = "uuid"
-	}
 	if c.driverRoot == "" {
 		c.driverRoot = "/"
+	}
+	if c.deviceIDStrategy == "" {
+		c.deviceIDStrategy = "uuid"
 	}
 	if c.targetDriverRoot == "" {
 		c.targetDriverRoot = c.driverRoot
@@ -107,6 +108,7 @@ func New(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interf
 		nvcdi.WithLogger(c.logger),
 		nvcdi.WithNVIDIACDIHookPath(c.nvidiaCTKPath),
 		nvcdi.WithDriverRoot(c.driverRoot),
+		nvcdi.WithDevRoot(c.devRoot),
 		nvcdi.WithDeviceNamers(deviceNamer),
 		nvcdi.WithVendor(c.vendor),
 		nvcdi.WithClass("gpu"),
@@ -129,6 +131,7 @@ func New(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interf
 			nvcdi.WithLogger(c.logger),
 			nvcdi.WithNVIDIACDIHookPath(c.nvidiaCTKPath),
 			nvcdi.WithDriverRoot(c.driverRoot),
+			nvcdi.WithDevRoot(c.devRoot),
 			nvcdi.WithVendor(c.vendor),
 			nvcdi.WithMode(mode),
 		)

--- a/internal/cdi/cdi.go
+++ b/internal/cdi/cdi.go
@@ -75,7 +75,7 @@ func New(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interf
 		opt(c)
 	}
 
-	if !c.deviceListStrategies.IsCDIEnabled() {
+	if !c.deviceListStrategies.AnyCDIEnabled() {
 		return &null{}, nil
 	}
 	hasNVML, _ := infolib.HasNvml()
@@ -87,11 +87,14 @@ func New(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interf
 	if c.logger == nil {
 		c.logger = logrus.StandardLogger()
 	}
+	if c.deviceIDStrategy == "" {
+		c.deviceIDStrategy = "uuid"
+	}
 	if c.driverRoot == "" {
 		c.driverRoot = "/"
 	}
-	if c.deviceIDStrategy == "" {
-		c.deviceIDStrategy = "uuid"
+	if c.devRoot == "" {
+		c.devRoot = c.driverRoot
 	}
 	if c.targetDriverRoot == "" {
 		c.targetDriverRoot = c.driverRoot

--- a/internal/cdi/cdi.go
+++ b/internal/cdi/cdi.go
@@ -19,11 +19,13 @@ package cdi
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi"
+	"github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/transform"
 	transformroot "github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/transform/root"
 	"github.com/sirupsen/logrus"
 	"k8s.io/klog/v2"
@@ -47,6 +49,7 @@ type cdiHandler struct {
 	driverRoot       string
 	devRoot          string
 	targetDriverRoot string
+	targetDevRoot    string
 	nvidiaCTKPath    string
 	vendor           string
 	deviceIDStrategy string
@@ -92,6 +95,9 @@ func New(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interf
 	}
 	if c.targetDriverRoot == "" {
 		c.targetDriverRoot = c.driverRoot
+	}
+	if c.targetDevRoot == "" {
+		c.targetDevRoot = c.devRoot
 	}
 
 	deviceNamer, err := nvcdi.NewDeviceNamer(c.deviceIDStrategy)
@@ -164,12 +170,9 @@ func (cdi *cdiHandler) CreateSpecFile() error {
 			return fmt.Errorf("failed to get CDI spec: %v", err)
 		}
 
-		err = transformroot.New(
-			transformroot.WithRoot(cdi.driverRoot),
-			transformroot.WithTargetRoot(cdi.targetDriverRoot),
-			transformroot.WithRelativeTo("host"),
-		).Transform(spec.Raw())
-		if err != nil {
+		// TODO: Once the NewDriverTransformer is merged in container-toolkit we can instantiate it directly.
+		transformer := cdi.getRootTransformer()
+		if err := transformer.Transform(spec.Raw()); err != nil {
 			return fmt.Errorf("failed to transform driver root in CDI spec: %v", err)
 		}
 
@@ -185,6 +188,30 @@ func (cdi *cdiHandler) CreateSpecFile() error {
 	}
 
 	return nil
+}
+
+func (cdi *cdiHandler) getRootTransformer() transform.Transformer {
+	driverRootTransformer := transformroot.New(
+		transformroot.WithRoot(cdi.driverRoot),
+		transformroot.WithTargetRoot(cdi.targetDriverRoot),
+		transformroot.WithRelativeTo("host"),
+	)
+
+	if cdi.devRoot == cdi.driverRoot || cdi.devRoot == "" {
+		return driverRootTransformer
+	}
+
+	ensureDev := func(p string) string {
+		return filepath.Join(strings.TrimSuffix(filepath.Clean(p), "/dev"), "/dev")
+	}
+
+	devRootTransformer := transformroot.New(
+		transformroot.WithRoot(ensureDev(cdi.devRoot)),
+		transformroot.WithTargetRoot(ensureDev(cdi.targetDevRoot)),
+		transformroot.WithRelativeTo("host"),
+	)
+
+	return transform.Merge(driverRootTransformer, devRootTransformer)
 }
 
 // QualifiedName constructs a CDI qualified device name for the specified resources.

--- a/internal/cdi/options.go
+++ b/internal/cdi/options.go
@@ -44,10 +44,17 @@ func WithDevRoot(root string) Option {
 	}
 }
 
-// WithTargetDriverRoot provides an Option to set the target driver root used by the 'cdi' interface
+// WithTargetDriverRoot provides an Option to set the target (host) driver root used by the 'cdi' interface
 func WithTargetDriverRoot(root string) Option {
 	return func(c *cdiHandler) {
 		c.targetDriverRoot = root
+	}
+}
+
+// WithTargetDevRoot provides an Option to set the target (host) dev root used by the 'cdi' interface
+func WithTargetDevRoot(root string) Option {
+	return func(c *cdiHandler) {
+		c.targetDevRoot = root
 	}
 }
 

--- a/internal/cdi/options.go
+++ b/internal/cdi/options.go
@@ -30,10 +30,17 @@ func WithDeviceListStrategies(deviceListStrategies spec.DeviceListStrategies) Op
 	}
 }
 
-// WithDriverRoot provides an Option to set the driver root used by the 'cdi' interface
+// WithDriverRoot provides an Option to set the driver root used by the 'cdi' interface.
 func WithDriverRoot(root string) Option {
 	return func(c *cdiHandler) {
 		c.driverRoot = root
+	}
+}
+
+// WithDevRoot sets the dev root for the `cdi` interface.
+func WithDevRoot(root string) Option {
+	return func(c *cdiHandler) {
+		c.devRoot = root
 	}
 }
 

--- a/internal/plugin/server.go
+++ b/internal/plugin/server.go
@@ -355,7 +355,7 @@ func (plugin *NvidiaDevicePlugin) getAllocateResponse(requestIds []string) (*plu
 		plugin.updateResponseForMPS(response)
 	}
 	if *plugin.config.Flags.Plugin.PassDeviceSpecs {
-		response.Devices = append(response.Devices, plugin.apiDeviceSpecs(*plugin.config.Flags.NvidiaDriverRoot, requestIds)...)
+		response.Devices = append(response.Devices, plugin.apiDeviceSpecs(*plugin.config.Flags.NvidiaDevRoot, requestIds)...)
 	}
 	if *plugin.config.Flags.GDSEnabled {
 		response.Envs["NVIDIA_GDS"] = "enabled"
@@ -500,7 +500,7 @@ func (plugin *NvidiaDevicePlugin) updateResponseForDeviceMounts(response *plugin
 	}
 }
 
-func (plugin *NvidiaDevicePlugin) apiDeviceSpecs(driverRoot string, ids []string) []*pluginapi.DeviceSpec {
+func (plugin *NvidiaDevicePlugin) apiDeviceSpecs(devRoot string, ids []string) []*pluginapi.DeviceSpec {
 	optional := map[string]bool{
 		"/dev/nvidiactl":        true,
 		"/dev/nvidia-uvm":       true,
@@ -519,7 +519,7 @@ func (plugin *NvidiaDevicePlugin) apiDeviceSpecs(driverRoot string, ids []string
 		}
 		spec := &pluginapi.DeviceSpec{
 			ContainerPath: p,
-			HostPath:      filepath.Join(driverRoot, p),
+			HostPath:      filepath.Join(devRoot, p),
 			Permissions:   "rw",
 		}
 		specs = append(specs, spec)


### PR DESCRIPTION
Thes changes add support to the NVIDIA GPU Device Plugin for driver
installations that have the following properties:
* driver files are installed at a `hostDriverRoot`, say: `/host/nvidia/driver`
* device nodes are created at `/dev`

In addition to the mounts of driver libraries (e.g. `libnvidia-ml.so.VERSION`)
and device nodes that are handled by the NVIDIA Container Runtime or CDI to
allow the device plugin to detect and enumerate devices, the `hostDriverRoot`
is mounted into the device plugin at `/driver-root`. This allows the detection
of driver files that are not required for the device plugin to fuction, but may
be required by specific workloads.

From the perspective of the CDI spec generation being run in the device plugin
container, all driver files are rooted at `/driver-root`. Furthermore, since
no device nodes are detected at `/driver-root/dev` we assume that these are
at `/dev` in the container (and on the host). The generated CDI specifications
need to be transformed so that they are valid for container workloads started
on the host. This means that occurrences of `/driver-root` need to be
transformed to `hostDriverRoot` or `/host/nvidia/driver` as per our example.