### PR TITLE
Make construction of infolib, nvmllib, and devicelib explicit

### DIFF
--- a/cmd/mps-control-daemon/mps/device.go
+++ b/cmd/mps-control-daemon/mps/device.go
@@ -28,11 +28,11 @@ import (
 
 var errInvalidDevice = errors.New("invalid device")
 
-// device represents an MPS-specific alias for an rm.Device.
-type device rm.Device
+// mpsDevice represents an MPS-specific alias for an rm.Device.
+type mpsDevice rm.Device
 
 // assertReplicas checks whether the number of replicas specified is valid.
-func (d *device) assertReplicas() error {
+func (d *mpsDevice) assertReplicas() error {
 	maxClients := d.maxClients()
 	if d.Replicas > maxClients {
 		return fmt.Errorf("%w maximum allowed replicas exceeded: %d > %d", errInvalidDevice, d.Replicas, maxClients)
@@ -41,7 +41,7 @@ func (d *device) assertReplicas() error {
 }
 
 // maxClients returns the maximum number of clients supported by an MPS server.
-func (d *device) maxClients() int {
+func (d *mpsDevice) maxClients() int {
 	if d.isAtLeastVolta() {
 		return 48
 	}
@@ -49,7 +49,7 @@ func (d *device) maxClients() int {
 }
 
 // isAtLeastVolta checks whether the specified device is a volta device or newer.
-func (d *device) isAtLeastVolta() bool {
+func (d *mpsDevice) isAtLeastVolta() bool {
 	vCc := "v" + strings.TrimPrefix(d.ComputeCapability, "v")
 	return semver.Compare(semver.Canonical(vCc), semver.Canonical("v7.5")) >= 0
 }

--- a/cmd/mps-control-daemon/mps/device_test.go
+++ b/cmd/mps-control-daemon/mps/device_test.go
@@ -25,14 +25,14 @@ import (
 func TestDevice(t *testing.T) {
 	testCases := []struct {
 		description            string
-		input                  device
+		input                  mpsDevice
 		expectedIsAtLeastVolta bool
 		expectedMaxClients     int
 		expectedAssertReplicas error
 	}{
 		{
 			description: "leading v ignored",
-			input: device{
+			input: mpsDevice{
 				ComputeCapability: "v7.5",
 			},
 			expectedIsAtLeastVolta: true,
@@ -40,7 +40,7 @@ func TestDevice(t *testing.T) {
 		},
 		{
 			description: "no-leading v supported",
-			input: device{
+			input: mpsDevice{
 				ComputeCapability: "7.5",
 			},
 			expectedIsAtLeastVolta: true,
@@ -48,7 +48,7 @@ func TestDevice(t *testing.T) {
 		},
 		{
 			description: "pre-volta clients",
-			input: device{
+			input: mpsDevice{
 				ComputeCapability: "7.0",
 			},
 			expectedIsAtLeastVolta: false,
@@ -56,7 +56,7 @@ func TestDevice(t *testing.T) {
 		},
 		{
 			description: "post-volta clients",
-			input: device{
+			input: mpsDevice{
 				ComputeCapability: "9.0",
 			},
 			expectedIsAtLeastVolta: true,
@@ -64,7 +64,7 @@ func TestDevice(t *testing.T) {
 		},
 		{
 			description: "pre-volta clients exceeded",
-			input: device{
+			input: mpsDevice{
 				ComputeCapability: "7.0",
 				Replicas:          29,
 			},
@@ -74,7 +74,7 @@ func TestDevice(t *testing.T) {
 		},
 		{
 			description: "post-volta clients exceeded",
-			input: device{
+			input: mpsDevice{
 				ComputeCapability: "9.0",
 				Replicas:          49,
 			},
@@ -84,7 +84,7 @@ func TestDevice(t *testing.T) {
 		},
 		{
 			description: "pre-volta clients max",
-			input: device{
+			input: mpsDevice{
 				ComputeCapability: "7.0",
 				Replicas:          16,
 			},
@@ -93,7 +93,7 @@ func TestDevice(t *testing.T) {
 		},
 		{
 			description: "post-volta clients max",
-			input: device{
+			input: mpsDevice{
 				ComputeCapability: "9.0",
 				Replicas:          48,
 			},

--- a/cmd/mps-control-daemon/mps/options.go
+++ b/cmd/mps-control-daemon/mps/options.go
@@ -17,8 +17,6 @@
 package mps
 
 import (
-	"github.com/NVIDIA/go-nvml/pkg/nvml"
-
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 )
 
@@ -29,12 +27,5 @@ type Option func(*manager)
 func WithConfig(config *spec.Config) Option {
 	return func(m *manager) {
 		m.config = config
-	}
-}
-
-// WithNvmlLib sets the NVML library associated with the MPS manager.
-func WithNvmlLib(nvmllib nvml.Interface) Option {
-	return func(m *manager) {
-		m.nvmllib = nvmllib
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/NVIDIA/go-gpuallocator v0.4.2
 	github.com/NVIDIA/go-nvlib v0.5.0
 	github.com/NVIDIA/go-nvml v0.12.0-6
-	github.com/NVIDIA/nvidia-container-toolkit v1.15.1-0.20240419094620-0aed9a16addf
+	github.com/NVIDIA/nvidia-container-toolkit v1.15.1-0.20240528113255-e4b46a09a77e
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/google/uuid v1.6.0
 	github.com/mittwald/go-helm-client v0.12.9

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/NVIDIA/k8s-device-plugin
 go 1.22.2
 
 require (
-	github.com/NVIDIA/go-gpuallocator v0.4.2
+	github.com/NVIDIA/go-gpuallocator v0.5.0
 	github.com/NVIDIA/go-nvlib v0.5.0
 	github.com/NVIDIA/go-nvml v0.12.0-6
 	github.com/NVIDIA/nvidia-container-toolkit v1.15.1-0.20240528113255-e4b46a09a77e

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.2
 
 require (
 	github.com/NVIDIA/go-gpuallocator v0.4.2
-	github.com/NVIDIA/go-nvlib v0.4.0
+	github.com/NVIDIA/go-nvlib v0.5.0
 	github.com/NVIDIA/go-nvml v0.12.0-6
 	github.com/NVIDIA/nvidia-container-toolkit v1.15.1-0.20240419094620-0aed9a16addf
 	github.com/fsnotify/fsnotify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migc
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7fz8=
 github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
-github.com/NVIDIA/go-gpuallocator v0.4.2 h1:OSW55pQKXQaL2qN+NFGtvlNzasl8wSr6vDW+4bRI4bg=
-github.com/NVIDIA/go-gpuallocator v0.4.2/go.mod h1:op8+/A79CnWBjdl/bsk2vR40Afj+EukIF4m8cE0YUsk=
+github.com/NVIDIA/go-gpuallocator v0.5.0 h1:166ICvPv2dU9oZ2J3kJ4y3XdbGCi6LhXgFZJtrqeu3A=
+github.com/NVIDIA/go-gpuallocator v0.5.0/go.mod h1:zos5bTIN01hpQioOyu9oRKglrznImMQvm0bZllMmckw=
 github.com/NVIDIA/go-nvlib v0.5.0 h1:951KGrfr+p3cs89alO9z/ZxPPWKxwht9tx9rxiADoLI=
 github.com/NVIDIA/go-nvlib v0.5.0/go.mod h1:87z49ULPr4GWPSGfSIp3taU4XENRYN/enIg88MzcL4k=
 github.com/NVIDIA/go-nvml v0.12.0-6 h1:FJYc2KrpvX+VOC/8QQvMiQMmZ/nPMRpdJO/Ik4xfcr0=

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/Microsoft/hcsshim v0.11.4 h1:68vKo2VN8DE9AdN4tnkWnmdhqdbpUFM8OF3Airm7
 github.com/Microsoft/hcsshim v0.11.4/go.mod h1:smjE4dvqPX9Zldna+t5FG3rnoHhaB7QYxPRqGcpAD9w=
 github.com/NVIDIA/go-gpuallocator v0.4.2 h1:OSW55pQKXQaL2qN+NFGtvlNzasl8wSr6vDW+4bRI4bg=
 github.com/NVIDIA/go-gpuallocator v0.4.2/go.mod h1:op8+/A79CnWBjdl/bsk2vR40Afj+EukIF4m8cE0YUsk=
-github.com/NVIDIA/go-nvlib v0.4.0 h1:dvuqjjSamBODFuxttPg4H/xtNVQRZOSlwFtuNKybcGI=
-github.com/NVIDIA/go-nvlib v0.4.0/go.mod h1:87z49ULPr4GWPSGfSIp3taU4XENRYN/enIg88MzcL4k=
+github.com/NVIDIA/go-nvlib v0.5.0 h1:951KGrfr+p3cs89alO9z/ZxPPWKxwht9tx9rxiADoLI=
+github.com/NVIDIA/go-nvlib v0.5.0/go.mod h1:87z49ULPr4GWPSGfSIp3taU4XENRYN/enIg88MzcL4k=
 github.com/NVIDIA/go-nvml v0.12.0-6 h1:FJYc2KrpvX+VOC/8QQvMiQMmZ/nPMRpdJO/Ik4xfcr0=
 github.com/NVIDIA/go-nvml v0.12.0-6/go.mod h1:8Llmj+1Rr+9VGGwZuRer5N/aCjxGuR5nPb/9ebBiIEQ=
 github.com/NVIDIA/nvidia-container-toolkit v1.15.1-0.20240419094620-0aed9a16addf h1:6eKsIVTytQ34X4rFoPjcW+JbJ8XvYH3ITevLED+enD8=

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/NVIDIA/go-nvlib v0.5.0 h1:951KGrfr+p3cs89alO9z/ZxPPWKxwht9tx9rxiADoLI
 github.com/NVIDIA/go-nvlib v0.5.0/go.mod h1:87z49ULPr4GWPSGfSIp3taU4XENRYN/enIg88MzcL4k=
 github.com/NVIDIA/go-nvml v0.12.0-6 h1:FJYc2KrpvX+VOC/8QQvMiQMmZ/nPMRpdJO/Ik4xfcr0=
 github.com/NVIDIA/go-nvml v0.12.0-6/go.mod h1:8Llmj+1Rr+9VGGwZuRer5N/aCjxGuR5nPb/9ebBiIEQ=
-github.com/NVIDIA/nvidia-container-toolkit v1.15.1-0.20240419094620-0aed9a16addf h1:6eKsIVTytQ34X4rFoPjcW+JbJ8XvYH3ITevLED+enD8=
-github.com/NVIDIA/nvidia-container-toolkit v1.15.1-0.20240419094620-0aed9a16addf/go.mod h1:92ofuEEVSg9zK6TTFHQyNhKy2nCk3S3Qe9QIATfcfHc=
+github.com/NVIDIA/nvidia-container-toolkit v1.15.1-0.20240528113255-e4b46a09a77e h1:1xxK51xOXiqqziqMdgEMWVmjfvRu1b265LgQQZBqRaE=
+github.com/NVIDIA/nvidia-container-toolkit v1.15.1-0.20240528113255-e4b46a09a77e/go.mod h1:Xzovqe8g9W8DiJe93gBD8FPjfduDpT+nfKIpc5s8IPE=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d h1:UrqY+r/OJnIp5u0s1SbQ8dVfLCZJsnvazdBP5hS4iRs=
 github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:HI8ITrYtUY+O+ZhtlqUnD8+KwNPOyugEhfP9fdUIaEQ=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/internal/cdi/cdi.go
+++ b/internal/cdi/cdi.go
@@ -74,7 +74,7 @@ func newHandler(opts ...Option) (Interface, error) {
 		c.nvml = nvml.New()
 	}
 	if c.nvdevice == nil {
-		c.nvdevice = nvdevice.New(nvdevice.WithNvml(c.nvml))
+		c.nvdevice = nvdevice.New(c.nvml)
 	}
 	if c.deviceIDStrategy == "" {
 		c.deviceIDStrategy = "uuid"

--- a/internal/cdi/cdi.go
+++ b/internal/cdi/cdi.go
@@ -97,7 +97,7 @@ func newHandler(opts ...Option) (Interface, error) {
 		nvcdi.WithLogger(c.logger),
 		nvcdi.WithNvmlLib(c.nvml),
 		nvcdi.WithDeviceLib(c.nvdevice),
-		nvcdi.WithNVIDIACTKPath(c.nvidiaCTKPath),
+		nvcdi.WithNVIDIACDIHookPath(c.nvidiaCTKPath),
 		nvcdi.WithDriverRoot(c.driverRoot),
 		nvcdi.WithDeviceNamers(deviceNamer),
 		nvcdi.WithVendor(c.vendor),
@@ -117,8 +117,9 @@ func newHandler(opts ...Option) (Interface, error) {
 
 	for _, mode := range additionalModes {
 		lib, err := nvcdi.New(
+			nvcdi.WithInfoLib(c.infolib),
 			nvcdi.WithLogger(c.logger),
-			nvcdi.WithNVIDIACTKPath(c.nvidiaCTKPath),
+			nvcdi.WithNVIDIACDIHookPath(c.nvidiaCTKPath),
 			nvcdi.WithDriverRoot(c.driverRoot),
 			nvcdi.WithVendor(c.vendor),
 			nvcdi.WithMode(mode),

--- a/internal/cdi/factory.go
+++ b/internal/cdi/factory.go
@@ -17,20 +17,20 @@
 package cdi
 
 import (
+	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
 	"k8s.io/klog/v2"
 )
 
 // New is a factory method that creates a CDI handler for creating CDI specs.
-func New(opts ...Option) (Interface, error) {
-	infolib := info.New()
-
+func New(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interface, opts ...Option) (Interface, error) {
 	hasNVML, _ := infolib.HasNvml()
 	if !hasNVML {
 		klog.Warning("No valid resources detected, creating a null CDI handler")
 		return NewNullHandler(), nil
 	}
 
-	return newHandler(opts...)
+	return newHandler(infolib, nvmllib, devicelib, opts...)
 }

--- a/internal/cdi/options.go
+++ b/internal/cdi/options.go
@@ -17,8 +17,6 @@
 package cdi
 
 import (
-	"github.com/NVIDIA/go-nvml/pkg/nvml"
-
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 )
 
@@ -50,13 +48,6 @@ func WithTargetDriverRoot(root string) Option {
 func WithNvidiaCTKPath(path string) Option {
 	return func(c *cdiHandler) {
 		c.nvidiaCTKPath = path
-	}
-}
-
-// WithNvml provides an Option to set the NVML library used by the 'cdi' interface
-func WithNvml(nvml nvml.Interface) Option {
-	return func(c *cdiHandler) {
-		c.nvml = nvml
 	}
 }
 

--- a/internal/plugin/manager/nvml.go
+++ b/internal/plugin/manager/nvml.go
@@ -27,7 +27,7 @@ type nvmlmanager manager
 
 // GetPlugins returns the plugins associated with the NVML resources available on the node
 func (m *nvmlmanager) GetPlugins() ([]plugin.Interface, error) {
-	rms, err := rm.NewNVMLResourceManagers(m.nvmllib, m.config)
+	rms, err := rm.NewNVMLResourceManagers(m.infolib, m.nvmllib, m.devicelib, m.config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct NVML resource managers: %v", err)
 	}

--- a/internal/plugin/manager/options.go
+++ b/internal/plugin/manager/options.go
@@ -17,6 +17,7 @@
 package manager
 
 import (
+	"github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
@@ -37,6 +38,13 @@ func WithCDIHandler(handler cdi.Interface) Option {
 func WithNVML(nvmllib nvml.Interface) Option {
 	return func(m *manager) {
 		m.nvmllib = nvmllib
+	}
+}
+
+// WithInfoLib sets the info lib for the manager.
+func WithInfoLib(infolib info.Interface) Option {
+	return func(m *manager) {
+		m.infolib = infolib
 	}
 }
 

--- a/internal/resource/nvml-lib.go
+++ b/internal/resource/nvml-lib.go
@@ -29,7 +29,7 @@ type nvmlLib struct {
 // NewNVMLManager creates a new manager that uses NVML to query and manage devices
 func NewNVMLManager() Manager {
 	nvmllib := nvml.New()
-	devicelib := device.New(device.WithNvml(nvmllib))
+	devicelib := device.New(nvmllib)
 
 	m := nvmlLib{
 		Interface: nvmllib,

--- a/internal/resource/nvml-lib.go
+++ b/internal/resource/nvml-lib.go
@@ -27,10 +27,7 @@ type nvmlLib struct {
 }
 
 // NewNVMLManager creates a new manager that uses NVML to query and manage devices
-func NewNVMLManager() Manager {
-	nvmllib := nvml.New()
-	devicelib := device.New(nvmllib)
-
+func NewNVMLManager(nvmllib nvml.Interface, devicelib device.Interface) Manager {
 	m := nvmlLib{
 		Interface: nvmllib,
 		devicelib: devicelib,

--- a/internal/rm/device_map.go
+++ b/internal/rm/device_map.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+	"github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
@@ -30,6 +31,8 @@ type deviceMapBuilder struct {
 	migStrategy         *string
 	resources           *spec.Resources
 	replicatedResources *spec.ReplicatedResources
+
+	newGPUDevice func(i int, gpu nvml.Device) (string, deviceInfo)
 }
 
 // DeviceMap stores a set of devices per resource name.
@@ -42,7 +45,13 @@ func NewDeviceMap(nvmllib nvml.Interface, config *spec.Config) (DeviceMap, error
 		migStrategy:         config.Flags.MigStrategy,
 		resources:           &config.Resources,
 		replicatedResources: config.Sharing.ReplicatedResources(),
+		newGPUDevice:        newNvmlGPUDevice,
 	}
+
+	if info.New().ResolvePlatform() == info.PlatformWSL {
+		b.newGPUDevice = newWslGPUDevice
+	}
+
 	return b.build()
 }
 
@@ -112,7 +121,7 @@ func (b *deviceMapBuilder) buildGPUDeviceMap() (DeviceMap, error) {
 		}
 		for _, resource := range b.resources.GPUs {
 			if resource.Pattern.Matches(name) {
-				index, info := newGPUDevice(i, gpu)
+				index, info := b.newGPUDevice(i, gpu)
 				return devices.setEntry(resource.Name, index, info)
 			}
 		}

--- a/internal/rm/device_map.go
+++ b/internal/rm/device_map.go
@@ -39,16 +39,16 @@ type deviceMapBuilder struct {
 type DeviceMap map[spec.ResourceName]Devices
 
 // NewDeviceMap creates a device map for the specified NVML library and config.
-func NewDeviceMap(nvmllib nvml.Interface, config *spec.Config) (DeviceMap, error) {
+func NewDeviceMap(infolib info.Interface, devicelib device.Interface, config *spec.Config) (DeviceMap, error) {
 	b := deviceMapBuilder{
-		Interface:           device.New(nvmllib),
+		Interface:           devicelib,
 		migStrategy:         config.Flags.MigStrategy,
 		resources:           &config.Resources,
 		replicatedResources: config.Sharing.ReplicatedResources(),
 		newGPUDevice:        newNvmlGPUDevice,
 	}
 
-	if info.New().ResolvePlatform() == info.PlatformWSL {
+	if infolib.ResolvePlatform() == info.PlatformWSL {
 		b.newGPUDevice = newWslGPUDevice
 	}
 

--- a/internal/rm/device_map.go
+++ b/internal/rm/device_map.go
@@ -38,7 +38,7 @@ type DeviceMap map[spec.ResourceName]Devices
 // NewDeviceMap creates a device map for the specified NVML library and config.
 func NewDeviceMap(nvmllib nvml.Interface, config *spec.Config) (DeviceMap, error) {
 	b := deviceMapBuilder{
-		Interface:           device.New(device.WithNvml(nvmllib)),
+		Interface:           device.New(nvmllib),
 		migStrategy:         config.Flags.MigStrategy,
 		resources:           &config.Resources,
 		replicatedResources: config.Sharing.ReplicatedResources(),

--- a/internal/rm/nvml_devices.go
+++ b/internal/rm/nvml_devices.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
 	"github.com/NVIDIA/k8s-device-plugin/internal/mig"
@@ -45,14 +44,14 @@ type nvmlMigDevice nvmlDevice
 var _ deviceInfo = (*nvmlDevice)(nil)
 var _ deviceInfo = (*nvmlMigDevice)(nil)
 
-func newGPUDevice(i int, gpu nvml.Device) (string, deviceInfo) {
+func newNvmlGPUDevice(i int, gpu nvml.Device) (string, deviceInfo) {
 	index := fmt.Sprintf("%v", i)
-	isWsl, _ := info.New().HasDXCore()
-	if isWsl {
-		return index, wslDevice{gpu}
-	}
-
 	return index, nvmlDevice{gpu}
+}
+
+func newWslGPUDevice(i int, gpu nvml.Device) (string, deviceInfo) {
+	index := fmt.Sprintf("%v", i)
+	return index, wslDevice{gpu}
 }
 
 func newMigDevice(i int, j int, mig nvml.Device) (string, nvmlMigDevice) {

--- a/internal/rm/nvml_manager.go
+++ b/internal/rm/nvml_manager.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 
 	"github.com/NVIDIA/go-gpuallocator/gpuallocator"
+	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+	"github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"k8s.io/klog/v2"
 
@@ -34,7 +36,7 @@ type nvmlResourceManager struct {
 var _ ResourceManager = (*nvmlResourceManager)(nil)
 
 // NewNVMLResourceManagers returns a set of ResourceManagers, one for each NVML resource in 'config'.
-func NewNVMLResourceManagers(nvmllib nvml.Interface, config *spec.Config) ([]ResourceManager, error) {
+func NewNVMLResourceManagers(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interface, config *spec.Config) ([]ResourceManager, error) {
 	ret := nvmllib.Init()
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("failed to initialize NVML: %v", ret)
@@ -46,7 +48,7 @@ func NewNVMLResourceManagers(nvmllib nvml.Interface, config *spec.Config) ([]Res
 		}
 	}()
 
-	deviceMap, err := NewDeviceMap(nvmllib, config)
+	deviceMap, err := NewDeviceMap(infolib, devicelib, config)
 	if err != nil {
 		return nil, fmt.Errorf("error building device map: %v", err)
 	}

--- a/internal/rm/rm.go
+++ b/internal/rm/rm.go
@@ -126,7 +126,7 @@ func AddDefaultResourcesToConfig(config *spec.Config) error {
 		}()
 
 		devicelib := device.New(
-			device.WithNvml(nvmllib),
+			nvmllib,
 		)
 		return devicelib.VisitMigProfiles(func(p device.MigProfile) error {
 			info := p.GetInfo()

--- a/internal/rm/rm.go
+++ b/internal/rm/rm.go
@@ -46,62 +46,6 @@ type ResourceManager interface {
 	ValidateRequest(AnnotatedIDs) error
 }
 
-// NewResourceManagers returns a []ResourceManager, one for each resource in 'config'.
-func NewResourceManagers(nvmllib nvml.Interface, config *spec.Config) ([]ResourceManager, error) {
-	// logWithReason logs the output of the has* / is* checks from the info.Interface
-	logWithReason := func(f func() (bool, string), tag string) bool {
-		is, reason := f()
-		if !is {
-			tag = "non-" + tag
-		}
-		klog.Infof("Detected %v platform: %v", tag, reason)
-		return is
-	}
-
-	infolib := info.New()
-
-	hasNVML := logWithReason(infolib.HasNvml, "NVML")
-	isTegra := logWithReason(infolib.HasTegraFiles, "Tegra")
-
-	if !hasNVML && !isTegra {
-		klog.Error("Incompatible platform detected")
-		klog.Error("If this is a GPU node, did you configure the NVIDIA Container Toolkit?")
-		klog.Error("You can check the prerequisites at: https://github.com/NVIDIA/k8s-device-plugin#prerequisites")
-		klog.Error("You can learn how to set the runtime at: https://github.com/NVIDIA/k8s-device-plugin#quick-start")
-		klog.Error("If this is not a GPU node, you should set up a toleration or nodeSelector to only deploy this plugin on GPU nodes")
-		if *config.Flags.FailOnInitError {
-			return nil, fmt.Errorf("platform detection failed")
-		}
-		return nil, nil
-	}
-
-	// The NVIDIA container stack does not yet support the use of integrated AND discrete GPUs on the same node.
-	if hasNVML && isTegra {
-		klog.Warning("Disabling Tegra-based resources on NVML system")
-		isTegra = false
-	}
-
-	var resourceManagers []ResourceManager
-
-	if hasNVML {
-		nvmlManagers, err := NewNVMLResourceManagers(nvmllib, config)
-		if err != nil {
-			return nil, fmt.Errorf("failed to construct NVML resource managers: %v", err)
-		}
-		resourceManagers = append(resourceManagers, nvmlManagers...)
-	}
-
-	if isTegra {
-		tegraManagers, err := NewTegraResourceManagers(config)
-		if err != nil {
-			return nil, fmt.Errorf("failed to construct Tegra resource managers: %v", err)
-		}
-		resourceManagers = append(resourceManagers, tegraManagers...)
-	}
-
-	return resourceManagers, nil
-}
-
 // Resource gets the resource name associated with the ResourceManager
 func (r *resourceManager) Resource() spec.ResourceName {
 	return r.resource

--- a/vendor/github.com/NVIDIA/go-gpuallocator/gpuallocator/device.go
+++ b/vendor/github.com/NVIDIA/go-gpuallocator/gpuallocator/device.go
@@ -82,9 +82,7 @@ func NewDevices(opts ...Option) (DeviceList, error) {
 		o.nvmllib = nvmlNew()
 	}
 	if o.devicelib == nil {
-		o.devicelib = device.New(
-			device.WithNvml(o.nvmllib),
-		)
+		o.devicelib = device.New(o.nvmllib)
 	}
 
 	return o.build()

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/device/api.go
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/device/api.go
@@ -38,7 +38,7 @@ type Interface interface {
 }
 
 type devicelib struct {
-	nvml           nvml.Interface
+	nvmllib        nvml.Interface
 	skippedDevices map[string]struct{}
 	verifySymbols  *bool
 	migProfiles    []MigProfile
@@ -47,13 +47,12 @@ type devicelib struct {
 var _ Interface = &devicelib{}
 
 // New creates a new instance of the 'device' interface.
-func New(opts ...Option) Interface {
-	d := &devicelib{}
+func New(nvmllib nvml.Interface, opts ...Option) Interface {
+	d := &devicelib{
+		nvmllib: nvmllib,
+	}
 	for _, opt := range opts {
 		opt(d)
-	}
-	if d.nvml == nil {
-		d.nvml = nvml.New()
 	}
 	if d.verifySymbols == nil {
 		verify := true
@@ -66,13 +65,6 @@ func New(opts ...Option) Interface {
 		)(d)
 	}
 	return d
-}
-
-// WithNvml provides an Option to set the NVML library used by the 'device' interface.
-func WithNvml(nvml nvml.Interface) Option {
-	return func(d *devicelib) {
-		d.nvml = nvml
-	}
 }
 
 // WithVerifySymbols provides an option to toggle whether to verify select symbols exist in dynamic libraries before calling them.

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/device/device.go
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/device/device.go
@@ -51,7 +51,7 @@ func (d *devicelib) NewDevice(dev nvml.Device) (Device, error) {
 
 // NewDeviceByUUID builds a new Device from a UUID.
 func (d *devicelib) NewDeviceByUUID(uuid string) (Device, error) {
-	dev, ret := d.nvml.DeviceGetHandleByUUID(uuid)
+	dev, ret := d.nvmllib.DeviceGetHandleByUUID(uuid)
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("error getting device handle for uuid '%v': %v", uuid, ret)
 	}
@@ -334,13 +334,13 @@ func (d *device) isSkipped() (bool, error) {
 
 // VisitDevices visits each top-level device and invokes a callback function for it.
 func (d *devicelib) VisitDevices(visit func(int, Device) error) error {
-	count, ret := d.nvml.DeviceGetCount()
+	count, ret := d.nvmllib.DeviceGetCount()
 	if ret != nvml.SUCCESS {
 		return fmt.Errorf("error getting device count: %v", ret)
 	}
 
 	for i := 0; i < count; i++ {
-		device, ret := d.nvml.DeviceGetHandleByIndex(i)
+		device, ret := d.nvmllib.DeviceGetHandleByIndex(i)
 		if ret != nvml.SUCCESS {
 			return fmt.Errorf("error getting device handle for index '%v': %v", i, ret)
 		}
@@ -469,5 +469,5 @@ func (d *devicelib) hasSymbol(symbol string) bool {
 		return true
 	}
 
-	return d.nvml.Extensions().LookupSymbol(symbol) == nil
+	return d.nvmllib.Extensions().LookupSymbol(symbol) == nil
 }

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/device/mig_device.go
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/device/mig_device.go
@@ -50,7 +50,7 @@ func (d *devicelib) NewMigDevice(handle nvml.Device) (MigDevice, error) {
 
 // NewMigDeviceByUUID builds a new MigDevice from a UUID.
 func (d *devicelib) NewMigDeviceByUUID(uuid string) (MigDevice, error) {
-	dev, ret := d.nvml.DeviceGetHandleByUUID(uuid)
+	dev, ret := d.nvmllib.DeviceGetHandleByUUID(uuid)
 	if ret != nvml.SUCCESS {
 		return nil, fmt.Errorf("error getting device handle for uuid '%v': %v", uuid, ret)
 	}

--- a/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/info/builder.go
+++ b/vendor/github.com/NVIDIA/go-nvlib/pkg/nvlib/info/builder.go
@@ -55,7 +55,7 @@ func New(opts ...Option) Interface {
 		)
 	}
 	if o.devicelib == nil {
-		o.devicelib = device.New(device.WithNvml(o.nvmllib))
+		o.devicelib = device.New(o.nvmllib)
 	}
 	if o.platform == "" {
 		o.platform = PlatformAuto

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/ldconfig.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/ldconfig.go
@@ -25,12 +25,12 @@ import (
 )
 
 // NewLDCacheUpdateHook creates a discoverer that updates the ldcache for the specified mounts. A logger can also be specified
-func NewLDCacheUpdateHook(logger logger.Interface, mounts Discover, nvidiaCTKPath, ldconfigPath string) (Discover, error) {
+func NewLDCacheUpdateHook(logger logger.Interface, mounts Discover, nvidiaCDIHookPath, ldconfigPath string) (Discover, error) {
 	d := ldconfig{
-		logger:        logger,
-		nvidiaCTKPath: nvidiaCTKPath,
-		ldconfigPath:  ldconfigPath,
-		mountsFrom:    mounts,
+		logger:            logger,
+		nvidiaCDIHookPath: nvidiaCDIHookPath,
+		ldconfigPath:      ldconfigPath,
+		mountsFrom:        mounts,
 	}
 
 	return &d, nil
@@ -38,10 +38,10 @@ func NewLDCacheUpdateHook(logger logger.Interface, mounts Discover, nvidiaCTKPat
 
 type ldconfig struct {
 	None
-	logger        logger.Interface
-	nvidiaCTKPath string
-	ldconfigPath  string
-	mountsFrom    Discover
+	logger            logger.Interface
+	nvidiaCDIHookPath string
+	ldconfigPath      string
+	mountsFrom        Discover
 }
 
 // Hooks checks the required mounts for libraries and returns a hook to update the LDcache for the discovered paths.
@@ -51,7 +51,7 @@ func (d ldconfig) Hooks() ([]Hook, error) {
 		return nil, fmt.Errorf("failed to discover mounts for ldcache update: %v", err)
 	}
 	h := CreateLDCacheUpdateHook(
-		d.nvidiaCTKPath,
+		d.nvidiaCDIHookPath,
 		d.ldconfigPath,
 		getLibraryPaths(mounts),
 	)
@@ -70,7 +70,7 @@ func CreateLDCacheUpdateHook(executable string, ldconfig string, libraries []str
 		args = append(args, "--folder", f)
 	}
 
-	hook := CreateNvidiaCTKHook(
+	hook := CreateNvidiaCDIHook(
 		executable,
 		"update-ldcache",
 		args...,

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/platform-support/tegra/symlinks.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/platform-support/tegra/symlinks.go
@@ -28,10 +28,10 @@ import (
 
 type symlinkHook struct {
 	discover.None
-	logger        logger.Interface
-	nvidiaCTKPath string
-	targets       []string
-	mountsFrom    discover.Discover
+	logger            logger.Interface
+	nvidiaCDIHookPath string
+	targets           []string
+	mountsFrom        discover.Discover
 
 	// The following can be overridden for testing
 	symlinkChainLocator lookup.Locator
@@ -42,7 +42,7 @@ type symlinkHook struct {
 func (o tegraOptions) createCSVSymlinkHooks(targets []string, mounts discover.Discover) discover.Discover {
 	return symlinkHook{
 		logger:              o.logger,
-		nvidiaCTKPath:       o.nvidiaCTKPath,
+		nvidiaCDIHookPath:   o.nvidiaCDIHookPath,
 		targets:             targets,
 		mountsFrom:          mounts,
 		symlinkChainLocator: o.symlinkChainLocator,
@@ -60,7 +60,7 @@ func (d symlinkHook) Hooks() ([]discover.Hook, error) {
 	csvSymlinks := d.getCSVFileSymlinks()
 
 	return discover.CreateCreateSymlinkHook(
-		d.nvidiaCTKPath,
+		d.nvidiaCDIHookPath,
 		append(csvSymlinks, specificLinks...),
 	).Hooks()
 }

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/platform-support/tegra/tegra.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/platform-support/tegra/tegra.go
@@ -30,7 +30,7 @@ type tegraOptions struct {
 	csvFiles           []string
 	driverRoot         string
 	devRoot            string
-	nvidiaCTKPath      string
+	nvidiaCDIHookPath  string
 	ldconfigPath       string
 	librarySearchPaths []string
 	ignorePatterns     ignoreMountSpecPatterns
@@ -80,7 +80,7 @@ func New(opts ...Option) (discover.Discover, error) {
 		return nil, fmt.Errorf("failed to create CSV discoverer: %v", err)
 	}
 
-	ldcacheUpdateHook, err := discover.NewLDCacheUpdateHook(o.logger, csvDiscoverer, o.nvidiaCTKPath, o.ldconfigPath)
+	ldcacheUpdateHook, err := discover.NewLDCacheUpdateHook(o.logger, csvDiscoverer, o.nvidiaCDIHookPath, o.ldconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ldcach update hook discoverer: %v", err)
 	}
@@ -133,10 +133,10 @@ func WithCSVFiles(csvFiles []string) Option {
 	}
 }
 
-// WithNVIDIACTKPath sets the path to the nvidia-container-toolkit binary.
-func WithNVIDIACTKPath(nvidiaCTKPath string) Option {
+// WithNVIDIACDIHookPath sets the path to the nvidia-cdi-hook binary.
+func WithNVIDIACDIHookPath(nvidiaCDIHookPath string) Option {
 	return func(o *tegraOptions) {
-		o.nvidiaCTKPath = nvidiaCTKPath
+		o.nvidiaCDIHookPath = nvidiaCDIHookPath
 	}
 }
 

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/common-nvml.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/common-nvml.go
@@ -36,12 +36,12 @@ func (l *nvmllib) newCommonNVMLDiscoverer() (discover.Discover, error) {
 		},
 	)
 
-	graphicsMounts, err := discover.NewGraphicsMountsDiscoverer(l.logger, l.driver, l.nvidiaCTKPath)
+	graphicsMounts, err := discover.NewGraphicsMountsDiscoverer(l.logger, l.driver, l.nvidiaCDIHookPath)
 	if err != nil {
 		l.logger.Warningf("failed to create discoverer for graphics mounts: %v", err)
 	}
 
-	driverFiles, err := NewDriverDiscoverer(l.logger, l.driver, l.nvidiaCTKPath, l.ldconfigPath, l.nvmllib)
+	driverFiles, err := NewDriverDiscoverer(l.logger, l.driver, l.nvidiaCDIHookPath, l.ldconfigPath, l.nvmllib)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discoverer for driver files: %v", err)
 	}

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/driver-nvml.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/driver-nvml.go
@@ -34,7 +34,7 @@ import (
 
 // NewDriverDiscoverer creates a discoverer for the libraries and binaries associated with a driver installation.
 // The supplied NVML Library is used to query the expected driver version.
-func NewDriverDiscoverer(logger logger.Interface, driver *root.Driver, nvidiaCTKPath string, ldconfigPath string, nvmllib nvml.Interface) (discover.Discover, error) {
+func NewDriverDiscoverer(logger logger.Interface, driver *root.Driver, nvidiaCDIHookPath string, ldconfigPath string, nvmllib nvml.Interface) (discover.Discover, error) {
 	if r := nvmllib.Init(); r != nvml.SUCCESS {
 		return nil, fmt.Errorf("failed to initialize NVML: %v", r)
 	}
@@ -49,11 +49,11 @@ func NewDriverDiscoverer(logger logger.Interface, driver *root.Driver, nvidiaCTK
 		return nil, fmt.Errorf("failed to determine driver version: %v", r)
 	}
 
-	return newDriverVersionDiscoverer(logger, driver, nvidiaCTKPath, ldconfigPath, version)
+	return newDriverVersionDiscoverer(logger, driver, nvidiaCDIHookPath, ldconfigPath, version)
 }
 
-func newDriverVersionDiscoverer(logger logger.Interface, driver *root.Driver, nvidiaCTKPath, ldconfigPath, version string) (discover.Discover, error) {
-	libraries, err := NewDriverLibraryDiscoverer(logger, driver, nvidiaCTKPath, ldconfigPath, version)
+func newDriverVersionDiscoverer(logger logger.Interface, driver *root.Driver, nvidiaCDIHookPath, ldconfigPath, version string) (discover.Discover, error) {
+	libraries, err := NewDriverLibraryDiscoverer(logger, driver, nvidiaCDIHookPath, ldconfigPath, version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discoverer for driver libraries: %v", err)
 	}
@@ -81,7 +81,7 @@ func newDriverVersionDiscoverer(logger logger.Interface, driver *root.Driver, nv
 }
 
 // NewDriverLibraryDiscoverer creates a discoverer for the libraries associated with the specified driver version.
-func NewDriverLibraryDiscoverer(logger logger.Interface, driver *root.Driver, nvidiaCTKPath, ldconfigPath, version string) (discover.Discover, error) {
+func NewDriverLibraryDiscoverer(logger logger.Interface, driver *root.Driver, nvidiaCDIHookPath, ldconfigPath, version string) (discover.Discover, error) {
 	libraryPaths, err := getVersionLibs(logger, driver, version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get libraries for driver version: %v", err)
@@ -97,7 +97,7 @@ func NewDriverLibraryDiscoverer(logger logger.Interface, driver *root.Driver, nv
 		libraryPaths,
 	)
 
-	hooks, _ := discover.NewLDCacheUpdateHook(logger, libraries, nvidiaCTKPath, ldconfigPath)
+	hooks, _ := discover.NewLDCacheUpdateHook(logger, libraries, nvidiaCDIHookPath, ldconfigPath)
 
 	d := discover.Merge(
 		libraries,

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/driver-wsl.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/driver-wsl.go
@@ -39,7 +39,7 @@ var requiredDriverStoreFiles = []string{
 }
 
 // newWSLDriverDiscoverer returns a Discoverer for WSL2 drivers.
-func newWSLDriverDiscoverer(logger logger.Interface, driverRoot string, nvidiaCTKPath, ldconfigPath string) (discover.Discover, error) {
+func newWSLDriverDiscoverer(logger logger.Interface, driverRoot string, nvidiaCDIHookPath, ldconfigPath string) (discover.Discover, error) {
 	err := dxcore.Init()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize dxcore: %v", err)
@@ -56,11 +56,11 @@ func newWSLDriverDiscoverer(logger logger.Interface, driverRoot string, nvidiaCT
 	}
 	logger.Infof("Using WSL driver store paths: %v", driverStorePaths)
 
-	return newWSLDriverStoreDiscoverer(logger, driverRoot, nvidiaCTKPath, ldconfigPath, driverStorePaths)
+	return newWSLDriverStoreDiscoverer(logger, driverRoot, nvidiaCDIHookPath, ldconfigPath, driverStorePaths)
 }
 
 // newWSLDriverStoreDiscoverer returns a Discoverer for WSL2 drivers in the driver store associated with a dxcore adapter.
-func newWSLDriverStoreDiscoverer(logger logger.Interface, driverRoot string, nvidiaCTKPath string, ldconfigPath string, driverStorePaths []string) (discover.Discover, error) {
+func newWSLDriverStoreDiscoverer(logger logger.Interface, driverRoot string, nvidiaCDIHookPath string, ldconfigPath string, driverStorePaths []string) (discover.Discover, error) {
 	var searchPaths []string
 	seen := make(map[string]bool)
 	for _, path := range driverStorePaths {
@@ -88,12 +88,12 @@ func newWSLDriverStoreDiscoverer(logger logger.Interface, driverRoot string, nvi
 	)
 
 	symlinkHook := nvidiaSMISimlinkHook{
-		logger:        logger,
-		mountsFrom:    libraries,
-		nvidiaCTKPath: nvidiaCTKPath,
+		logger:            logger,
+		mountsFrom:        libraries,
+		nvidiaCDIHookPath: nvidiaCDIHookPath,
 	}
 
-	ldcacheHook, _ := discover.NewLDCacheUpdateHook(logger, libraries, nvidiaCTKPath, ldconfigPath)
+	ldcacheHook, _ := discover.NewLDCacheUpdateHook(logger, libraries, nvidiaCDIHookPath, ldconfigPath)
 
 	d := discover.Merge(
 		libraries,
@@ -106,9 +106,9 @@ func newWSLDriverStoreDiscoverer(logger logger.Interface, driverRoot string, nvi
 
 type nvidiaSMISimlinkHook struct {
 	discover.None
-	logger        logger.Interface
-	mountsFrom    discover.Discover
-	nvidiaCTKPath string
+	logger            logger.Interface
+	mountsFrom        discover.Discover
+	nvidiaCDIHookPath string
 }
 
 // Hooks returns a hook that creates a symlink to nvidia-smi in the driver store.
@@ -135,7 +135,7 @@ func (m nvidiaSMISimlinkHook) Hooks() ([]discover.Hook, error) {
 	}
 	link := "/usr/bin/nvidia-smi"
 	links := []string{fmt.Sprintf("%s::%s", target, link)}
-	symlinkHook := discover.CreateCreateSymlinkHook(m.nvidiaCTKPath, links)
+	symlinkHook := discover.CreateCreateSymlinkHook(m.nvidiaCDIHookPath, links)
 
 	return symlinkHook.Hooks()
 }

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/lib-csv.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/lib-csv.go
@@ -44,7 +44,7 @@ func (l *csvlib) GetAllDeviceSpecs() ([]specs.Device, error) {
 		tegra.WithLogger(l.logger),
 		tegra.WithDriverRoot(l.driverRoot),
 		tegra.WithDevRoot(l.devRoot),
-		tegra.WithNVIDIACTKPath(l.nvidiaCTKPath),
+		tegra.WithNVIDIACDIHookPath(l.nvidiaCDIHookPath),
 		tegra.WithLdconfigPath(l.ldconfigPath),
 		tegra.WithCSVFiles(l.csvFiles),
 		tegra.WithLibrarySearchPaths(l.librarySearchPaths...),

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/lib-wsl.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/lib-wsl.go
@@ -54,7 +54,7 @@ func (l *wsllib) GetAllDeviceSpecs() ([]specs.Device, error) {
 
 // GetCommonEdits generates a CDI specification that can be used for ANY devices
 func (l *wsllib) GetCommonEdits() (*cdi.ContainerEdits, error) {
-	driver, err := newWSLDriverDiscoverer(l.logger, l.driverRoot, l.nvidiaCTKPath, l.ldconfigPath)
+	driver, err := newWSLDriverDiscoverer(l.logger, l.driverRoot, l.nvidiaCDIHookPath, l.ldconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create discoverer for WSL driver: %v", err)
 	}

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/lib.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/lib.go
@@ -48,7 +48,7 @@ type nvcdilib struct {
 	deviceNamers       DeviceNamers
 	driverRoot         string
 	devRoot            string
-	nvidiaCTKPath      string
+	nvidiaCDIHookPath  string
 	ldconfigPath       string
 	configSearchPaths  []string
 	librarySearchPaths []string
@@ -81,24 +81,34 @@ func New(opts ...Option) (Interface, error) {
 		indexNamer, _ := NewDeviceNamer(DeviceNameStrategyIndex)
 		l.deviceNamers = []DeviceNamer{indexNamer}
 	}
+	if l.nvidiaCDIHookPath == "" {
+		l.nvidiaCDIHookPath = "/usr/bin/nvidia-cdi-hook"
+	}
 	if l.driverRoot == "" {
 		l.driverRoot = "/"
 	}
 	if l.devRoot == "" {
 		l.devRoot = l.driverRoot
 	}
-	if l.nvidiaCTKPath == "" {
-		l.nvidiaCTKPath = "/usr/bin/nvidia-ctk"
-	}
-	if l.infolib == nil {
-		l.infolib = info.New()
-	}
-
 	l.driver = root.New(
 		root.WithLogger(l.logger),
 		root.WithDriverRoot(l.driverRoot),
 		root.WithLibrarySearchPaths(l.librarySearchPaths...),
 	)
+	if l.nvmllib == nil {
+		l.nvmllib = nvml.New()
+	}
+	if l.devicelib == nil {
+		l.devicelib = device.New(l.nvmllib)
+	}
+	if l.infolib == nil {
+		l.infolib = info.New(
+			info.WithRoot(l.driverRoot),
+			info.WithLogger(l.logger),
+			info.WithNvmlLib(l.nvmllib),
+			info.WithDeviceLib(l.devicelib),
+		)
+	}
 
 	var lib Interface
 	switch l.resolveMode() {
@@ -113,13 +123,6 @@ func New(opts ...Option) (Interface, error) {
 		}
 		lib = (*managementlib)(l)
 	case ModeNvml:
-		if l.nvmllib == nil {
-			l.nvmllib = nvml.New()
-		}
-		if l.devicelib == nil {
-			l.devicelib = device.New(device.WithNvml(l.nvmllib))
-		}
-
 		lib = (*nvmllib)(l)
 	case ModeWsl:
 		lib = (*wsllib)(l)
@@ -184,26 +187,19 @@ func (l *nvcdilib) resolveMode() (rmode string) {
 		return l.mode
 	}
 	defer func() {
-		l.logger.Infof("Auto-detected mode as %q", rmode)
+		l.logger.Infof("Auto-detected mode as '%v'", rmode)
 	}()
 
-	isWSL, reason := l.infolib.HasDXCore()
-	l.logger.Debugf("Is WSL-based system? %v: %v", isWSL, reason)
-
-	if isWSL {
+	platform := l.infolib.ResolvePlatform()
+	switch platform {
+	case info.PlatformNVML:
+		return ModeNvml
+	case info.PlatformTegra:
+		return ModeCSV
+	case info.PlatformWSL:
 		return ModeWsl
 	}
-
-	isNvml, reason := l.infolib.HasNvml()
-	l.logger.Debugf("Is NVML-based system? %v: %v", isNvml, reason)
-
-	isTegra, reason := l.infolib.IsTegraSystem()
-	l.logger.Debugf("Is Tegra-based system? %v: %v", isTegra, reason)
-
-	if isTegra && !isNvml {
-		return ModeCSV
-	}
-
+	l.logger.Warningf("Unsupported platform detected: %v; assuming %v", platform, ModeNvml)
 	return ModeNvml
 }
 

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/management.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/management.go
@@ -66,7 +66,7 @@ func (m *managementlib) GetCommonEdits() (*cdi.ContainerEdits, error) {
 		return nil, fmt.Errorf("failed to get CUDA version: %v", err)
 	}
 
-	driver, err := newDriverVersionDiscoverer(m.logger, m.driver, m.nvidiaCTKPath, m.ldconfigPath, version)
+	driver, err := newDriverVersionDiscoverer(m.logger, m.driver, m.nvidiaCDIHookPath, m.ldconfigPath, version)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create driver library discoverer: %v", err)
 	}
@@ -123,7 +123,7 @@ func (m *managementlib) newManagementDeviceDiscoverer() (discover.Discover, erro
 	deviceFolderPermissionHooks := newDeviceFolderPermissionHookDiscoverer(
 		m.logger,
 		m.devRoot,
-		m.nvidiaCTKPath,
+		m.nvidiaCDIHookPath,
 		deviceNodes,
 	)
 

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/options.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/options.go
@@ -18,6 +18,7 @@ package nvcdi
 
 import (
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+	"github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
 	"github.com/NVIDIA/nvidia-container-toolkit/internal/logger"
@@ -31,6 +32,13 @@ type Option func(*nvcdilib)
 func WithDeviceLib(devicelib device.Interface) Option {
 	return func(l *nvcdilib) {
 		l.devicelib = devicelib
+	}
+}
+
+// WithInfoLib sets the info library for CDI spec generation.
+func WithInfoLib(infolib info.Interface) Option {
+	return func(l *nvcdilib) {
+		l.infolib = infolib
 	}
 }
 
@@ -63,9 +71,16 @@ func WithLogger(logger logger.Interface) Option {
 }
 
 // WithNVIDIACTKPath sets the path to the NVIDIA Container Toolkit CLI path for the library
+//
+// Deprecated: Use WithNVIDIACDIHookPath instead.
 func WithNVIDIACTKPath(path string) Option {
+	return WithNVIDIACDIHookPath(path)
+}
+
+// WithNVIDIACDIHookPath sets the path to the NVIDIA Container Toolkit CLI path for the library
+func WithNVIDIACDIHookPath(path string) Option {
 	return func(l *nvcdilib) {
-		l.nvidiaCTKPath = path
+		l.nvidiaCDIHookPath = path
 	}
 }
 

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/spec/set-minimum-version.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/spec/set-minimum-version.go
@@ -1,5 +1,5 @@
 /**
-# Copyright (c) NVIDIA CORPORATION.  All rights reserved.
+# Copyright 2024 NVIDIA CORPORATION
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,26 +17,19 @@
 package spec
 
 import (
-	"io"
+	"fmt"
 
+	"tags.cncf.io/container-device-interface/pkg/cdi"
 	"tags.cncf.io/container-device-interface/specs-go"
 )
 
-const (
-	// DetectMinimumVersion is a constant that triggers a spec to detect the minimum required version.
-	//
-	// Deprecated: DetectMinimumVersion is deprecated and will be removed.
-	DetectMinimumVersion = "DETECT_MINIMUM_VERSION"
+type setMinimumRequiredVersion struct{}
 
-	// FormatJSON indicates a JSON output format
-	FormatJSON = "json"
-	// FormatYAML indicates a YAML output format
-	FormatYAML = "yaml"
-)
-
-// Interface is the interface for the spec API
-type Interface interface {
-	io.WriterTo
-	Save(string) error
-	Raw() *specs.Spec
+func (d setMinimumRequiredVersion) Transform(spec *specs.Spec) error {
+	minVersion, err := cdi.MinimumRequiredVersion(spec)
+	if err != nil {
+		return fmt.Errorf("failed to get minimum required CDI spec version: %v", err)
+	}
+	spec.Version = minVersion
+	return nil
 }

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/workarounds-device-folder-permissions.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/workarounds-device-folder-permissions.go
@@ -25,10 +25,10 @@ import (
 )
 
 type deviceFolderPermissions struct {
-	logger        logger.Interface
-	devRoot       string
-	nvidiaCTKPath string
-	devices       discover.Discover
+	logger            logger.Interface
+	devRoot           string
+	nvidiaCDIHookPath string
+	devices           discover.Discover
 }
 
 var _ discover.Discover = (*deviceFolderPermissions)(nil)
@@ -39,12 +39,12 @@ var _ discover.Discover = (*deviceFolderPermissions)(nil)
 // The nested devices that are applicable to the NVIDIA GPU devices are:
 //   - DRM devices at /dev/dri/*
 //   - NVIDIA Caps devices at /dev/nvidia-caps/*
-func newDeviceFolderPermissionHookDiscoverer(logger logger.Interface, devRoot string, nvidiaCTKPath string, devices discover.Discover) discover.Discover {
+func newDeviceFolderPermissionHookDiscoverer(logger logger.Interface, devRoot string, nvidiaCDIHookPath string, devices discover.Discover) discover.Discover {
 	d := &deviceFolderPermissions{
-		logger:        logger,
-		devRoot:       devRoot,
-		nvidiaCTKPath: nvidiaCTKPath,
-		devices:       devices,
+		logger:            logger,
+		devRoot:           devRoot,
+		nvidiaCDIHookPath: nvidiaCDIHookPath,
+		devices:           devices,
 	}
 
 	return d
@@ -70,8 +70,8 @@ func (d *deviceFolderPermissions) Hooks() ([]discover.Hook, error) {
 		args = append(args, "--path", folder)
 	}
 
-	hook := discover.CreateNvidiaCTKHook(
-		d.nvidiaCTKPath,
+	hook := discover.CreateNvidiaCDIHook(
+		d.nvidiaCDIHookPath,
 		"chmod",
 		args...,
 	)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -43,7 +43,7 @@ github.com/NVIDIA/go-nvlib/pkg/pciids
 ## explicit; go 1.20
 github.com/NVIDIA/go-nvml/pkg/dl
 github.com/NVIDIA/go-nvml/pkg/nvml
-# github.com/NVIDIA/nvidia-container-toolkit v1.15.1-0.20240419094620-0aed9a16addf
+# github.com/NVIDIA/nvidia-container-toolkit v1.15.1-0.20240528113255-e4b46a09a77e
 ## explicit; go 1.20
 github.com/NVIDIA/nvidia-container-toolkit/internal/config/image
 github.com/NVIDIA/nvidia-container-toolkit/internal/discover

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -27,7 +27,7 @@ github.com/Masterminds/squirrel
 # github.com/Microsoft/hcsshim v0.11.4
 ## explicit; go 1.18
 github.com/Microsoft/hcsshim/osversion
-# github.com/NVIDIA/go-gpuallocator v0.4.2
+# github.com/NVIDIA/go-gpuallocator v0.5.0
 ## explicit; go 1.20
 github.com/NVIDIA/go-gpuallocator/gpuallocator
 github.com/NVIDIA/go-gpuallocator/internal/links

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -31,7 +31,7 @@ github.com/Microsoft/hcsshim/osversion
 ## explicit; go 1.20
 github.com/NVIDIA/go-gpuallocator/gpuallocator
 github.com/NVIDIA/go-gpuallocator/internal/links
-# github.com/NVIDIA/go-nvlib v0.4.0
+# github.com/NVIDIA/go-nvlib v0.5.0
 ## explicit; go 1.20
 github.com/NVIDIA/go-nvlib/pkg/nvlib/device
 github.com/NVIDIA/go-nvlib/pkg/nvlib/info


### PR DESCRIPTION
This change ensures the infolib, nvmllib, and devicelib instances
are constructed once and passed by reference to functions that
need them.