### PR TITLE
Add node name environment variable to the GFD deployments

### DIFF
--- a/deployments/static/gpu-feature-discovery-daemonset-with-mig-mixed.yaml
+++ b/deployments/static/gpu-feature-discovery-daemonset-with-mig-mixed.yaml
@@ -32,6 +32,10 @@ spec:
               value: all
             - name: MIG_STRATEGY
               value: mixed
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           securityContext:
             privileged: true
       affinity:

--- a/deployments/static/gpu-feature-discovery-daemonset-with-mig-single.yaml
+++ b/deployments/static/gpu-feature-discovery-daemonset-with-mig-single.yaml
@@ -32,6 +32,10 @@ spec:
               value: all
             - name: MIG_STRATEGY
               value: single
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           securityContext:
             privileged: true
       affinity:

--- a/deployments/static/gpu-feature-discovery-daemonset.yaml
+++ b/deployments/static/gpu-feature-discovery-daemonset.yaml
@@ -32,6 +32,10 @@ spec:
           env:
             - name: MIG_STRATEGY
               value: none
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Without the `NODE_NAME` environment variable, GFD was failing to start with an error. The `NODE_NAME` env var was present in the helm chart but was missing in the static deployments. This change adds the missing `NODE_NAME` env var to the static deployment.