### PR TITLE
Raise error in GFD when MPS sharing is enabled for MIG devices

### DIFF
--- a/internal/lm/nvml_test.go
+++ b/internal/lm/nvml_test.go
@@ -84,6 +84,7 @@ func TestSharingLabeler(t *testing.T) {
 		manager        resource.Manager
 		config         *spec.Config
 		expectedLabels map[string]string
+		expectedError  error
 	}{
 		{
 			description: "nil config",
@@ -186,15 +187,20 @@ func TestSharingLabeler(t *testing.T) {
 					},
 				},
 			},
-			expectedLabels: map[string]string{
-				"nvidia.com/mps.capable": "false",
-			},
+			expectedError:  errMPSSharingNotSupported,
+			expectedLabels: nil,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			require.EqualValues(t, tc.expectedLabels, newSharingLabeler(tc.manager, tc.config))
+			labels, err := newSharingLabeler(tc.manager, tc.config)
+			require.ErrorIs(t, err, tc.expectedError)
+			if tc.expectedError != nil {
+				require.Nil(t, labels)
+			} else {
+				require.EqualValues(t, tc.expectedLabels, labels)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This change raises an error in GFD if MPS sharing is enabled for MIG devices instead of (siliently) setting `nvidia.com/mps.capable=false`.

This aligns GFD behaviour with that of the device plugin.