### PR TITLE
Remove provenance information from image manifests

### DIFF
--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -75,6 +75,7 @@ build-%: DOCKERFILE = $(CURDIR)/deployments/container/Dockerfile.$(DOCKERFILE_SU
 $(IMAGE_TARGETS): image-%:
 	DOCKER_BUILDKIT=1 \
 		$(DOCKER) $(BUILDX) build --pull \
+		--provenance=false --sbom=false \
 		$(DOCKER_BUILD_OPTIONS) \
 		$(DOCKER_BUILD_PLATFORM_OPTIONS) \
 		--tag $(IMAGE) \


### PR DESCRIPTION
Tools such as oc mirror do not support the provenence metadata added to the image manifests with newer docker buildx versions.

This change disables the addition of provenance information.