### PR TITLE
Don't require node-name to be set if not needed

### DIFF
--- a/cmd/gpu-feature-discovery/main.go
+++ b/cmd/gpu-feature-discovery/main.go
@@ -167,17 +167,21 @@ func start(c *cli.Context, cfg *Config) error {
 			clientSets = cs
 		}
 
+		labelOutputer, err := lm.NewOutputer(
+			config,
+			cfg.nodeConfig,
+			clientSets,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create label outputer: %w", err)
+		}
+
 		klog.Info("Start running")
 		d := &gfd{
-			manager: manager,
-			vgpu:    vgpul,
-			config:  config,
-
-			labelOutputer: lm.NewOutputer(
-				config,
-				cfg.nodeConfig,
-				clientSets,
-			),
+			manager:       manager,
+			vgpu:          vgpul,
+			config:        config,
+			labelOutputer: labelOutputer,
 		}
 		restart, err := d.run(sigs)
 		if err != nil {

--- a/cmd/gpu-feature-discovery/main_test.go
+++ b/cmd/gpu-feature-discovery/main_test.go
@@ -114,11 +114,14 @@ func TestRunOneshot(t *testing.T) {
 	setupMachineFile(t)
 	defer removeMachineFile(t)
 
+	labelOutputer, err := lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{})
+	require.NoError(t, err)
+
 	d := gfd{
 		manager:       nvmlMock,
 		vgpu:          vgpuMock,
 		config:        conf,
-		labelOutputer: lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{}),
+		labelOutputer: labelOutputer,
 	}
 	restart, err := d.run(nil)
 	require.NoError(t, err, "Error from run function")
@@ -166,11 +169,14 @@ func TestRunWithNoTimestamp(t *testing.T) {
 	setupMachineFile(t)
 	defer removeMachineFile(t)
 
+	labelOutputer, err := lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{})
+	require.NoError(t, err)
+
 	d := gfd{
 		manager:       nvmlMock,
 		vgpu:          vgpuMock,
 		config:        conf,
-		labelOutputer: lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{}),
+		labelOutputer: labelOutputer,
 	}
 	restart, err := d.run(nil)
 	require.NoError(t, err, "Error from run function")
@@ -230,11 +236,14 @@ func TestRunSleep(t *testing.T) {
 	var runRestart bool
 	var runError error
 	go func() {
+		labelOutputer, err := lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{})
+		require.NoError(t, err)
+
 		d := gfd{
 			manager:       nvmlMock,
 			vgpu:          vgpuMock,
 			config:        conf,
-			labelOutputer: lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{}),
+			labelOutputer: labelOutputer,
 		}
 		runRestart, runError = d.run(sigs)
 	}()
@@ -390,11 +399,14 @@ func TestFailOnNVMLInitError(t *testing.T) {
 
 			nvmlMock := rt.NewManagerMockWithDevices(rt.NewFullGPU()).WithErrorOnInit(tc.errorOnInit)
 
+			labelOutputer, err := lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{})
+			require.NoError(t, err)
+
 			d := gfd{
 				manager:       resource.WithConfig(nvmlMock, conf),
 				vgpu:          vgpuMock,
 				config:        conf,
-				labelOutputer: lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{}),
+				labelOutputer: labelOutputer,
 			}
 			restart, err := d.run(nil)
 			if tc.expectError {

--- a/cmd/gpu-feature-discovery/mig_test.go
+++ b/cmd/gpu-feature-discovery/mig_test.go
@@ -47,11 +47,14 @@ func TestMigStrategyNone(t *testing.T) {
 	setupMachineFile(t)
 	defer removeMachineFile(t)
 
+	labelOutputer, err := lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{})
+	require.NoError(t, err)
+
 	d := gfd{
 		manager:       nvmlMock,
 		vgpu:          vgpuMock,
 		config:        conf,
-		labelOutputer: lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{}),
+		labelOutputer: labelOutputer,
 	}
 	restart, err := d.run(nil)
 	require.NoError(t, err, "Error from run function")
@@ -105,11 +108,14 @@ func TestMigStrategySingleForNoMigDevices(t *testing.T) {
 	setupMachineFile(t)
 	defer removeMachineFile(t)
 
+	labelOutputer, err := lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{})
+	require.NoError(t, err)
+
 	d := gfd{
 		manager:       nvmlMock,
 		vgpu:          vgpuMock,
 		config:        conf,
-		labelOutputer: lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{}),
+		labelOutputer: labelOutputer,
 	}
 	restart, err := d.run(nil)
 	require.NoError(t, err, "Error from run function")
@@ -170,11 +176,14 @@ func TestMigStrategySingleForMigDeviceMigDisabled(t *testing.T) {
 	setupMachineFile(t)
 	defer removeMachineFile(t)
 
+	labelOutputer, err := lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{})
+	require.NoError(t, err)
+
 	d := gfd{
 		manager:       nvmlMock,
 		vgpu:          vgpuMock,
 		config:        conf,
-		labelOutputer: lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{}),
+		labelOutputer: labelOutputer,
 	}
 	restart, err := d.run(nil)
 	require.NoError(t, err, "Error from run function")
@@ -235,11 +244,14 @@ func TestMigStrategySingle(t *testing.T) {
 	setupMachineFile(t)
 	defer removeMachineFile(t)
 
+	labelOutputer, err := lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{})
+	require.NoError(t, err)
+
 	d := gfd{
 		manager:       nvmlMock,
 		vgpu:          vgpuMock,
 		config:        conf,
-		labelOutputer: lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{}),
+		labelOutputer: labelOutputer,
 	}
 	restart, err := d.run(nil)
 	require.NoError(t, err, "Error from run function")
@@ -301,11 +313,14 @@ func TestMigStrategyMixed(t *testing.T) {
 	setupMachineFile(t)
 	defer removeMachineFile(t)
 
+	labelOutputer, err := lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{})
+	require.NoError(t, err)
+
 	d := gfd{
 		manager:       nvmlMock,
 		vgpu:          vgpuMock,
 		config:        conf,
-		labelOutputer: lm.NewOutputer(conf, flags.NodeConfig{}, flags.ClientSets{}),
+		labelOutputer: labelOutputer,
 	}
 	restart, err := d.run(nil)
 	require.NoError(t, err, "Error from run function")

--- a/internal/flags/node.go
+++ b/internal/flags/node.go
@@ -38,7 +38,6 @@ func (n *NodeConfig) Flags() []cli.Flag {
 		&cli.StringFlag{
 			Name:        "node-name",
 			Usage:       "The name of the node to be worked on.",
-			Required:    true,
 			Destination: &n.Name,
 			EnvVars:     []string{"NODE_NAME"},
 		},

--- a/internal/lm/output.go
+++ b/internal/lm/output.go
@@ -42,15 +42,22 @@ type Outputer interface {
 }
 
 // TODO: Replace this with functional options.
-func NewOutputer(config *spec.Config, nodeConfig flags.NodeConfig, clientSets flags.ClientSets) Outputer {
+func NewOutputer(config *spec.Config, nodeConfig flags.NodeConfig, clientSets flags.ClientSets) (Outputer, error) {
 	if config.Flags.UseNodeFeatureAPI == nil || !*config.Flags.UseNodeFeatureAPI {
-		return ToFile(*config.Flags.GFD.OutputFile)
+		return ToFile(*config.Flags.GFD.OutputFile), nil
 	}
 
-	return &nodeFeatureObject{
+	if nodeConfig.Name == "" {
+		return nil, fmt.Errorf("required flag node-name not set")
+	}
+	if nodeConfig.Namespace == "" {
+		return nil, fmt.Errorf("required flag namespace not set")
+	}
+	o := nodeFeatureObject{
 		nodeConfig:   nodeConfig,
 		nfdClientset: clientSets.NFD,
 	}
+	return &o, nil
 }
 
 func ToFile(path string) Outputer {


### PR DESCRIPTION
The `node-name` is only needed if the NodeFeatureAPI is used.