### PR TITLE
[no-relnote] Change context during E2E call

### DIFF
--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -31,7 +31,7 @@ e2e-test:
 		echo "[ERR] KUBECONFIG missing, must be defined"; \
 		exit 1; \
 	fi
-	$(GO_CMD) test -v $(CURDIR)/tests/e2e -args \
+	cd $(CURDIR)/tests/e2e && $(GO_CMD) test -v . -args \
 		-kubeconfig=$(KUBECONFIG) \
 		-driver-enabled=$(DRIVER_ENABLED) \
 		-image.repo=$(E2E_IMAGE_REPO) \


### PR DESCRIPTION
This PR enables E2E after https://github.com/NVIDIA/k8s-device-plugin/pull/855 