### PR TITLE
Fix usage of hasConfigMap

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/_helpers.tpl
+++ b/deployments/helm/nvidia-device-plugin/templates/_helpers.tpl
@@ -217,3 +217,15 @@ Pod annotations for the plugin and GFD
 {{- end -}}
 {{- toYaml $annotations }}
 {{- end -}}
+
+
+{{/*
+Collection of typed options for the device plugin.
+
+We convert this to JSON so that it can be included and converted to an object using fromJson.
+*/}}
+{{- define "nvidia-device-plugin.options" -}}
+{{- $options := dict "" "" -}}
+{{- $_ := set $options "hasConfigMap" ( eq ( (include "nvidia-device-plugin.hasConfigMap" . ) | trim ) "true" ) -}}
+{{- mustToJson $options -}}
+{{- end -}}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -14,8 +14,8 @@
 
 {{- if .Values.devicePlugin.enabled }}
 ---
-{{- $hasConfigMap := (include "nvidia-device-plugin.hasConfigMap" .) | trim }}
-{{- $useServiceAccount := eq $hasConfigMap "true" }}
+{{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
+{{- $useServiceAccount := $options.hasConfigMap }}
 {{- $configMapName := (include "nvidia-device-plugin.configMapName" .) | trim }}
 {{- $migStrategiesAreAllNone := (include "nvidia-device-plugin.allPossibleMigStrategiesAreNone" .) | trim }}
 {{- $daemonsetName := printf "%s" (include "nvidia-device-plugin.fullname" .) | trunc 63 | trimSuffix "-" }}
@@ -56,7 +56,7 @@ spec:
       {{- if $useServiceAccount }}
       serviceAccountName: {{ include "nvidia-device-plugin.fullname" . }}-service-account
       {{- end }}
-      {{- if eq $hasConfigMap "true" }}
+      {{- if $options.hasConfigMap }}
       shareProcessNamespace: true
       initContainers:
       - image: {{ include "nvidia-device-plugin.fullimage" . }}
@@ -94,7 +94,7 @@ spec:
             mountPath: /config
       {{- end }}
       containers:
-      {{- if eq $hasConfigMap "true" }}
+      {{- if $options.hasConfigMap }}
       - image: {{ include "nvidia-device-plugin.fullimage" . }}
         name: nvidia-device-plugin-sidecar
         command: ["config-manager"]
@@ -170,7 +170,7 @@ spec:
           - name: MOFED_ENABLED
             value: "{{ .Values.mofedEnabled }}"
         {{- end }}
-        {{- if eq $hasConfigMap "true" }}
+        {{- if $options.hasConfigMap }}
           - name: CONFIG_FILE
             value: /config/config.yaml
         {{- end }}
@@ -201,7 +201,7 @@ spec:
             mountPath: /mps
           - name: cdi-root
             mountPath: /var/run/cdi
-        {{- if eq $hasConfigMap "true" }}
+        {{- if $options.hasConfigMap }}
           - name: available-configs
             mountPath: /available-configs
           - name: config
@@ -231,7 +231,7 @@ spec:
           hostPath:
             path: /var/run/cdi
             type: DirectoryOrCreate
-      {{- if eq $hasConfigMap "true" }}
+      {{- if $options.hasConfigMap }}
         - name: available-configs
           configMap:
             name: "{{ $configMapName }}"

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
@@ -14,8 +14,8 @@
 
 {{- if .Values.gfd.enabled }}
 ---
-{{- $hasConfigMap := (include "nvidia-device-plugin.hasConfigMap" .) | trim }}
-{{- $useServiceAccount := or ( eq $hasConfigMap "true" ) ( and .Values.gfd.enabled .Values.nfd.enableNodeFeatureApi ) }}
+{{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
+{{- $useServiceAccount := or ( $options.hasConfigMap ) ( and .Values.gfd.enabled .Values.nfd.enableNodeFeatureApi ) }}
 {{- $configMapName := (include "nvidia-device-plugin.configMapName" .) | trim }}
 {{- $migStrategiesAreAllNone := (include "nvidia-device-plugin.allPossibleMigStrategiesAreNone" .) | trim }}
 {{- $daemonsetName := printf "%s-gpu-feature-discovery" (include "nvidia-device-plugin.fullname" .) | trunc 63 | trimSuffix "-" }}
@@ -56,7 +56,7 @@ spec:
       {{- if $useServiceAccount }}
       serviceAccountName: {{ include "nvidia-device-plugin.fullname" . }}-service-account
       {{- end }}
-      {{- if eq $hasConfigMap "true" }}
+      {{- if $options.hasConfigMap }}
       shareProcessNamespace: true
       initContainers:
       - image: {{ include "nvidia-device-plugin.fullimage" . }}
@@ -94,7 +94,7 @@ spec:
             mountPath: /config
       {{- end }}
       containers:
-      {{- if eq $hasConfigMap "true" }}
+      {{- if $options.hasConfigMap }}
       - image: {{ include "nvidia-device-plugin.fullimage" . }}
         name: gpu-feature-discovery-sidecar
         command: ["config-manager"]
@@ -164,7 +164,7 @@ spec:
           - name: GFD_USE_NODE_FEATURE_API
             value: "{{ .Values.nfd.enableNodeFeatureApi }}"
         {{- end }}
-        {{- if eq $hasConfigMap "true" }}
+        {{- if $options.hasConfigMap }}
           - name: CONFIG_FILE
             value: /config/config.yaml
         {{- end }}
@@ -181,7 +181,7 @@ spec:
             mountPath: "/etc/kubernetes/node-feature-discovery/features.d"
           - name: host-sys
             mountPath: "/sys"
-        {{- if eq $hasConfigMap "true" }}
+        {{- if $options.hasConfigMap }}
           - name: available-configs
             mountPath: /available-configs
           - name: config
@@ -198,7 +198,7 @@ spec:
         - name: host-sys
           hostPath:
             path: "/sys"
-      {{- if eq $hasConfigMap "true" }}
+      {{- if $options.hasConfigMap }}
         - name: available-configs
           configMap:
             name: "{{ $configMapName }}"

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 {{- if .Values.devicePlugin.enabled }}
 ---
-{{- $hasConfigMap := (include "nvidia-device-plugin.hasConfigMap" .) | trim }}
+{{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
 {{- $configMapName := (include "nvidia-device-plugin.configMapName" .) | trim }}
 {{- $migStrategiesAreAllNone := (include "nvidia-device-plugin.allPossibleMigStrategiesAreNone" .) | trim }}
 {{- $daemonsetName := printf "%s-mps-control-daemon" (include "nvidia-device-plugin.fullname" .) | trunc 63 | trimSuffix "-" }}
@@ -51,7 +51,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if eq $hasConfigMap "true" }}
+      {{- if $options.hasConfigMap }}
       serviceAccountName: {{ include "nvidia-device-plugin.fullname" . }}-service-account
       shareProcessNamespace: true
       {{- end }}
@@ -69,7 +69,7 @@ spec:
         resources:
           {{- toYaml . | nindent 12 }}
         {{- end }}
-      {{- if eq $hasConfigMap "true" }}
+      {{- if $options.hasConfigMap }}
       - image: {{ include "nvidia-device-plugin.fullimage" . }}
         name: mps-control-daemon-init
         command: ["config-manager"]
@@ -105,7 +105,7 @@ spec:
             mountPath: /config
       {{- end }}
       containers:
-      {{- if eq $hasConfigMap "true" }}
+      {{- if $options.hasConfigMap }}
         # TODO: How do we synchronize the plugin and control-daemon on restart.
         - image: {{ include "nvidia-device-plugin.fullimage" . }}
           name: mps-control-daemon-sidecar
@@ -155,7 +155,7 @@ spec:
           - name: MIG_STRATEGY
             value: "{{ .Values.migStrategy }}"
         {{- end }}
-        {{- if eq $hasConfigMap "true" }}
+        {{- if $options.hasConfigMap }}
           - name: CONFIG_FILE
             value: /config/config.yaml
         {{- end }}
@@ -174,7 +174,7 @@ spec:
             mountPath: /dev/shm
           - name: mps-root
             mountPath: /mps
-          {{- if eq $hasConfigMap "true" }}
+          {{- if $options.hasConfigMap }}
           - name: available-configs
             mountPath: /available-configs
           - name: config
@@ -192,7 +192,7 @@ spec:
       - name: mps-shm
         hostPath:
           path: {{ .Values.mps.root }}/shm
-      {{- if eq $hasConfigMap "true" }}
+      {{- if $options.hasConfigMap }}
       - name: available-configs
         configMap:
           name: "{{ $configMapName }}"

--- a/deployments/helm/nvidia-device-plugin/templates/role-binding.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/role-binding.yml
@@ -1,4 +1,6 @@
-{{- if or (include "nvidia-device-plugin.hasConfigMap" .) ( and .Values.gfd.enabled .Values.nfd.enableNodeFeatureApi ) }}
+---
+{{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
+{{- if or $options.hasConfigMap ( and .Values.gfd.enabled .Values.nfd.enableNodeFeatureApi ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/deployments/helm/nvidia-device-plugin/templates/role.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/role.yml
@@ -1,4 +1,6 @@
-{{- if or (include "nvidia-device-plugin.hasConfigMap" .) ( and .Values.gfd.enabled .Values.nfd.enableNodeFeatureApi ) }}
+---
+{{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
+{{- if or $options.hasConfigMap ( and .Values.gfd.enabled .Values.nfd.enableNodeFeatureApi ) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deployments/helm/nvidia-device-plugin/templates/service-account.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/service-account.yml
@@ -1,4 +1,6 @@
-{{- if or (include "nvidia-device-plugin.hasConfigMap" .) ( and .Values.gfd.enabled .Values.nfd.enableNodeFeatureApi ) }}
+---
+{{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
+{{- if or $options.hasConfigMap ( and .Values.gfd.enabled .Values.nfd.enableNodeFeatureApi ) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
The helm include statement always generates a string. This was leading to inconsistent handling of the hasConfigMap option.

This change adds a options helper that can be used to pass derrived values as JSON so that the type information is retained when including these.

Fixes #689