### PR TITLE
Allow device-discovery-strategy to be specified

### DIFF
--- a/api/config/v1/flags.go
+++ b/api/config/v1/flags.go
@@ -55,16 +55,16 @@ type Flags struct {
 
 // CommandLineFlags holds the list of command line flags used to configure the device plugin and GFD.
 type CommandLineFlags struct {
-	MigStrategy       *string                 `json:"migStrategy"                yaml:"migStrategy"`
-	FailOnInitError   *bool                   `json:"failOnInitError"            yaml:"failOnInitError"`
-	MpsRoot           *string                 `json:"mpsRoot,omitempty"          yaml:"mpsRoot,omitempty"`
-	NvidiaDriverRoot  *string                 `json:"nvidiaDriverRoot,omitempty" yaml:"nvidiaDriverRoot,omitempty"`
-	GDSEnabled        *bool                   `json:"gdsEnabled"                 yaml:"gdsEnabled"`
-	MOFEDEnabled      *bool                   `json:"mofedEnabled"               yaml:"mofedEnabled"`
-	UseNodeFeatureAPI *bool                   `json:"useNodeFeatureAPI"          yaml:"useNodeFeatureAPI"`
-	Mode              *string                 `json:"mode"                       yaml:"mode"`
-	Plugin            *PluginCommandLineFlags `json:"plugin,omitempty"           yaml:"plugin,omitempty"`
-	GFD               *GFDCommandLineFlags    `json:"gfd,omitempty"              yaml:"gfd,omitempty"`
+	MigStrategy             *string                 `json:"migStrategy"                yaml:"migStrategy"`
+	FailOnInitError         *bool                   `json:"failOnInitError"            yaml:"failOnInitError"`
+	MpsRoot                 *string                 `json:"mpsRoot,omitempty"          yaml:"mpsRoot,omitempty"`
+	NvidiaDriverRoot        *string                 `json:"nvidiaDriverRoot,omitempty" yaml:"nvidiaDriverRoot,omitempty"`
+	GDSEnabled              *bool                   `json:"gdsEnabled"                 yaml:"gdsEnabled"`
+	MOFEDEnabled            *bool                   `json:"mofedEnabled"               yaml:"mofedEnabled"`
+	UseNodeFeatureAPI       *bool                   `json:"useNodeFeatureAPI"          yaml:"useNodeFeatureAPI"`
+	DeviceDiscoveryStrategy *string                 `json:"deviceDiscoveryStrategy"    yaml:"deviceDiscoveryStrategy"`
+	Plugin                  *PluginCommandLineFlags `json:"plugin,omitempty"           yaml:"plugin,omitempty"`
+	GFD                     *GFDCommandLineFlags    `json:"gfd,omitempty"              yaml:"gfd,omitempty"`
 }
 
 // PluginCommandLineFlags holds the list of command line flags specific to the device plugin.
@@ -129,8 +129,8 @@ func (f *Flags) UpdateFromCLIFlags(c *cli.Context, flags []cli.Flag) {
 				updateFromCLIFlag(&f.MOFEDEnabled, c, n)
 			case "use-node-feature-api":
 				updateFromCLIFlag(&f.UseNodeFeatureAPI, c, n)
-			case "mode":
-				updateFromCLIFlag(&f.Mode, c, n)
+			case "device-discovery-strategy":
+				updateFromCLIFlag(&f.DeviceDiscoveryStrategy, c, n)
 			}
 			// Plugin specific flags
 			if f.Plugin == nil {

--- a/api/config/v1/flags_test.go
+++ b/api/config/v1/flags_test.go
@@ -163,7 +163,7 @@ func TestMarshalFlags(t *testing.T) {
 				"gdsEnabled": null,
 				"mofedEnabled": null,
 				"useNodeFeatureAPI": null,
-				"mode": null
+				"deviceDiscoveryStrategy": null
 			}`,
 		},
 		{
@@ -180,7 +180,7 @@ func TestMarshalFlags(t *testing.T) {
 				"gdsEnabled": null,
 				"mofedEnabled": null,
 				"useNodeFeatureAPI": null,
-				"mode": null,
+				"deviceDiscoveryStrategy": null,
 				"gfd": {
 					"oneshot": null,
 					"noTimestamp": null,
@@ -204,7 +204,7 @@ func TestMarshalFlags(t *testing.T) {
 				"gdsEnabled": null,
 				"mofedEnabled": null,
 				"useNodeFeatureAPI": null,
-				"mode": null,
+				"deviceDiscoveryStrategy": null,
 				"gfd": {
 					"oneshot": null,
 					"noTimestamp": null,

--- a/cmd/gpu-feature-discovery/main.go
+++ b/cmd/gpu-feature-discovery/main.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"syscall"
 	"time"
 
@@ -104,11 +103,11 @@ func main() {
 			Usage:   "Use NFD NodeFeature API to publish labels",
 			EnvVars: []string{"GFD_USE_NODE_FEATURE_API", "USE_NODE_FEATURE_API"},
 		},
-		&cli.StringFlag{
-			Name:    "mode",
-			Value:   "auto",
-			Usage:   "Select GFD mode between 'auto','nvml','tegra' or 'vfio'",
-			EnvVars: []string{"MODE", "GFD_MODE"},
+		&cli.StringSliceFlag{
+			Name:    "device-discovery-strategy",
+			Value:   cli.NewStringSlice("auto"),
+			Usage:   "the strategy to use to discover devices: 'auto', 'nvml', 'tegra' or 'vfio'",
+			EnvVars: []string{"DEVICE_DISCOVERY_STRATEGY"},
 		},
 	}
 
@@ -124,9 +123,13 @@ func main() {
 }
 
 func validateFlags(config *spec.Config) error {
-	validModes := []string{"auto", "nvml", "tegra", "vfio"}
-	if !slices.Contains(validModes, *config.Flags.Mode) {
-		return fmt.Errorf("%s invalid mode option must be 'auto','nvml','tegra' or 'vfio'", *config.Flags.Mode)
+	switch *config.Flags.DeviceDiscoveryStrategy {
+	case "auto":
+	case "nvml":
+	case "tegra":
+	case "vfio":
+	default:
+		return fmt.Errorf("invalid --device-discovery-strategy option %v", *config.Flags.DeviceDiscoveryStrategy)
 	}
 	return nil
 }

--- a/cmd/gpu-feature-discovery/main_test.go
+++ b/cmd/gpu-feature-discovery/main_test.go
@@ -212,9 +212,9 @@ func TestRunSleep(t *testing.T) {
 	conf := &spec.Config{
 		Flags: spec.Flags{
 			CommandLineFlags: spec.CommandLineFlags{
-				MigStrategy:     ptr("none"),
-				FailOnInitError: ptr(true),
-				Mode:            ptr("auto"),
+				MigStrategy:             ptr("none"),
+				FailOnInitError:         ptr(true),
+				DeviceDiscoveryStrategy: ptr("auto"),
 				GFD: &spec.GFDCommandLineFlags{
 					Oneshot:         ptr(false),
 					OutputFile:      ptr("./gfd-test-loop"),

--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -128,6 +128,12 @@ func main() {
 			Usage:   "the path on the host where MPS-specific mounts and files are created by the MPS control daemon manager",
 			EnvVars: []string{"MPS_ROOT"},
 		},
+		&cli.StringFlag{
+			Name:    "device-discovery-strategy",
+			Value:   "auto",
+			Usage:   "the strategy to use to discover devices: 'auto', 'nvml', or 'tegra'",
+			EnvVars: []string{"DEVICE_DISCOVERY_STRATEGY"},
+		},
 	}
 
 	err := c.Run(os.Args)
@@ -159,6 +165,14 @@ func validateFlags(infolib nvinfo.Interface, config *spec.Config) error {
 		if config.Flags.MpsRoot == nil || *config.Flags.MpsRoot == "" {
 			return fmt.Errorf("using MPS requires --mps-root to be specified")
 		}
+	}
+
+	switch *config.Flags.DeviceDiscoveryStrategy {
+	case "auto":
+	case "nvml":
+	case "tegra":
+	default:
+		return fmt.Errorf("invalid --device-discovery-strategy option %v", *config.Flags.DeviceDiscoveryStrategy)
 	}
 
 	return nil

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -177,6 +177,12 @@ spec:
           - name: NVIDIA_MIG_MONITOR_DEVICES
             value: all
         {{- end }}
+        {{- if typeIs "string" .Values.deviceDiscoveryStrategy }}
+          - name: DEVICE_DISCOVERY_STRATEGY
+            value: {{ .Values.deviceDiscoveryStrategy }}
+        {{- end }}
+          - name: DEVICE_PLUGIN_MODE
+            value: "{{ .Values.devicePlugin.mode }}"
           - name: NVIDIA_VISIBLE_DEVICES
             value: all
           - name: NVIDIA_DRIVER_CAPABILITIES

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
@@ -171,8 +171,10 @@ spec:
           - name: NVIDIA_MIG_MONITOR_DEVICES
             value: all
         {{- end }}
-          - name: GFD_MODE
-            value: "{{ .Values.gfdMode }}"
+        {{- if typeIs "string" .Values.deviceDiscoveryStrategy }}
+          - name: DEVICE_DISCOVERY_STRATEGY
+            value: {{ .Values.deviceDiscoveryStrategy }}
+        {{- end }}
         securityContext:
           {{- include "gpu-feature-discovery.securityContext" . | nindent 10 }}
         volumeMounts:

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -35,7 +35,7 @@ deviceIDStrategy: null
 nvidiaDriverRoot: null
 gdsEnabled: null
 mofedEnabled: null
-gfdMode: "auto"
+deviceDiscoveryStrategy: null
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
This change adds a device-discovery-strategy flag to the device plugin (as was done for GFD in #676). This allows the platform detection to be overridden using the corresponding `devicePlugin.mode` helm value or `DEVICE_DISCOVERY_STRATEGY` envvar.

The default of "auto" follows the previous behaviour.

Depends on #730 