### PR TITLE
update default go version of the main container image

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GOLANG_VERSION=1.20.5
+ARG GOLANG_VERSION=1.22.6
 FROM nvidia/cuda:12.6.0-base-ubi8 as build
 
 RUN yum install -y \


### PR DESCRIPTION
As the go.mod file pins the minimum go version to 1.22.2, it no longer makes sense for the container's default go version to be a values lesser than that. Sp we bump the default golang build arg to 1.22.6


Signed-off-by: Tariq Ibrahim <tibrahim@nvidia.com>