### PR TITLE
Bump golang to 1.22.4

### DIFF
--- a/versions.mk
+++ b/versions.mk
@@ -22,7 +22,7 @@ VERSION ?= v0.16.0-rc.1
 # vVERSION represents the version with a guaranteed v-prefix
 vVERSION := v$(VERSION:v%=%)
 
-GOLANG_VERSION ?= 1.22.2
+GOLANG_VERSION ?= 1.22.4
 
 BUILDIMAGE_TAG ?= devel-go$(GOLANG_VERSION)
 BUILDIMAGE ?=  ghcr.io/nvidia/k8s-test-infra:$(BUILDIMAGE_TAG)


### PR DESCRIPTION
This is requried to address https://nvd.nist.gov/vuln/detail/CVE-2024-24790