### PR TITLE
Set /dev/shm size from /proc/meminfo

### DIFF
--- a/cmd/mps-control-daemon/main.go
+++ b/cmd/mps-control-daemon/main.go
@@ -56,7 +56,6 @@ func main() {
 	c.Name = "NVIDIA MPS Control Daemon"
 	c.Version = info.GetVersionString()
 	c.Action = func(ctx *cli.Context) error {
-		klog.InfoS("Starting "+ctx.App.Name, "version", ctx.App.Version)
 		return start(ctx, config)
 	}
 	c.Commands = []*cli.Command{
@@ -79,7 +78,7 @@ func main() {
 	}
 	c.Flags = config.flags
 
-	klog.Infof("Starting %v %v", c.Name, c.Version)
+	klog.InfoS(c.Name, "version", c.Version)
 	err := c.Run(os.Args)
 	if err != nil {
 		klog.Error(err)

--- a/cmd/mps-control-daemon/mount/mount-shm.go
+++ b/cmd/mps-control-daemon/mount/mount-shm.go
@@ -17,22 +17,27 @@
 package mount
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
+	"strings"
 
 	"github.com/urfave/cli/v2"
+	"k8s.io/klog/v2"
 	"k8s.io/mount-utils"
 )
 
 // NewCommand constructs a mount command.
 func NewCommand() *cli.Command {
-	// Create the 'generate-cdi' command
-	return &cli.Command{
+	c := cli.Command{
 		Name:   "mount-shm",
 		Usage:  "Set up the /dev/shm mount required by the MPS daemon",
 		Action: mountShm,
 	}
+
+	return &c
 }
 
 // mountShm creates a tmpfs mount at /mps/shm to be used by the mps control daemon.
@@ -54,11 +59,50 @@ func mountShm(c *cli.Context) error {
 		return fmt.Errorf("error creating directory %v: %w", shmDir, err)
 	}
 
-	//  TODO: What should the size of the shm be
-	mountOptions := []string{"rw", "nosuid", "nodev", "noexec", "relatime", "size=65536k"}
+	sizeArg := fmt.Sprintf("size=%v", getDefaultShmSize())
+	mountOptions := []string{"rw", "nosuid", "nodev", "noexec", "relatime", sizeArg}
 	if err := mounter.Mount("shm", shmDir, "tmpfs", mountOptions); err != nil {
 		return fmt.Errorf("error mounting %v as tmpfs: %w", shmDir, err)
 	}
 
 	return nil
+}
+
+// getDefaultShmSize returns the default size for the tmpfs to be created.
+// This reads /proc/meminfo to get the total memory to calculate this. If this
+// fails a fallback size of 65536k is used.
+func getDefaultShmSize() string {
+	const fallbackSize = "65536k"
+
+	meminfo, err := os.Open("/proc/meminfo")
+	if err != nil {
+		klog.ErrorS(err, "failed to open /proc/meminfo")
+		return fallbackSize
+	}
+	defer func() {
+		_ = meminfo.Close()
+	}()
+
+	scanner := bufio.NewScanner(meminfo)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "MemTotal:") {
+			continue
+		}
+
+		parts := strings.SplitN(strings.TrimSpace(strings.TrimPrefix(line, "MemTotal:")), " ", 2)
+		memTotal, err := strconv.Atoi(parts[0])
+		if err != nil {
+			klog.ErrorS(err, "could not convert MemTotal to an integer")
+			return fallbackSize
+		}
+
+		var unit string
+		if len(parts) == 2 {
+			unit = string(parts[1][0])
+		}
+
+		return fmt.Sprintf("%d%s", memTotal/2, unit)
+	}
+	return fallbackSize
 }


### PR DESCRIPTION
This change reads MemTotal from /proc/meminfo and sets
the dev/shm size to half this value. This aligns with the
default for creating tmpfs mounts.

If reading the value fails, the previous default of 65536k is used.