### PR TITLE
Use reduced ubi8 base image

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG GOLANG_VERSION=1.22.6
-FROM nvidia/cuda:12.6.0-base-ubi8 as build
+FROM nvcr.io/nvidia/cuda:12.6.0-base-ubi8 AS build
 
 RUN yum install -y \
     wget make git gcc \
@@ -44,10 +44,28 @@ ARG VERSION="N/A"
 ARG GIT_COMMIT="unknown"
 RUN make PREFIX=/artifacts cmds
 
-FROM nvidia/cuda:12.6.0-base-ubi8
+# We use the ubi8-minimal image as a reference image in removing unneeded dependencies.
+FROM redhat/ubi8-minimal:latest AS minimal
 
-# Remove CUDA libs(compat etc) in favor of libs installed by the NVIDIA driver
-RUN dnf remove -y cuda-*
+RUN rpm -qa --queryformat='^%{NAME}-\[0-9\].*\.%{ARCH}$\n' | sort -u > /tmp/package-names.minimal
+RUN rpm -qa | sort -u > /tmp/package-list.minimal
+
+# We define the following image as a base image and remove unneeded packages.
+FROM nvcr.io/nvidia/cuda:12.6.0-base-ubi8 AS base
+
+WORKDIR /cleanup
+
+COPY --from=minimal /tmp/package-names.minimal package-names.minimal
+COPY --from=minimal /tmp/package-list.minimal package-list.minimal
+COPY deployments/container/cleanup/* .
+
+RUN ./cleanup.sh
+
+WORKDIR /
+
+# We use the base images constructed above.
+# TODO: We will move to a shared base image once this implementation has been stabilized.
+FROM base
 
 ENV NVIDIA_DISABLE_REQUIRE="true"
 ENV NVIDIA_VISIBLE_DEVICES=all

--- a/deployments/container/cleanup/cleanup.sh
+++ b/deployments/container/cleanup/cleanup.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express orimplied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -x
+
+rpm -qa | sort -u > package-list.original
+
+echo "install_weak_deps=False" >> /etc/dnf/dnf.conf
+rm -f /etc/dnf/protected.d/*.conf
+
+rm -f /etc/yum.repos.d/cuda.repo
+rm -f /etc/ld.so.conf.d/nvidia.conf
+
+dnf remove -y \
+    cuda* \
+    systemd
+
+# Remove the CUDA public key
+for key in $(rpm -qa gpg-pubkey*); do
+    rpm -qi ${key} | grep -o "cudatools <cudatools@nvidia.com>"
+    if [[ $? -eq 0 ]]; then
+        rpm -e ${key}
+    fi
+done
+
+dnf clean all
+rm -rf /var/cache/dnf
+
+dnf install -y microdnf
+
+microdnf remove $(rpm -q --whatrequires dnf)
+rpm -e dnf
+
+microdnf remove \
+    $(rpm -q --whatrequires /usr/libexec/platform-python) \
+    $(rpm -q --whatrequires 'python(abi)') \
+    python* \
+    dnf*
+
+microdnf remove \
+    $(rpm -qa | sort | grep -v -f package-names.minimal -e gpg-pubkey)
+
+# We don't want to add third-party content to the base image and only remove packages.
+# We therefore skip running microdnf update here
+# microdnf update
+
+microdnf clean all
+rpm -e microdnf libdnf libpeas
+rm -rf /var/lib/dnf
+
+set +x
+rpm -qa | sort -u > package-list.cleaned
+for p in $(rpm -qa | sort -u); do
+    echo "START $p" >> package-list.cleaned.info
+    echo "INFO" >> package-list.cleaned.info
+    rpm -qi $p >> package-list.cleaned.info
+    echo "REQUIRES" >> package-list.cleaned.info
+    rpm -qR $p >> package-list.cleaned.info
+    echo "END $p" >>  package-list.cleaned.info
+done
+
+rm -rf /var/cache/dnf


### PR DESCRIPTION
These changes apply a set of transforms / cleanups to the CUDA ubi8 base to remove unneeded packages.