### PR TITLE
[no-relnotes] Use dependabot to update go toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,13 @@ updates:
       interval: "weekly"
       day: "sunday"
 
+  # A dependabot rule to bump the golang version.
+  - package-ecosystem: "docker"
+    target-branch: main
+    directory: "/deployments/devel"
+    schedule:
+      interval: "daily"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -36,8 +36,8 @@ jobs:
     - name: Get Golang version
       id: vars
       run: |
-        GOLANG_VERSION=$( grep "GOLANG_VERSION ?=" versions.mk )
-        echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION ?= }" >> $GITHUB_ENV
+        GOLANG_VERSION=$(./hack/golang-version.sh)
+        echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION := }" >> $GITHUB_ENV
     - name: Install Go
       uses: actions/setup-go@v5
       with:
@@ -54,31 +54,31 @@ jobs:
     name: Unit test
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Get Golang version
-        id: vars
-        run: |
-          GOLANG_VERSION=$( grep "GOLANG_VERSION ?=" versions.mk )
-          echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION ?= }" >> $GITHUB_ENV
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GOLANG_VERSION }}
-      - run: make test
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Get Golang version
+      id: vars
+      run: |
+        GOLANG_VERSION=$(./hack/golang-version.sh)
+        echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION ?= }" >> $GITHUB_ENV
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GOLANG_VERSION }}
+    - run: make test
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Get Golang version
-        id: vars
-        run: |
-          GOLANG_VERSION=$( grep "GOLANG_VERSION ?=" versions.mk )
-          echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION ?= }" >> $GITHUB_ENV
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GOLANG_VERSION }}
-      - run: make build
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Get Golang version
+      id: vars
+      run: |
+        GOLANG_VERSION=$(./hack/golang-version.sh)
+        echo "GOLANG_VERSION=${GOLANG_VERSION##GOLANG_VERSION ?= }" >> $GITHUB_ENV
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GOLANG_VERSION }}
+    - run: make build

--- a/hack/golang-version.sh
+++ b/hack/golang-version.sh
@@ -1,4 +1,5 @@
-# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#!/bin/bash
+# Copyright 2024 NVIDIA CORPORATION
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,16 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This Dockerfile is also used to define the golang version used in this project
-# This allows dependabot to manage this version in addition to other images.
-FROM golang:1.22.4
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-WORKDIR /work
-COPY * .
+DOCKERFILE_ROOT=${SCRIPTS_DIR}/../deployments/devel
 
-RUN make install-tools
+GOLANG_VERSION=$(grep -E "^FROM golang:.*$" ${DOCKERFILE_ROOT}/Dockerfile | grep -oE "[0-9\.]+")
 
-# We need to set the /work directory as a safe directory.
-# This allows git commands to run in the container.
-RUN git config --file=/.gitconfig --add safe.directory /work
-
+echo $GOLANG_VERSION

--- a/versions.mk
+++ b/versions.mk
@@ -22,7 +22,7 @@ VERSION ?= v0.16.0-rc.1
 # vVERSION represents the version with a guaranteed v-prefix
 vVERSION := v$(VERSION:v%=%)
 
-GOLANG_VERSION ?= 1.22.4
+GOLANG_VERSION := $(shell ./hack/golang-version.sh)
 
 BUILDIMAGE_TAG ?= devel-go$(GOLANG_VERSION)
 BUILDIMAGE ?=  $(DRIVER_NAME):$(BUILDIMAGE_TAG)


### PR DESCRIPTION
This change uses Dependabot to update the golang toolcain.

The `deployments/devel/Dockfile` is used as a reference for defining the golang version through the `FROM` clause.