### PR TITLE
Adding security context to initContainer

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -92,6 +92,8 @@ spec:
             mountPath: /available-configs
           - name: config
             mountPath: /config
+        securityContext:
+          {{- include "nvidia-device-plugin.securityContext" . | nindent 10 }}
       {{- end }}
       containers:
       {{- if $options.hasConfigMap }}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -194,6 +194,9 @@ spec:
             value: compute,utility
         securityContext:
           {{- include "nvidia-device-plugin.securityContext" . | nindent 10 }}
+          capabilities:
+            add:
+              - SYS_ADMIN
         volumeMounts:
           - name: device-plugin
             mountPath: /var/lib/kubelet/device-plugins

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -92,6 +92,10 @@ spec:
             mountPath: /available-configs
           - name: config
             mountPath: /config
+        {{- with .Values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
           {{- include "nvidia-device-plugin.securityContext" . | nindent 10 }}
       {{- end }}
@@ -130,6 +134,10 @@ spec:
             mountPath: /available-configs
           - name: config
             mountPath: /config
+        {{- with .Values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
           {{- include "nvidia-device-plugin.securityContext" . | nindent 10 }}
       {{- end }}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
@@ -92,6 +92,8 @@ spec:
             mountPath: /available-configs
           - name: config
             mountPath: /config
+        securityContext:
+          {{- include "gpu-feature-discovery.securityContext" . | nindent 10 }}
       {{- end }}
       containers:
       {{- if $options.hasConfigMap }}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
@@ -97,7 +97,7 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- include "gpu-feature-discovery.securityContext" . | nindent 10 }}
+          {{- include "nvidia-device-plugin.securityContext" . | nindent 10 }}
       {{- end }}
       containers:
       {{- if $options.hasConfigMap }}
@@ -139,7 +139,7 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         securityContext:
-          {{- include "gpu-feature-discovery.securityContext" . | nindent 10 }}
+          {{- include "nvidia-device-plugin.securityContext" . | nindent 10 }}
       {{- end }}
       - image: {{ include "nvidia-device-plugin.fullimage" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -185,7 +185,10 @@ spec:
           - name: GFD_MODE
             value: "{{ .Values.gfdMode }}"
         securityContext:
-          {{- include "gpu-feature-discovery.securityContext" . | nindent 10 }}
+          {{- include "nvidia-device-plugin.securityContext" . | nindent 10 }}
+          capabilities:
+            add:
+              - SYS_ADMIN
         volumeMounts:
           - name: output-dir
             mountPath: "/etc/kubernetes/node-feature-discovery/features.d"

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
@@ -92,6 +92,10 @@ spec:
             mountPath: /available-configs
           - name: config
             mountPath: /config
+        {{- with .Values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
           {{- include "gpu-feature-discovery.securityContext" . | nindent 10 }}
       {{- end }}
@@ -130,6 +134,10 @@ spec:
             mountPath: /available-configs
           - name: config
             mountPath: /config
+        {{- with .Values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
           {{- include "gpu-feature-discovery.securityContext" . | nindent 10 }}
       {{- end }}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -103,6 +103,10 @@ spec:
             mountPath: /available-configs
           - name: config
             mountPath: /config
+        {{- with .Values.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- end }}
       containers:
       {{- if $options.hasConfigMap }}
@@ -140,6 +144,10 @@ spec:
               mountPath: /available-configs
             - name: config
               mountPath: /config
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
       {{- end }}
         - image: {{ include "nvidia-device-plugin.fullimage" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -61,6 +61,7 @@ spec:
         command: [mps-control-daemon, mount-shm]
         securityContext:
           privileged: true
+          {{- include "mps-control-daemon.securityContext" . | nindent 10 }}
         volumeMounts:
         - name: mps-root
           mountPath: /mps
@@ -140,6 +141,8 @@ spec:
               mountPath: /available-configs
             - name: config
               mountPath: /config
+          securityContext:
+            {{- include "mps-control-daemon.securityContext" . | nindent 10 }}
       {{- end }}
         - image: {{ include "nvidia-device-plugin.fullimage" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -169,6 +172,7 @@ spec:
             value: compute,utility
           securityContext:
             privileged: true
+            {{- include "mps-control-daemon.securityContext" . | nindent 10 }}
           volumeMounts:
           - name: mps-shm
             mountPath: /dev/shm

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -98,6 +98,8 @@ spec:
           value: ""
         - name: PROCESS_TO_SIGNAL
           value: ""
+        securityContext:
+          {{- include "nvidia-device-plugin.securityContext" . | nindent 10 }}
         volumeMounts:
           - name: available-configs
             mountPath: /available-configs
@@ -139,6 +141,8 @@ spec:
             value: "1"
           - name: PROCESS_TO_SIGNAL
             value: "/usr/bin/mps-control-daemon"
+          securityContext:
+            {{- include "nvidia-device-plugin.securityContext" . | nindent 10 }}
           volumeMounts:
             - name: available-configs
               mountPath: /available-configs

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -61,7 +61,6 @@ spec:
         command: [mps-control-daemon, mount-shm]
         securityContext:
           privileged: true
-          {{- include "mps-control-daemon.securityContext" . | nindent 10 }}
         volumeMounts:
         - name: mps-root
           mountPath: /mps
@@ -141,8 +140,6 @@ spec:
               mountPath: /available-configs
             - name: config
               mountPath: /config
-          securityContext:
-            {{- include "mps-control-daemon.securityContext" . | nindent 10 }}
       {{- end }}
         - image: {{ include "nvidia-device-plugin.fullimage" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -172,7 +169,6 @@ spec:
             value: compute,utility
           securityContext:
             privileged: true
-            {{- include "mps-control-daemon.securityContext" . | nindent 10 }}
           volumeMounts:
           - name: mps-shm
             mountPath: /dev/shm

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{- if .Values.devicePlugin.enabled }}
+{{- if .Values.devicePluginMps.enabled }}
 ---
 {{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
 {{- $configMapName := (include "nvidia-device-plugin.configMapName" .) | trim }}

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -101,6 +101,9 @@ runtimeClassName: null
 
 devicePlugin:
   enabled: true
+  
+devicePluginMps:
+  enabled: true
 
 gfd:
   enabled: false


### PR DESCRIPTION
 **Changes** 

1. Adding security context to init container as keyverno policies implies that initContainer should have securityContext defined as well
2. Adding resources for every container and initContainer on each daemonset.
3. Adding property devicePluginMps in values that controlles enabling or disabling mps daemonset.