### PR TITLE
Accept kubelet socket from command line

### DIFF
--- a/cmd/nvidia-device-plugin/plugin-manager.go
+++ b/cmd/nvidia-device-plugin/plugin-manager.go
@@ -29,7 +29,7 @@ import (
 )
 
 // NewPluginManager creates an NVML-based plugin manager
-func NewPluginManager(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interface, config *spec.Config) (manager.Interface, error) {
+func NewPluginManager(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interface, kubeletSocket string, config *spec.Config) (manager.Interface, error) {
 	var err error
 	switch *config.Flags.MigStrategy {
 	case spec.MigStrategyNone:
@@ -67,6 +67,7 @@ func NewPluginManager(infolib info.Interface, nvmllib nvml.Interface, devicelib 
 		manager.WithCDIHandler(cdiHandler),
 		manager.WithConfig(config),
 		manager.WithFailOnInitError(*config.Flags.FailOnInitError),
+		manager.WithKubeletSocket(kubeletSocket),
 		manager.WithMigStrategy(*config.Flags.MigStrategy),
 	)
 	if err != nil {

--- a/internal/plugin/manager/factory.go
+++ b/internal/plugin/manager/factory.go
@@ -38,6 +38,8 @@ type manager struct {
 
 	cdiHandler cdi.Interface
 	config     *spec.Config
+
+	kubeletSocket string
 }
 
 // New creates a new plugin manager with the supplied options.

--- a/internal/plugin/manager/nvml.go
+++ b/internal/plugin/manager/nvml.go
@@ -34,7 +34,7 @@ func (m *nvmlmanager) GetPlugins() ([]plugin.Interface, error) {
 
 	var plugins []plugin.Interface
 	for _, r := range rms {
-		plugin, err := plugin.NewNvidiaDevicePlugin(m.config, r, m.cdiHandler)
+		plugin, err := plugin.NewNvidiaDevicePlugin(m.config, m.kubeletSocket, r, m.cdiHandler)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create plugin: %w", err)
 		}

--- a/internal/plugin/manager/options.go
+++ b/internal/plugin/manager/options.go
@@ -68,3 +68,9 @@ func WithConfig(config *spec.Config) Option {
 		m.config = config
 	}
 }
+
+func WithKubeletSocket(kubeletSocket string) Option {
+	return func(m *manager) {
+		m.kubeletSocket = kubeletSocket
+	}
+}

--- a/internal/plugin/manager/tegra.go
+++ b/internal/plugin/manager/tegra.go
@@ -34,7 +34,7 @@ func (m *tegramanager) GetPlugins() ([]plugin.Interface, error) {
 
 	var plugins []plugin.Interface
 	for _, r := range rms {
-		plugin, err := plugin.NewNvidiaDevicePlugin(m.config, r, m.cdiHandler)
+		plugin, err := plugin.NewNvidiaDevicePlugin(m.config, m.kubeletSocket, r, m.cdiHandler)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create plugin: %w", err)
 		}


### PR DESCRIPTION
This also makes it possible to test device plugin logic that does not depend on the kubelet.