### PR TITLE
Fixing allPossibleMigStrategiesAreNone helm chart helper.

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/_helpers.tpl
+++ b/deployments/helm/nvidia-device-plugin/templates/_helpers.tpl
@@ -130,7 +130,7 @@ Check if migStrategy (from all possible configurations) is "none"
   {{- if ne .Values.migStrategy "none" -}}
     {{- $result = false -}}
   {{- end -}}
-{{- else if ne (include "nvidia-device-plugin.configMapName" .) "true" -}}
+{{- else if eq (include "nvidia-device-plugin.hasConfigMap" .) "true" -}}
     {{- $result = false -}}
 {{- else -}}
   {{- range $name, $contents := $.Values.config.map -}}

--- a/deployments/helm/nvidia-device-plugin/templates/_helpers.tpl
+++ b/deployments/helm/nvidia-device-plugin/templates/_helpers.tpl
@@ -227,5 +227,6 @@ We convert this to JSON so that it can be included and converted to an object us
 {{- define "nvidia-device-plugin.options" -}}
 {{- $options := dict "" "" -}}
 {{- $_ := set $options "hasConfigMap" ( eq ( (include "nvidia-device-plugin.hasConfigMap" . ) | trim ) "true" ) -}}
+{{- $_ := set $options "addMigMonitorDevices" ( ne ( (include "nvidia-device-plugin.allPossibleMigStrategiesAreNone" . ) | trim ) "true" )  -}}
 {{- mustToJson $options -}}
 {{- end -}}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -17,7 +17,6 @@
 {{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
 {{- $useServiceAccount := $options.hasConfigMap }}
 {{- $configMapName := (include "nvidia-device-plugin.configMapName" .) | trim }}
-{{- $migStrategiesAreAllNone := (include "nvidia-device-plugin.allPossibleMigStrategiesAreNone" .) | trim }}
 {{- $daemonsetName := printf "%s" (include "nvidia-device-plugin.fullname" .) | trunc 63 | trimSuffix "-" }}
 apiVersion: apps/v1
 kind: DaemonSet
@@ -174,7 +173,7 @@ spec:
           - name: CONFIG_FILE
             value: /config/config.yaml
         {{- end }}
-        {{- if ne $migStrategiesAreAllNone "true" }}
+        {{- if $options.addMigMonitorDevices }}
           - name: NVIDIA_MIG_MONITOR_DEVICES
             value: all
         {{- end }}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
@@ -17,7 +17,6 @@
 {{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
 {{- $useServiceAccount := or ( $options.hasConfigMap ) ( and .Values.gfd.enabled .Values.nfd.enableNodeFeatureApi ) }}
 {{- $configMapName := (include "nvidia-device-plugin.configMapName" .) | trim }}
-{{- $migStrategiesAreAllNone := (include "nvidia-device-plugin.allPossibleMigStrategiesAreNone" .) | trim }}
 {{- $daemonsetName := printf "%s-gpu-feature-discovery" (include "nvidia-device-plugin.fullname" .) | trunc 63 | trimSuffix "-" }}
 apiVersion: apps/v1
 kind: DaemonSet
@@ -168,7 +167,7 @@ spec:
           - name: CONFIG_FILE
             value: /config/config.yaml
         {{- end }}
-        {{- if ne $migStrategiesAreAllNone "true" }}
+        {{- if $options.addMigMonitorDevices }}
           - name: NVIDIA_MIG_MONITOR_DEVICES
             value: all
         {{- end }}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -15,7 +15,6 @@
 ---
 {{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
 {{- $configMapName := (include "nvidia-device-plugin.configMapName" .) | trim }}
-{{- $migStrategiesAreAllNone := (include "nvidia-device-plugin.allPossibleMigStrategiesAreNone" .) | trim }}
 {{- $daemonsetName := printf "%s-mps-control-daemon" (include "nvidia-device-plugin.fullname" .) | trunc 63 | trimSuffix "-" }}
 apiVersion: apps/v1
 kind: DaemonSet
@@ -159,7 +158,7 @@ spec:
           - name: CONFIG_FILE
             value: /config/config.yaml
         {{- end }}
-        {{- if ne $migStrategiesAreAllNone "true" }}
+        {{- if $options.addMigMonitorDevices }}
           - name: NVIDIA_MIG_MONITOR_DEVICES
             value: all
         {{- end }}


### PR DESCRIPTION
`configMapName` is the empty string `""` by default and it breaks `allPossibleMigStrategiesAreNone` function with default values.

See https://github.com/NVIDIA/k8s-device-plugin/issues/670 for details.