### PR TITLE
Align container driver root envvars

### DIFF
--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -115,10 +115,11 @@ func main() {
 			EnvVars: []string{"NVIDIA_CTK_PATH"},
 		},
 		&cli.StringFlag{
-			Name:    "container-driver-root",
+			Name:    "driver-root-ctr-path",
+			Aliases: []string{"container-driver-root"},
 			Value:   spec.DefaultContainerDriverRoot,
 			Usage:   "the path where the NVIDIA driver root is mounted in the container; used for generating CDI specifications",
-			EnvVars: []string{"CONTAINER_DRIVER_ROOT"},
+			EnvVars: []string{"DRIVER_ROOT_CTR_PATH", "CONTAINER_DRIVER_ROOT"},
 		},
 		&cli.StringFlag{
 			Name:    "mps-root",


### PR DESCRIPTION
This change aligns the container driver root envar with those used by the Container Toolkit (DRIVER_ROOT_CTR_PATH).

The command line argument is also changed to match the value used there.