### PR TITLE
[no-relnote] Increase timeout for GPU job test to 10 minutes

### DIFF
--- a/tests/e2e/device-plugin_test.go
+++ b/tests/e2e/device-plugin_test.go
@@ -37,6 +37,10 @@ import (
 	"github.com/NVIDIA/k8s-device-plugin/tests/e2e/framework"
 )
 
+const (
+	devicePluginEventuallyTimeout = 10 * time.Minute
+)
+
 // Actual test suite
 var _ = NVDescribe("GPU Device Plugin", func() {
 	f := framework.NewFramework("k8s-device-plugin")
@@ -177,7 +181,7 @@ var _ = NVDescribe("GPU Device Plugin", func() {
 						return nil
 					}
 					return fmt.Errorf("job %s/%s not completed yet", job.Namespace, job.Name)
-				}, 5*time.Minute, 5*time.Second).Should(BeNil())
+				}, devicePluginEventuallyTimeout, 5*time.Second).Should(BeNil())
 			})
 		})
 	})


### PR DESCRIPTION
The device plugin e2e tests regularly fail due to a timeout of 5 minutes:
```
[FAILED] Timed out after 300.001s.
```
This introduced flakiness into the tests. 

This change increased the timeout for the device plugin job checks to 10 minutes instead.