### PR TITLE
Use go to manage build image dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,13 @@ updates:
     - dependencies
     - maintenance
 
+  - package-ecosystem: "gomod"
+    target-branch: main
+    directory: "deployments/devel"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -51,26 +51,34 @@ jobs:
     - name: Check golang modules
       run: make check-vendor
   test:
-      name: Unit test
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout code
-          uses: actions/checkout@v4
-        - name: Get Golang version
-          id: vars
-          run: |
-            GOLANG_VERSION=$( grep "GOLANG_VERSION ?=" versions.mk )
-            echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION ?= }" >> $GITHUB_ENV
-        - name: Install Go
-          uses: actions/setup-go@v5
-          with:
-            go-version: ${{ env.GOLANG_VERSION }}
-        - run: make test
-  build:
+    name: Unit test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-      name: Checkout code
-
-    - name: Build
-      run: make docker-build
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Get Golang version
+        id: vars
+        run: |
+          GOLANG_VERSION=$( grep "GOLANG_VERSION ?=" versions.mk )
+          echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION ?= }" >> $GITHUB_ENV
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+      - run: make test
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Get Golang version
+        id: vars
+        run: |
+          GOLANG_VERSION=$( grep "GOLANG_VERSION ?=" versions.mk )
+          echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION ?= }" >> $GITHUB_ENV
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
+      - run: make build

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,18 @@ coverage: test
 generate:
 	go generate $(MODULE)/...
 
+
+# Generate an image for containerized builds
+# Note: This image is local only
+.PHONY: .build-image
+.build-image:
+	make -f deployments/devel/Makefile .build-image
+
+ifeq ($(BUILD_DEVEL_IMAGE),yes)
+$(DOCKER_TARGETS): .build-image
+.shell: .build-image
+endif
+
 $(DOCKER_TARGETS): docker-%:
 	@echo "Running 'make $(*)' in container image $(BUILDIMAGE)"
 	$(DOCKER) run \

--- a/demo/clusters/kind/scripts/build-plugin-image.sh
+++ b/demo/clusters/kind/scripts/build-plugin-image.sh
@@ -35,7 +35,7 @@ cd ${PROJECT_DIR}
 
 # Regenerate the CRDs and build the container image
 # TODO: This should be part of the image name
-make docker-generate
+make docker-generate BUILD_DEVEL_IMAGE=yes
 make -f deployments/container/Makefile build
 
 cd ${CURRENT_DIR}

--- a/deployments/devel/Dockerfile
+++ b/deployments/devel/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,19 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DRIVER_NAME := k8s-device-plugin
-MODULE := github.com/NVIDIA/$(DRIVER_NAME)
+ARG GOLANG_VERSION=x.x.x
+FROM golang:${GOLANG_VERSION}
 
-REGISTRY ?= nvcr.io/nvidia
+WORKDIR /work
+COPY * .
 
-VERSION ?= v0.16.0-rc.1
+RUN make install-tools
 
-# vVERSION represents the version with a guaranteed v-prefix
-vVERSION := v$(VERSION:v%=%)
+# We need to set the /work directory as a safe directory.
+# This allows git commands to run in the container.
+RUN git config --file=/.gitconfig --add safe.directory /work
 
-GOLANG_VERSION ?= 1.22.4
-
-BUILDIMAGE_TAG ?= devel-go$(GOLANG_VERSION)
-BUILDIMAGE ?=  $(DRIVER_NAME):$(BUILDIMAGE_TAG)
-
-GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always --abbrev=40 2> /dev/null || echo "")

--- a/deployments/devel/Makefile
+++ b/deployments/devel/Makefile
@@ -1,0 +1,37 @@
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+download:
+	@echo Download go.mod dependencies
+	@go mod download
+
+install-tools: download
+	@echo Installing tools from tools.go
+	@cat tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI % go install %
+
+
+DOCKER ?= docker
+-include $(CURDIR)/versions.mk
+
+DOCKERFILE_DEVEL = deployments/devel/Dockerfile
+DOCKERFILE_CONTEXT = deployments/devel
+
+.PHONY: .build-image
+.build-image:
+	$(DOCKER) build \
+		--progress=plain \
+		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
+		--tag $(BUILDIMAGE) \
+		-f $(DOCKERFILE_DEVEL) \
+		$(DOCKERFILE_CONTEXT)

--- a/deployments/devel/go.mod
+++ b/deployments/devel/go.mod
@@ -1,0 +1,10 @@
+module github.com/NVIDIA/k8s-device-plugin/deployments/devel
+
+go 1.22
+
+require github.com/matryer/moq v0.3.3
+
+require (
+	golang.org/x/mod v0.14.0 // indirect
+	golang.org/x/tools v0.17.0 // indirect
+)

--- a/deployments/devel/go.sum
+++ b/deployments/devel/go.sum
@@ -1,0 +1,10 @@
+github.com/matryer/moq v0.3.3 h1:pScMH9VyrdT4S93yiLpVyU8rCDqGQr24uOyBxmktG5Q=
+github.com/matryer/moq v0.3.3/go.mod h1:RJ75ZZZD71hejp39j4crZLsEDszGk6iH4v4YsWFKH4s=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=
+golang.org/x/sync v0.6.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/tools v0.17.0 h1:FvmRgNOcs3kOa+T20R1uhfP9F6HgG2mfxDv1vrx1Htc=
+golang.org/x/tools v0.17.0/go.mod h1:xsh6VxdV005rRVaS6SSAf9oiAqljS7UZUacMZ8Bnsps=

--- a/deployments/devel/tools.go
+++ b/deployments/devel/tools.go
@@ -1,4 +1,8 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+//go:build tools
+// +build tools
+
+/**
+# Copyright 2024 NVIDIA CORPORATION
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,20 +15,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+**/
 
-DRIVER_NAME := k8s-device-plugin
-MODULE := github.com/NVIDIA/$(DRIVER_NAME)
+package main
 
-REGISTRY ?= nvcr.io/nvidia
-
-VERSION ?= v0.16.0-rc.1
-
-# vVERSION represents the version with a guaranteed v-prefix
-vVERSION := v$(VERSION:v%=%)
-
-GOLANG_VERSION ?= 1.22.4
-
-BUILDIMAGE_TAG ?= devel-go$(GOLANG_VERSION)
-BUILDIMAGE ?=  $(DRIVER_NAME):$(BUILDIMAGE_TAG)
-
-GIT_COMMIT ?= $(shell git describe --match="" --dirty --long --always --abbrev=40 2> /dev/null || echo "")
+// Define the tooling required to build the device plugin.
+import (
+	_ "github.com/matryer/moq"
+)


### PR DESCRIPTION
This change manages tooling dependencies using go instead of relying on the k8s-test-infra image.

This allows for the image and tooling dependencies to be updated independently.