### PR TITLE
Allow /dev/shm size to be specified

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -61,6 +61,11 @@ spec:
         command: [mps-control-daemon, mount-shm]
         securityContext:
           privileged: true
+        env:
+        {{- if typeIs "string" .Values.mps.devShmSize }}
+        - name: MPS_DEV_SHM_SIZE
+          value: {{ .Values.mps.devShmSize }}
+        {{- end }}
         volumeMounts:
         - name: mps-root
           mountPath: /mps

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -150,3 +150,9 @@ mps:
   # directories.
   # Pipe directories will be created at {{ mps.root }}/{{ .ResourceName }}
   root: "/run/nvidia/mps"
+  # devShmSize specifies the size in bytes of the tmpfs created for the MPS
+  # control daemon.
+  # The format should match that of the size argument (excluding the size=)
+  # prefix when mounting a tmpfs:
+  #    See https://man7.org/linux/man-pages/man5/tmpfs.5.html
+  devShmSize: null


### PR DESCRIPTION
This change allows the size of the /dev/shm created for MPS to be specified as part of the helm deployment.