### PR TITLE
Use SELinux package to apply context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/google/renameio v1.0.1
 	github.com/google/uuid v1.6.0
+	github.com/opencontainers/selinux v1.11.0
 	github.com/prometheus/procfs v0.15.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.9.0

--- a/vendor/github.com/opencontainers/selinux/LICENSE
+++ b/vendor/github.com/opencontainers/selinux/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/opencontainers/selinux/go-selinux/doc.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/doc.go
@@ -1,0 +1,13 @@
+/*
+Package selinux provides a high-level interface for interacting with selinux.
+
+Usage:
+
+	import "github.com/opencontainers/selinux/go-selinux"
+
+	// Ensure that selinux is enforcing mode.
+	if selinux.EnforceMode() != selinux.Enforcing {
+		selinux.SetEnforceMode(selinux.Enforcing)
+	}
+*/
+package selinux

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux.go
@@ -1,0 +1,314 @@
+package selinux
+
+import (
+	"errors"
+)
+
+const (
+	// Enforcing constant indicate SELinux is in enforcing mode
+	Enforcing = 1
+	// Permissive constant to indicate SELinux is in permissive mode
+	Permissive = 0
+	// Disabled constant to indicate SELinux is disabled
+	Disabled = -1
+	// maxCategory is the maximum number of categories used within containers
+	maxCategory = 1024
+	// DefaultCategoryRange is the upper bound on the category range
+	DefaultCategoryRange = uint32(maxCategory)
+)
+
+var (
+	// ErrMCSAlreadyExists is returned when trying to allocate a duplicate MCS.
+	ErrMCSAlreadyExists = errors.New("MCS label already exists")
+	// ErrEmptyPath is returned when an empty path has been specified.
+	ErrEmptyPath = errors.New("empty path")
+
+	// ErrInvalidLabel is returned when an invalid label is specified.
+	ErrInvalidLabel = errors.New("invalid Label")
+
+	// InvalidLabel is returned when an invalid label is specified.
+	//
+	// Deprecated: use [ErrInvalidLabel].
+	InvalidLabel = ErrInvalidLabel
+
+	// ErrIncomparable is returned two levels are not comparable
+	ErrIncomparable = errors.New("incomparable levels")
+	// ErrLevelSyntax is returned when a sensitivity or category do not have correct syntax in a level
+	ErrLevelSyntax = errors.New("invalid level syntax")
+
+	// ErrContextMissing is returned if a requested context is not found in a file.
+	ErrContextMissing = errors.New("context does not have a match")
+	// ErrVerifierNil is returned when a context verifier function is nil.
+	ErrVerifierNil = errors.New("verifier function is nil")
+
+	// CategoryRange allows the upper bound on the category range to be adjusted
+	CategoryRange = DefaultCategoryRange
+
+	privContainerMountLabel string
+)
+
+// Context is a representation of the SELinux label broken into 4 parts
+type Context map[string]string
+
+// SetDisabled disables SELinux support for the package
+func SetDisabled() {
+	setDisabled()
+}
+
+// GetEnabled returns whether SELinux is currently enabled.
+func GetEnabled() bool {
+	return getEnabled()
+}
+
+// ClassIndex returns the int index for an object class in the loaded policy,
+// or -1 and an error
+func ClassIndex(class string) (int, error) {
+	return classIndex(class)
+}
+
+// SetFileLabel sets the SELinux label for this path, following symlinks,
+// or returns an error.
+func SetFileLabel(fpath string, label string) error {
+	return setFileLabel(fpath, label)
+}
+
+// LsetFileLabel sets the SELinux label for this path, not following symlinks,
+// or returns an error.
+func LsetFileLabel(fpath string, label string) error {
+	return lSetFileLabel(fpath, label)
+}
+
+// FileLabel returns the SELinux label for this path, following symlinks,
+// or returns an error.
+func FileLabel(fpath string) (string, error) {
+	return fileLabel(fpath)
+}
+
+// LfileLabel returns the SELinux label for this path, not following symlinks,
+// or returns an error.
+func LfileLabel(fpath string) (string, error) {
+	return lFileLabel(fpath)
+}
+
+// SetFSCreateLabel tells the kernel what label to use for all file system objects
+// created by this task.
+// Set the label to an empty string to return to the default label. Calls to SetFSCreateLabel
+// should be wrapped in runtime.LockOSThread()/runtime.UnlockOSThread() until file system
+// objects created by this task are finished to guarantee another goroutine does not migrate
+// to the current thread before execution is complete.
+func SetFSCreateLabel(label string) error {
+	return setFSCreateLabel(label)
+}
+
+// FSCreateLabel returns the default label the kernel which the kernel is using
+// for file system objects created by this task. "" indicates default.
+func FSCreateLabel() (string, error) {
+	return fsCreateLabel()
+}
+
+// CurrentLabel returns the SELinux label of the current process thread, or an error.
+func CurrentLabel() (string, error) {
+	return currentLabel()
+}
+
+// PidLabel returns the SELinux label of the given pid, or an error.
+func PidLabel(pid int) (string, error) {
+	return pidLabel(pid)
+}
+
+// ExecLabel returns the SELinux label that the kernel will use for any programs
+// that are executed by the current process thread, or an error.
+func ExecLabel() (string, error) {
+	return execLabel()
+}
+
+// CanonicalizeContext takes a context string and writes it to the kernel
+// the function then returns the context that the kernel will use. Use this
+// function to check if two contexts are equivalent
+func CanonicalizeContext(val string) (string, error) {
+	return canonicalizeContext(val)
+}
+
+// ComputeCreateContext requests the type transition from source to target for
+// class from the kernel.
+func ComputeCreateContext(source string, target string, class string) (string, error) {
+	return computeCreateContext(source, target, class)
+}
+
+// CalculateGlbLub computes the glb (greatest lower bound) and lub (least upper bound)
+// of a source and target range.
+// The glblub is calculated as the greater of the low sensitivities and
+// the lower of the high sensitivities and the and of each category bitset.
+func CalculateGlbLub(sourceRange, targetRange string) (string, error) {
+	return calculateGlbLub(sourceRange, targetRange)
+}
+
+// SetExecLabel sets the SELinux label that the kernel will use for any programs
+// that are executed by the current process thread, or an error. Calls to SetExecLabel
+// should  be wrapped in runtime.LockOSThread()/runtime.UnlockOSThread() until execution
+// of the program is finished to guarantee another goroutine does not migrate to the current
+// thread before execution is complete.
+func SetExecLabel(label string) error {
+	return writeCon(attrPath("exec"), label)
+}
+
+// SetTaskLabel sets the SELinux label for the current thread, or an error.
+// This requires the dyntransition permission. Calls to SetTaskLabel should
+// be wrapped in runtime.LockOSThread()/runtime.UnlockOSThread() to guarantee
+// the current thread does not run in a new mislabeled thread.
+func SetTaskLabel(label string) error {
+	return writeCon(attrPath("current"), label)
+}
+
+// SetSocketLabel takes a process label and tells the kernel to assign the
+// label to the next socket that gets created. Calls to SetSocketLabel
+// should be wrapped in runtime.LockOSThread()/runtime.UnlockOSThread() until
+// the socket is created to guarantee another goroutine does not migrate
+// to the current thread before execution is complete.
+func SetSocketLabel(label string) error {
+	return writeCon(attrPath("sockcreate"), label)
+}
+
+// SocketLabel retrieves the current socket label setting
+func SocketLabel() (string, error) {
+	return readCon(attrPath("sockcreate"))
+}
+
+// PeerLabel retrieves the label of the client on the other side of a socket
+func PeerLabel(fd uintptr) (string, error) {
+	return peerLabel(fd)
+}
+
+// SetKeyLabel takes a process label and tells the kernel to assign the
+// label to the next kernel keyring that gets created. Calls to SetKeyLabel
+// should be wrapped in runtime.LockOSThread()/runtime.UnlockOSThread() until
+// the kernel keyring is created to guarantee another goroutine does not migrate
+// to the current thread before execution is complete.
+func SetKeyLabel(label string) error {
+	return setKeyLabel(label)
+}
+
+// KeyLabel retrieves the current kernel keyring label setting
+func KeyLabel() (string, error) {
+	return readCon("/proc/self/attr/keycreate")
+}
+
+// Get returns the Context as a string
+func (c Context) Get() string {
+	return c.get()
+}
+
+// NewContext creates a new Context struct from the specified label
+func NewContext(label string) (Context, error) {
+	return newContext(label)
+}
+
+// ClearLabels clears all reserved labels
+func ClearLabels() {
+	clearLabels()
+}
+
+// ReserveLabel reserves the MLS/MCS level component of the specified label
+func ReserveLabel(label string) {
+	reserveLabel(label)
+}
+
+// MLSEnabled checks if MLS is enabled.
+func MLSEnabled() bool {
+	return isMLSEnabled()
+}
+
+// EnforceMode returns the current SELinux mode Enforcing, Permissive, Disabled
+func EnforceMode() int {
+	return enforceMode()
+}
+
+// SetEnforceMode sets the current SELinux mode Enforcing, Permissive.
+// Disabled is not valid, since this needs to be set at boot time.
+func SetEnforceMode(mode int) error {
+	return setEnforceMode(mode)
+}
+
+// DefaultEnforceMode returns the systems default SELinux mode Enforcing,
+// Permissive or Disabled. Note this is just the default at boot time.
+// EnforceMode tells you the systems current mode.
+func DefaultEnforceMode() int {
+	return defaultEnforceMode()
+}
+
+// ReleaseLabel un-reserves the MLS/MCS Level field of the specified label,
+// allowing it to be used by another process.
+func ReleaseLabel(label string) {
+	releaseLabel(label)
+}
+
+// ROFileLabel returns the specified SELinux readonly file label
+func ROFileLabel() string {
+	return roFileLabel()
+}
+
+// KVMContainerLabels returns the default processLabel and mountLabel to be used
+// for kvm containers by the calling process.
+func KVMContainerLabels() (string, string) {
+	return kvmContainerLabels()
+}
+
+// InitContainerLabels returns the default processLabel and file labels to be
+// used for containers running an init system like systemd by the calling process.
+func InitContainerLabels() (string, string) {
+	return initContainerLabels()
+}
+
+// ContainerLabels returns an allocated processLabel and fileLabel to be used for
+// container labeling by the calling process.
+func ContainerLabels() (processLabel string, fileLabel string) {
+	return containerLabels()
+}
+
+// SecurityCheckContext validates that the SELinux label is understood by the kernel
+func SecurityCheckContext(val string) error {
+	return securityCheckContext(val)
+}
+
+// CopyLevel returns a label with the MLS/MCS level from src label replaced on
+// the dest label.
+func CopyLevel(src, dest string) (string, error) {
+	return copyLevel(src, dest)
+}
+
+// Chcon changes the fpath file object to the SELinux label.
+// If fpath is a directory and recurse is true, then Chcon walks the
+// directory tree setting the label.
+//
+// The fpath itself is guaranteed to be relabeled last.
+func Chcon(fpath string, label string, recurse bool) error {
+	return chcon(fpath, label, recurse)
+}
+
+// DupSecOpt takes an SELinux process label and returns security options that
+// can be used to set the SELinux Type and Level for future container processes.
+func DupSecOpt(src string) ([]string, error) {
+	return dupSecOpt(src)
+}
+
+// DisableSecOpt returns a security opt that can be used to disable SELinux
+// labeling support for future container processes.
+func DisableSecOpt() []string {
+	return []string{"disable"}
+}
+
+// GetDefaultContextWithLevel gets a single context for the specified SELinux user
+// identity that is reachable from the specified scon context. The context is based
+// on the per-user /etc/selinux/{SELINUXTYPE}/contexts/users/<username> if it exists,
+// and falls back to the global /etc/selinux/{SELINUXTYPE}/contexts/default_contexts
+// file.
+func GetDefaultContextWithLevel(user, level, scon string) (string, error) {
+	return getDefaultContextWithLevel(user, level, scon)
+}
+
+// PrivContainerMountLabel returns mount label for privileged containers
+func PrivContainerMountLabel() string {
+	// Make sure label is initialized.
+	_ = label("")
+	return privContainerMountLabel
+}

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
@@ -1,0 +1,1295 @@
+package selinux
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"math/big"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/opencontainers/selinux/pkg/pwalkdir"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	minSensLen       = 2
+	contextFile      = "/usr/share/containers/selinux/contexts"
+	selinuxDir       = "/etc/selinux/"
+	selinuxUsersDir  = "contexts/users"
+	defaultContexts  = "contexts/default_contexts"
+	selinuxConfig    = selinuxDir + "config"
+	selinuxfsMount   = "/sys/fs/selinux"
+	selinuxTypeTag   = "SELINUXTYPE"
+	selinuxTag       = "SELINUX"
+	xattrNameSelinux = "security.selinux"
+)
+
+type selinuxState struct {
+	mcsList       map[string]bool
+	selinuxfs     string
+	selinuxfsOnce sync.Once
+	enabledSet    bool
+	enabled       bool
+	sync.Mutex
+}
+
+type level struct {
+	cats *big.Int
+	sens uint
+}
+
+type mlsRange struct {
+	low  *level
+	high *level
+}
+
+type defaultSECtx struct {
+	userRdr           io.Reader
+	verifier          func(string) error
+	defaultRdr        io.Reader
+	user, level, scon string
+}
+
+type levelItem byte
+
+const (
+	sensitivity levelItem = 's'
+	category    levelItem = 'c'
+)
+
+var (
+	readOnlyFileLabel string
+	state             = selinuxState{
+		mcsList: make(map[string]bool),
+	}
+
+	// for attrPath()
+	attrPathOnce   sync.Once
+	haveThreadSelf bool
+
+	// for policyRoot()
+	policyRootOnce sync.Once
+	policyRootVal  string
+
+	// for label()
+	loadLabelsOnce sync.Once
+	labels         map[string]string
+)
+
+func policyRoot() string {
+	policyRootOnce.Do(func() {
+		policyRootVal = filepath.Join(selinuxDir, readConfig(selinuxTypeTag))
+	})
+
+	return policyRootVal
+}
+
+func (s *selinuxState) setEnable(enabled bool) bool {
+	s.Lock()
+	defer s.Unlock()
+	s.enabledSet = true
+	s.enabled = enabled
+	return s.enabled
+}
+
+func (s *selinuxState) getEnabled() bool {
+	s.Lock()
+	enabled := s.enabled
+	enabledSet := s.enabledSet
+	s.Unlock()
+	if enabledSet {
+		return enabled
+	}
+
+	enabled = false
+	if fs := getSelinuxMountPoint(); fs != "" {
+		if con, _ := CurrentLabel(); con != "kernel" {
+			enabled = true
+		}
+	}
+	return s.setEnable(enabled)
+}
+
+// setDisabled disables SELinux support for the package
+func setDisabled() {
+	state.setEnable(false)
+}
+
+func verifySELinuxfsMount(mnt string) bool {
+	var buf unix.Statfs_t
+	for {
+		err := unix.Statfs(mnt, &buf)
+		if err == nil {
+			break
+		}
+		if err == unix.EAGAIN || err == unix.EINTR { //nolint:errorlint // unix errors are bare
+			continue
+		}
+		return false
+	}
+
+	if uint32(buf.Type) != uint32(unix.SELINUX_MAGIC) {
+		return false
+	}
+	if (buf.Flags & unix.ST_RDONLY) != 0 {
+		return false
+	}
+
+	return true
+}
+
+func findSELinuxfs() string {
+	// fast path: check the default mount first
+	if verifySELinuxfsMount(selinuxfsMount) {
+		return selinuxfsMount
+	}
+
+	// check if selinuxfs is available before going the slow path
+	fs, err := os.ReadFile("/proc/filesystems")
+	if err != nil {
+		return ""
+	}
+	if !bytes.Contains(fs, []byte("\tselinuxfs\n")) {
+		return ""
+	}
+
+	// slow path: try to find among the mounts
+	f, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for {
+		mnt := findSELinuxfsMount(scanner)
+		if mnt == "" { // error or not found
+			return ""
+		}
+		if verifySELinuxfsMount(mnt) {
+			return mnt
+		}
+	}
+}
+
+// findSELinuxfsMount returns a next selinuxfs mount point found,
+// if there is one, or an empty string in case of EOF or error.
+func findSELinuxfsMount(s *bufio.Scanner) string {
+	for s.Scan() {
+		txt := s.Bytes()
+		// The first field after - is fs type.
+		// Safe as spaces in mountpoints are encoded as \040
+		if !bytes.Contains(txt, []byte(" - selinuxfs ")) {
+			continue
+		}
+		const mPos = 5 // mount point is 5th field
+		fields := bytes.SplitN(txt, []byte(" "), mPos+1)
+		if len(fields) < mPos+1 {
+			continue
+		}
+		return string(fields[mPos-1])
+	}
+
+	return ""
+}
+
+func (s *selinuxState) getSELinuxfs() string {
+	s.selinuxfsOnce.Do(func() {
+		s.selinuxfs = findSELinuxfs()
+	})
+
+	return s.selinuxfs
+}
+
+// getSelinuxMountPoint returns the path to the mountpoint of an selinuxfs
+// filesystem or an empty string if no mountpoint is found.  Selinuxfs is
+// a proc-like pseudo-filesystem that exposes the SELinux policy API to
+// processes.  The existence of an selinuxfs mount is used to determine
+// whether SELinux is currently enabled or not.
+func getSelinuxMountPoint() string {
+	return state.getSELinuxfs()
+}
+
+// getEnabled returns whether SELinux is currently enabled.
+func getEnabled() bool {
+	return state.getEnabled()
+}
+
+func readConfig(target string) string {
+	in, err := os.Open(selinuxConfig)
+	if err != nil {
+		return ""
+	}
+	defer in.Close()
+
+	scanner := bufio.NewScanner(in)
+
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			// Skip blank lines
+			continue
+		}
+		if line[0] == ';' || line[0] == '#' {
+			// Skip comments
+			continue
+		}
+		fields := bytes.SplitN(line, []byte{'='}, 2)
+		if len(fields) != 2 {
+			continue
+		}
+		if bytes.Equal(fields[0], []byte(target)) {
+			return string(bytes.Trim(fields[1], `"`))
+		}
+	}
+	return ""
+}
+
+func isProcHandle(fh *os.File) error {
+	var buf unix.Statfs_t
+
+	for {
+		err := unix.Fstatfs(int(fh.Fd()), &buf)
+		if err == nil {
+			break
+		}
+		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
+			return &os.PathError{Op: "fstatfs", Path: fh.Name(), Err: err}
+		}
+	}
+	if buf.Type != unix.PROC_SUPER_MAGIC {
+		return fmt.Errorf("file %q is not on procfs", fh.Name())
+	}
+
+	return nil
+}
+
+func readCon(fpath string) (string, error) {
+	if fpath == "" {
+		return "", ErrEmptyPath
+	}
+
+	in, err := os.Open(fpath)
+	if err != nil {
+		return "", err
+	}
+	defer in.Close()
+
+	if err := isProcHandle(in); err != nil {
+		return "", err
+	}
+	return readConFd(in)
+}
+
+func readConFd(in *os.File) (string, error) {
+	data, err := io.ReadAll(in)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes.TrimSuffix(data, []byte{0})), nil
+}
+
+// classIndex returns the int index for an object class in the loaded policy,
+// or -1 and an error
+func classIndex(class string) (int, error) {
+	permpath := fmt.Sprintf("class/%s/index", class)
+	indexpath := filepath.Join(getSelinuxMountPoint(), permpath)
+
+	indexB, err := os.ReadFile(indexpath)
+	if err != nil {
+		return -1, err
+	}
+	index, err := strconv.Atoi(string(indexB))
+	if err != nil {
+		return -1, err
+	}
+
+	return index, nil
+}
+
+// lSetFileLabel sets the SELinux label for this path, not following symlinks,
+// or returns an error.
+func lSetFileLabel(fpath string, label string) error {
+	if fpath == "" {
+		return ErrEmptyPath
+	}
+	for {
+		err := unix.Lsetxattr(fpath, xattrNameSelinux, []byte(label), 0)
+		if err == nil {
+			break
+		}
+		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
+			return &os.PathError{Op: "lsetxattr", Path: fpath, Err: err}
+		}
+	}
+
+	return nil
+}
+
+// setFileLabel sets the SELinux label for this path, following symlinks,
+// or returns an error.
+func setFileLabel(fpath string, label string) error {
+	if fpath == "" {
+		return ErrEmptyPath
+	}
+	for {
+		err := unix.Setxattr(fpath, xattrNameSelinux, []byte(label), 0)
+		if err == nil {
+			break
+		}
+		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
+			return &os.PathError{Op: "setxattr", Path: fpath, Err: err}
+		}
+	}
+
+	return nil
+}
+
+// fileLabel returns the SELinux label for this path, following symlinks,
+// or returns an error.
+func fileLabel(fpath string) (string, error) {
+	if fpath == "" {
+		return "", ErrEmptyPath
+	}
+
+	label, err := getxattr(fpath, xattrNameSelinux)
+	if err != nil {
+		return "", &os.PathError{Op: "getxattr", Path: fpath, Err: err}
+	}
+	// Trim the NUL byte at the end of the byte buffer, if present.
+	if len(label) > 0 && label[len(label)-1] == '\x00' {
+		label = label[:len(label)-1]
+	}
+	return string(label), nil
+}
+
+// lFileLabel returns the SELinux label for this path, not following symlinks,
+// or returns an error.
+func lFileLabel(fpath string) (string, error) {
+	if fpath == "" {
+		return "", ErrEmptyPath
+	}
+
+	label, err := lgetxattr(fpath, xattrNameSelinux)
+	if err != nil {
+		return "", &os.PathError{Op: "lgetxattr", Path: fpath, Err: err}
+	}
+	// Trim the NUL byte at the end of the byte buffer, if present.
+	if len(label) > 0 && label[len(label)-1] == '\x00' {
+		label = label[:len(label)-1]
+	}
+	return string(label), nil
+}
+
+func setFSCreateLabel(label string) error {
+	return writeCon(attrPath("fscreate"), label)
+}
+
+// fsCreateLabel returns the default label the kernel which the kernel is using
+// for file system objects created by this task. "" indicates default.
+func fsCreateLabel() (string, error) {
+	return readCon(attrPath("fscreate"))
+}
+
+// currentLabel returns the SELinux label of the current process thread, or an error.
+func currentLabel() (string, error) {
+	return readCon(attrPath("current"))
+}
+
+// pidLabel returns the SELinux label of the given pid, or an error.
+func pidLabel(pid int) (string, error) {
+	return readCon(fmt.Sprintf("/proc/%d/attr/current", pid))
+}
+
+// ExecLabel returns the SELinux label that the kernel will use for any programs
+// that are executed by the current process thread, or an error.
+func execLabel() (string, error) {
+	return readCon(attrPath("exec"))
+}
+
+func writeCon(fpath, val string) error {
+	if fpath == "" {
+		return ErrEmptyPath
+	}
+	if val == "" {
+		if !getEnabled() {
+			return nil
+		}
+	}
+
+	out, err := os.OpenFile(fpath, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if err := isProcHandle(out); err != nil {
+		return err
+	}
+
+	if val != "" {
+		_, err = out.Write([]byte(val))
+	} else {
+		_, err = out.Write(nil)
+	}
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func attrPath(attr string) string {
+	// Linux >= 3.17 provides this
+	const threadSelfPrefix = "/proc/thread-self/attr"
+
+	attrPathOnce.Do(func() {
+		st, err := os.Stat(threadSelfPrefix)
+		if err == nil && st.Mode().IsDir() {
+			haveThreadSelf = true
+		}
+	})
+
+	if haveThreadSelf {
+		return filepath.Join(threadSelfPrefix, attr)
+	}
+
+	return filepath.Join("/proc/self/task", strconv.Itoa(unix.Gettid()), "attr", attr)
+}
+
+// canonicalizeContext takes a context string and writes it to the kernel
+// the function then returns the context that the kernel will use. Use this
+// function to check if two contexts are equivalent
+func canonicalizeContext(val string) (string, error) {
+	return readWriteCon(filepath.Join(getSelinuxMountPoint(), "context"), val)
+}
+
+// computeCreateContext requests the type transition from source to target for
+// class from the kernel.
+func computeCreateContext(source string, target string, class string) (string, error) {
+	classidx, err := classIndex(class)
+	if err != nil {
+		return "", err
+	}
+
+	return readWriteCon(filepath.Join(getSelinuxMountPoint(), "create"), fmt.Sprintf("%s %s %d", source, target, classidx))
+}
+
+// catsToBitset stores categories in a bitset.
+func catsToBitset(cats string) (*big.Int, error) {
+	bitset := new(big.Int)
+
+	catlist := strings.Split(cats, ",")
+	for _, r := range catlist {
+		ranges := strings.SplitN(r, ".", 2)
+		if len(ranges) > 1 {
+			catstart, err := parseLevelItem(ranges[0], category)
+			if err != nil {
+				return nil, err
+			}
+			catend, err := parseLevelItem(ranges[1], category)
+			if err != nil {
+				return nil, err
+			}
+			for i := catstart; i <= catend; i++ {
+				bitset.SetBit(bitset, int(i), 1)
+			}
+		} else {
+			cat, err := parseLevelItem(ranges[0], category)
+			if err != nil {
+				return nil, err
+			}
+			bitset.SetBit(bitset, int(cat), 1)
+		}
+	}
+
+	return bitset, nil
+}
+
+// parseLevelItem parses and verifies that a sensitivity or category are valid
+func parseLevelItem(s string, sep levelItem) (uint, error) {
+	if len(s) < minSensLen || levelItem(s[0]) != sep {
+		return 0, ErrLevelSyntax
+	}
+	val, err := strconv.ParseUint(s[1:], 10, 32)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint(val), nil
+}
+
+// parseLevel fills a level from a string that contains
+// a sensitivity and categories
+func (l *level) parseLevel(levelStr string) error {
+	lvl := strings.SplitN(levelStr, ":", 2)
+	sens, err := parseLevelItem(lvl[0], sensitivity)
+	if err != nil {
+		return fmt.Errorf("failed to parse sensitivity: %w", err)
+	}
+	l.sens = sens
+	if len(lvl) > 1 {
+		cats, err := catsToBitset(lvl[1])
+		if err != nil {
+			return fmt.Errorf("failed to parse categories: %w", err)
+		}
+		l.cats = cats
+	}
+
+	return nil
+}
+
+// rangeStrToMLSRange marshals a string representation of a range.
+func rangeStrToMLSRange(rangeStr string) (*mlsRange, error) {
+	r := &mlsRange{}
+	l := strings.SplitN(rangeStr, "-", 2)
+
+	switch len(l) {
+	// rangeStr that has a low and a high level, e.g. s4:c0.c1023-s6:c0.c1023
+	case 2:
+		r.high = &level{}
+		if err := r.high.parseLevel(l[1]); err != nil {
+			return nil, fmt.Errorf("failed to parse high level %q: %w", l[1], err)
+		}
+		fallthrough
+	// rangeStr that is single level, e.g. s6:c0,c3,c5,c30.c1023
+	case 1:
+		r.low = &level{}
+		if err := r.low.parseLevel(l[0]); err != nil {
+			return nil, fmt.Errorf("failed to parse low level %q: %w", l[0], err)
+		}
+	}
+
+	if r.high == nil {
+		r.high = r.low
+	}
+
+	return r, nil
+}
+
+// bitsetToStr takes a category bitset and returns it in the
+// canonical selinux syntax
+func bitsetToStr(c *big.Int) string {
+	var str string
+
+	length := 0
+	for i := int(c.TrailingZeroBits()); i < c.BitLen(); i++ {
+		if c.Bit(i) == 0 {
+			continue
+		}
+		if length == 0 {
+			if str != "" {
+				str += ","
+			}
+			str += "c" + strconv.Itoa(i)
+		}
+		if c.Bit(i+1) == 1 {
+			length++
+			continue
+		}
+		if length == 1 {
+			str += ",c" + strconv.Itoa(i)
+		} else if length > 1 {
+			str += ".c" + strconv.Itoa(i)
+		}
+		length = 0
+	}
+
+	return str
+}
+
+func (l *level) equal(l2 *level) bool {
+	if l2 == nil || l == nil {
+		return l == l2
+	}
+	if l2.sens != l.sens {
+		return false
+	}
+	if l2.cats == nil || l.cats == nil {
+		return l2.cats == l.cats
+	}
+	return l.cats.Cmp(l2.cats) == 0
+}
+
+// String returns an mlsRange as a string.
+func (m mlsRange) String() string {
+	low := "s" + strconv.Itoa(int(m.low.sens))
+	if m.low.cats != nil && m.low.cats.BitLen() > 0 {
+		low += ":" + bitsetToStr(m.low.cats)
+	}
+
+	if m.low.equal(m.high) {
+		return low
+	}
+
+	high := "s" + strconv.Itoa(int(m.high.sens))
+	if m.high.cats != nil && m.high.cats.BitLen() > 0 {
+		high += ":" + bitsetToStr(m.high.cats)
+	}
+
+	return low + "-" + high
+}
+
+func max(a, b uint) uint {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b uint) uint {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// calculateGlbLub computes the glb (greatest lower bound) and lub (least upper bound)
+// of a source and target range.
+// The glblub is calculated as the greater of the low sensitivities and
+// the lower of the high sensitivities and the and of each category bitset.
+func calculateGlbLub(sourceRange, targetRange string) (string, error) {
+	s, err := rangeStrToMLSRange(sourceRange)
+	if err != nil {
+		return "", err
+	}
+	t, err := rangeStrToMLSRange(targetRange)
+	if err != nil {
+		return "", err
+	}
+
+	if s.high.sens < t.low.sens || t.high.sens < s.low.sens {
+		/* these ranges have no common sensitivities */
+		return "", ErrIncomparable
+	}
+
+	outrange := &mlsRange{low: &level{}, high: &level{}}
+
+	/* take the greatest of the low */
+	outrange.low.sens = max(s.low.sens, t.low.sens)
+
+	/* take the least of the high */
+	outrange.high.sens = min(s.high.sens, t.high.sens)
+
+	/* find the intersecting categories */
+	if s.low.cats != nil && t.low.cats != nil {
+		outrange.low.cats = new(big.Int)
+		outrange.low.cats.And(s.low.cats, t.low.cats)
+	}
+	if s.high.cats != nil && t.high.cats != nil {
+		outrange.high.cats = new(big.Int)
+		outrange.high.cats.And(s.high.cats, t.high.cats)
+	}
+
+	return outrange.String(), nil
+}
+
+func readWriteCon(fpath string, val string) (string, error) {
+	if fpath == "" {
+		return "", ErrEmptyPath
+	}
+	f, err := os.OpenFile(fpath, os.O_RDWR, 0)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	_, err = f.Write([]byte(val))
+	if err != nil {
+		return "", err
+	}
+
+	return readConFd(f)
+}
+
+// peerLabel retrieves the label of the client on the other side of a socket
+func peerLabel(fd uintptr) (string, error) {
+	l, err := unix.GetsockoptString(int(fd), unix.SOL_SOCKET, unix.SO_PEERSEC)
+	if err != nil {
+		return "", &os.PathError{Op: "getsockopt", Path: "fd " + strconv.Itoa(int(fd)), Err: err}
+	}
+	return l, nil
+}
+
+// setKeyLabel takes a process label and tells the kernel to assign the
+// label to the next kernel keyring that gets created
+func setKeyLabel(label string) error {
+	err := writeCon("/proc/self/attr/keycreate", label)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if label == "" && errors.Is(err, os.ErrPermission) {
+		return nil
+	}
+	return err
+}
+
+// get returns the Context as a string
+func (c Context) get() string {
+	if l := c["level"]; l != "" {
+		return c["user"] + ":" + c["role"] + ":" + c["type"] + ":" + l
+	}
+	return c["user"] + ":" + c["role"] + ":" + c["type"]
+}
+
+// newContext creates a new Context struct from the specified label
+func newContext(label string) (Context, error) {
+	c := make(Context)
+
+	if len(label) != 0 {
+		con := strings.SplitN(label, ":", 4)
+		if len(con) < 3 {
+			return c, ErrInvalidLabel
+		}
+		c["user"] = con[0]
+		c["role"] = con[1]
+		c["type"] = con[2]
+		if len(con) > 3 {
+			c["level"] = con[3]
+		}
+	}
+	return c, nil
+}
+
+// clearLabels clears all reserved labels
+func clearLabels() {
+	state.Lock()
+	state.mcsList = make(map[string]bool)
+	state.Unlock()
+}
+
+// reserveLabel reserves the MLS/MCS level component of the specified label
+func reserveLabel(label string) {
+	if len(label) != 0 {
+		con := strings.SplitN(label, ":", 4)
+		if len(con) > 3 {
+			_ = mcsAdd(con[3])
+		}
+	}
+}
+
+func selinuxEnforcePath() string {
+	return filepath.Join(getSelinuxMountPoint(), "enforce")
+}
+
+// isMLSEnabled checks if MLS is enabled.
+func isMLSEnabled() bool {
+	enabledB, err := os.ReadFile(filepath.Join(getSelinuxMountPoint(), "mls"))
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(enabledB, []byte{'1'})
+}
+
+// enforceMode returns the current SELinux mode Enforcing, Permissive, Disabled
+func enforceMode() int {
+	var enforce int
+
+	enforceB, err := os.ReadFile(selinuxEnforcePath())
+	if err != nil {
+		return -1
+	}
+	enforce, err = strconv.Atoi(string(enforceB))
+	if err != nil {
+		return -1
+	}
+	return enforce
+}
+
+// setEnforceMode sets the current SELinux mode Enforcing, Permissive.
+// Disabled is not valid, since this needs to be set at boot time.
+func setEnforceMode(mode int) error {
+	//nolint:gosec // ignore G306: permissions to be 0600 or less.
+	return os.WriteFile(selinuxEnforcePath(), []byte(strconv.Itoa(mode)), 0o644)
+}
+
+// defaultEnforceMode returns the systems default SELinux mode Enforcing,
+// Permissive or Disabled. Note this is just the default at boot time.
+// EnforceMode tells you the systems current mode.
+func defaultEnforceMode() int {
+	switch readConfig(selinuxTag) {
+	case "enforcing":
+		return Enforcing
+	case "permissive":
+		return Permissive
+	}
+	return Disabled
+}
+
+func mcsAdd(mcs string) error {
+	if mcs == "" {
+		return nil
+	}
+	state.Lock()
+	defer state.Unlock()
+	if state.mcsList[mcs] {
+		return ErrMCSAlreadyExists
+	}
+	state.mcsList[mcs] = true
+	return nil
+}
+
+func mcsDelete(mcs string) {
+	if mcs == "" {
+		return
+	}
+	state.Lock()
+	defer state.Unlock()
+	state.mcsList[mcs] = false
+}
+
+func intToMcs(id int, catRange uint32) string {
+	var (
+		SETSIZE = int(catRange)
+		TIER    = SETSIZE
+		ORD     = id
+	)
+
+	if id < 1 || id > 523776 {
+		return ""
+	}
+
+	for ORD > TIER {
+		ORD -= TIER
+		TIER--
+	}
+	TIER = SETSIZE - TIER
+	ORD += TIER
+	return fmt.Sprintf("s0:c%d,c%d", TIER, ORD)
+}
+
+func uniqMcs(catRange uint32) string {
+	var (
+		n      uint32
+		c1, c2 uint32
+		mcs    string
+	)
+
+	for {
+		_ = binary.Read(rand.Reader, binary.LittleEndian, &n)
+		c1 = n % catRange
+		_ = binary.Read(rand.Reader, binary.LittleEndian, &n)
+		c2 = n % catRange
+		if c1 == c2 {
+			continue
+		} else if c1 > c2 {
+			c1, c2 = c2, c1
+		}
+		mcs = fmt.Sprintf("s0:c%d,c%d", c1, c2)
+		if err := mcsAdd(mcs); err != nil {
+			continue
+		}
+		break
+	}
+	return mcs
+}
+
+// releaseLabel un-reserves the MLS/MCS Level field of the specified label,
+// allowing it to be used by another process.
+func releaseLabel(label string) {
+	if len(label) != 0 {
+		con := strings.SplitN(label, ":", 4)
+		if len(con) > 3 {
+			mcsDelete(con[3])
+		}
+	}
+}
+
+// roFileLabel returns the specified SELinux readonly file label
+func roFileLabel() string {
+	return readOnlyFileLabel
+}
+
+func openContextFile() (*os.File, error) {
+	if f, err := os.Open(contextFile); err == nil {
+		return f, nil
+	}
+	return os.Open(filepath.Join(policyRoot(), "contexts", "lxc_contexts"))
+}
+
+func loadLabels() {
+	labels = make(map[string]string)
+	in, err := openContextFile()
+	if err != nil {
+		return
+	}
+	defer in.Close()
+
+	scanner := bufio.NewScanner(in)
+
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			// Skip blank lines
+			continue
+		}
+		if line[0] == ';' || line[0] == '#' {
+			// Skip comments
+			continue
+		}
+		fields := bytes.SplitN(line, []byte{'='}, 2)
+		if len(fields) != 2 {
+			continue
+		}
+		key, val := bytes.TrimSpace(fields[0]), bytes.TrimSpace(fields[1])
+		labels[string(key)] = string(bytes.Trim(val, `"`))
+	}
+
+	con, _ := NewContext(labels["file"])
+	con["level"] = fmt.Sprintf("s0:c%d,c%d", maxCategory-2, maxCategory-1)
+	privContainerMountLabel = con.get()
+	reserveLabel(privContainerMountLabel)
+}
+
+func label(key string) string {
+	loadLabelsOnce.Do(func() {
+		loadLabels()
+	})
+	return labels[key]
+}
+
+// kvmContainerLabels returns the default processLabel and mountLabel to be used
+// for kvm containers by the calling process.
+func kvmContainerLabels() (string, string) {
+	processLabel := label("kvm_process")
+	if processLabel == "" {
+		processLabel = label("process")
+	}
+
+	return addMcs(processLabel, label("file"))
+}
+
+// initContainerLabels returns the default processLabel and file labels to be
+// used for containers running an init system like systemd by the calling process.
+func initContainerLabels() (string, string) {
+	processLabel := label("init_process")
+	if processLabel == "" {
+		processLabel = label("process")
+	}
+
+	return addMcs(processLabel, label("file"))
+}
+
+// containerLabels returns an allocated processLabel and fileLabel to be used for
+// container labeling by the calling process.
+func containerLabels() (processLabel string, fileLabel string) {
+	if !getEnabled() {
+		return "", ""
+	}
+
+	processLabel = label("process")
+	fileLabel = label("file")
+	readOnlyFileLabel = label("ro_file")
+
+	if processLabel == "" || fileLabel == "" {
+		return "", fileLabel
+	}
+
+	if readOnlyFileLabel == "" {
+		readOnlyFileLabel = fileLabel
+	}
+
+	return addMcs(processLabel, fileLabel)
+}
+
+func addMcs(processLabel, fileLabel string) (string, string) {
+	scon, _ := NewContext(processLabel)
+	if scon["level"] != "" {
+		mcs := uniqMcs(CategoryRange)
+		scon["level"] = mcs
+		processLabel = scon.Get()
+		scon, _ = NewContext(fileLabel)
+		scon["level"] = mcs
+		fileLabel = scon.Get()
+	}
+	return processLabel, fileLabel
+}
+
+// securityCheckContext validates that the SELinux label is understood by the kernel
+func securityCheckContext(val string) error {
+	//nolint:gosec // ignore G306: permissions to be 0600 or less.
+	return os.WriteFile(filepath.Join(getSelinuxMountPoint(), "context"), []byte(val), 0o644)
+}
+
+// copyLevel returns a label with the MLS/MCS level from src label replaced on
+// the dest label.
+func copyLevel(src, dest string) (string, error) {
+	if src == "" {
+		return "", nil
+	}
+	if err := SecurityCheckContext(src); err != nil {
+		return "", err
+	}
+	if err := SecurityCheckContext(dest); err != nil {
+		return "", err
+	}
+	scon, err := NewContext(src)
+	if err != nil {
+		return "", err
+	}
+	tcon, err := NewContext(dest)
+	if err != nil {
+		return "", err
+	}
+	mcsDelete(tcon["level"])
+	_ = mcsAdd(scon["level"])
+	tcon["level"] = scon["level"]
+	return tcon.Get(), nil
+}
+
+// chcon changes the fpath file object to the SELinux label.
+// If fpath is a directory and recurse is true, then chcon walks the
+// directory tree setting the label.
+func chcon(fpath string, label string, recurse bool) error {
+	if fpath == "" {
+		return ErrEmptyPath
+	}
+	if label == "" {
+		return nil
+	}
+
+	excludePaths := map[string]bool{
+		"/":           true,
+		"/bin":        true,
+		"/boot":       true,
+		"/dev":        true,
+		"/etc":        true,
+		"/etc/passwd": true,
+		"/etc/pki":    true,
+		"/etc/shadow": true,
+		"/home":       true,
+		"/lib":        true,
+		"/lib64":      true,
+		"/media":      true,
+		"/opt":        true,
+		"/proc":       true,
+		"/root":       true,
+		"/run":        true,
+		"/sbin":       true,
+		"/srv":        true,
+		"/sys":        true,
+		"/tmp":        true,
+		"/usr":        true,
+		"/var":        true,
+		"/var/lib":    true,
+		"/var/log":    true,
+	}
+
+	if home := os.Getenv("HOME"); home != "" {
+		excludePaths[home] = true
+	}
+
+	if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
+		if usr, err := user.Lookup(sudoUser); err == nil {
+			excludePaths[usr.HomeDir] = true
+		}
+	}
+
+	if fpath != "/" {
+		fpath = strings.TrimSuffix(fpath, "/")
+	}
+	if excludePaths[fpath] {
+		return fmt.Errorf("SELinux relabeling of %s is not allowed", fpath)
+	}
+
+	if !recurse {
+		err := lSetFileLabel(fpath, label)
+		if err != nil {
+			// Check if file doesn't exist, must have been removed
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			// Check if current label is correct on disk
+			flabel, nerr := lFileLabel(fpath)
+			if nerr == nil && flabel == label {
+				return nil
+			}
+			// Check if file doesn't exist, must have been removed
+			if errors.Is(nerr, os.ErrNotExist) {
+				return nil
+			}
+			return err
+		}
+		return nil
+	}
+
+	return rchcon(fpath, label)
+}
+
+func rchcon(fpath, label string) error { //revive:disable:cognitive-complexity
+	fastMode := false
+	// If the current label matches the new label, assume
+	// other labels are correct.
+	if cLabel, err := lFileLabel(fpath); err == nil && cLabel == label {
+		fastMode = true
+	}
+	return pwalkdir.Walk(fpath, func(p string, _ fs.DirEntry, _ error) error {
+		if fastMode {
+			if cLabel, err := lFileLabel(fpath); err == nil && cLabel == label {
+				return nil
+			}
+		}
+		err := lSetFileLabel(p, label)
+		// Walk a file tree can race with removal, so ignore ENOENT.
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	})
+}
+
+// dupSecOpt takes an SELinux process label and returns security options that
+// can be used to set the SELinux Type and Level for future container processes.
+func dupSecOpt(src string) ([]string, error) {
+	if src == "" {
+		return nil, nil
+	}
+	con, err := NewContext(src)
+	if err != nil {
+		return nil, err
+	}
+	if con["user"] == "" ||
+		con["role"] == "" ||
+		con["type"] == "" {
+		return nil, nil
+	}
+	dup := []string{
+		"user:" + con["user"],
+		"role:" + con["role"],
+		"type:" + con["type"],
+	}
+
+	if con["level"] != "" {
+		dup = append(dup, "level:"+con["level"])
+	}
+
+	return dup, nil
+}
+
+// findUserInContext scans the reader for a valid SELinux context
+// match that is verified with the verifier. Invalid contexts are
+// skipped. It returns a matched context or an empty string if no
+// match is found. If a scanner error occurs, it is returned.
+func findUserInContext(context Context, r io.Reader, verifier func(string) error) (string, error) {
+	fromRole := context["role"]
+	fromType := context["type"]
+	scanner := bufio.NewScanner(r)
+
+	for scanner.Scan() {
+		fromConns := strings.Fields(scanner.Text())
+		if len(fromConns) == 0 {
+			// Skip blank lines
+			continue
+		}
+
+		line := fromConns[0]
+
+		if line[0] == ';' || line[0] == '#' {
+			// Skip comments
+			continue
+		}
+
+		// user context files contexts are formatted as
+		// role_r:type_t:s0 where the user is missing.
+		lineArr := strings.SplitN(line, ":", 4)
+		// skip context with typo, or role and type do not match
+		if len(lineArr) != 3 ||
+			lineArr[0] != fromRole ||
+			lineArr[1] != fromType {
+			continue
+		}
+
+		for _, cc := range fromConns[1:] {
+			toConns := strings.SplitN(cc, ":", 4)
+			if len(toConns) != 3 {
+				continue
+			}
+
+			context["role"] = toConns[0]
+			context["type"] = toConns[1]
+
+			outConn := context.get()
+			if err := verifier(outConn); err != nil {
+				continue
+			}
+
+			return outConn, nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("failed to scan for context: %w", err)
+	}
+
+	return "", nil
+}
+
+func getDefaultContextFromReaders(c *defaultSECtx) (string, error) {
+	if c.verifier == nil {
+		return "", ErrVerifierNil
+	}
+
+	context, err := newContext(c.scon)
+	if err != nil {
+		return "", fmt.Errorf("failed to create label for %s: %w", c.scon, err)
+	}
+
+	// set so the verifier validates the matched context with the provided user and level.
+	context["user"] = c.user
+	context["level"] = c.level
+
+	conn, err := findUserInContext(context, c.userRdr, c.verifier)
+	if err != nil {
+		return "", err
+	}
+
+	if conn != "" {
+		return conn, nil
+	}
+
+	conn, err = findUserInContext(context, c.defaultRdr, c.verifier)
+	if err != nil {
+		return "", err
+	}
+
+	if conn != "" {
+		return conn, nil
+	}
+
+	return "", fmt.Errorf("context %q not found: %w", c.scon, ErrContextMissing)
+}
+
+func getDefaultContextWithLevel(user, level, scon string) (string, error) {
+	userPath := filepath.Join(policyRoot(), selinuxUsersDir, user)
+	fu, err := os.Open(userPath)
+	if err != nil {
+		return "", err
+	}
+	defer fu.Close()
+
+	defaultPath := filepath.Join(policyRoot(), defaultContexts)
+	fd, err := os.Open(defaultPath)
+	if err != nil {
+		return "", err
+	}
+	defer fd.Close()
+
+	c := defaultSECtx{
+		user:       user,
+		level:      level,
+		scon:       scon,
+		userRdr:    fu,
+		defaultRdr: fd,
+		verifier:   securityCheckContext,
+	}
+
+	return getDefaultContextFromReaders(&c)
+}

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_stub.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_stub.go
@@ -1,0 +1,155 @@
+//go:build !linux
+// +build !linux
+
+package selinux
+
+func attrPath(string) string {
+	return ""
+}
+
+func readCon(fpath string) (string, error) {
+	return "", nil
+}
+
+func writeCon(string, string) error {
+	return nil
+}
+
+func setDisabled() {}
+
+func getEnabled() bool {
+	return false
+}
+
+func classIndex(class string) (int, error) {
+	return -1, nil
+}
+
+func setFileLabel(fpath string, label string) error {
+	return nil
+}
+
+func lSetFileLabel(fpath string, label string) error {
+	return nil
+}
+
+func fileLabel(fpath string) (string, error) {
+	return "", nil
+}
+
+func lFileLabel(fpath string) (string, error) {
+	return "", nil
+}
+
+func setFSCreateLabel(label string) error {
+	return nil
+}
+
+func fsCreateLabel() (string, error) {
+	return "", nil
+}
+
+func currentLabel() (string, error) {
+	return "", nil
+}
+
+func pidLabel(pid int) (string, error) {
+	return "", nil
+}
+
+func execLabel() (string, error) {
+	return "", nil
+}
+
+func canonicalizeContext(val string) (string, error) {
+	return "", nil
+}
+
+func computeCreateContext(source string, target string, class string) (string, error) {
+	return "", nil
+}
+
+func calculateGlbLub(sourceRange, targetRange string) (string, error) {
+	return "", nil
+}
+
+func peerLabel(fd uintptr) (string, error) {
+	return "", nil
+}
+
+func setKeyLabel(label string) error {
+	return nil
+}
+
+func (c Context) get() string {
+	return ""
+}
+
+func newContext(label string) (Context, error) {
+	return Context{}, nil
+}
+
+func clearLabels() {
+}
+
+func reserveLabel(label string) {
+}
+
+func isMLSEnabled() bool {
+	return false
+}
+
+func enforceMode() int {
+	return Disabled
+}
+
+func setEnforceMode(mode int) error {
+	return nil
+}
+
+func defaultEnforceMode() int {
+	return Disabled
+}
+
+func releaseLabel(label string) {
+}
+
+func roFileLabel() string {
+	return ""
+}
+
+func kvmContainerLabels() (string, string) {
+	return "", ""
+}
+
+func initContainerLabels() (string, string) {
+	return "", ""
+}
+
+func containerLabels() (processLabel string, fileLabel string) {
+	return "", ""
+}
+
+func securityCheckContext(val string) error {
+	return nil
+}
+
+func copyLevel(src, dest string) (string, error) {
+	return "", nil
+}
+
+func chcon(fpath string, label string, recurse bool) error {
+	return nil
+}
+
+func dupSecOpt(src string) ([]string, error) {
+	return nil, nil
+}
+
+func getDefaultContextWithLevel(user, level, scon string) (string, error) {
+	return "", nil
+}
+
+func label(_ string) string {
+	return ""
+}

--- a/vendor/github.com/opencontainers/selinux/go-selinux/xattrs_linux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/xattrs_linux.go
@@ -1,0 +1,71 @@
+package selinux
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// lgetxattr returns a []byte slice containing the value of
+// an extended attribute attr set for path.
+func lgetxattr(path, attr string) ([]byte, error) {
+	// Start with a 128 length byte array
+	dest := make([]byte, 128)
+	sz, errno := doLgetxattr(path, attr, dest)
+	for errno == unix.ERANGE { //nolint:errorlint // unix errors are bare
+		// Buffer too small, use zero-sized buffer to get the actual size
+		sz, errno = doLgetxattr(path, attr, []byte{})
+		if errno != nil {
+			return nil, errno
+		}
+
+		dest = make([]byte, sz)
+		sz, errno = doLgetxattr(path, attr, dest)
+	}
+	if errno != nil {
+		return nil, errno
+	}
+
+	return dest[:sz], nil
+}
+
+// doLgetxattr is a wrapper that retries on EINTR
+func doLgetxattr(path, attr string, dest []byte) (int, error) {
+	for {
+		sz, err := unix.Lgetxattr(path, attr, dest)
+		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
+			return sz, err
+		}
+	}
+}
+
+// getxattr returns a []byte slice containing the value of
+// an extended attribute attr set for path.
+func getxattr(path, attr string) ([]byte, error) {
+	// Start with a 128 length byte array
+	dest := make([]byte, 128)
+	sz, errno := dogetxattr(path, attr, dest)
+	for errno == unix.ERANGE { //nolint:errorlint // unix errors are bare
+		// Buffer too small, use zero-sized buffer to get the actual size
+		sz, errno = dogetxattr(path, attr, []byte{})
+		if errno != nil {
+			return nil, errno
+		}
+
+		dest = make([]byte, sz)
+		sz, errno = dogetxattr(path, attr, dest)
+	}
+	if errno != nil {
+		return nil, errno
+	}
+
+	return dest[:sz], nil
+}
+
+// dogetxattr is a wrapper that retries on EINTR
+func dogetxattr(path, attr string, dest []byte) (int, error) {
+	for {
+		sz, err := unix.Getxattr(path, attr, dest)
+		if err != unix.EINTR { //nolint:errorlint // unix errors are bare
+			return sz, err
+		}
+	}
+}

--- a/vendor/github.com/opencontainers/selinux/pkg/pwalkdir/README.md
+++ b/vendor/github.com/opencontainers/selinux/pkg/pwalkdir/README.md
@@ -1,0 +1,54 @@
+## pwalkdir: parallel implementation of filepath.WalkDir
+
+This is a wrapper for [filepath.WalkDir](https://pkg.go.dev/path/filepath#WalkDir)
+which may speed it up by calling multiple callback functions (WalkDirFunc)
+in parallel, utilizing goroutines.
+
+By default, it utilizes 2\*runtime.NumCPU() goroutines for callbacks.
+This can be changed by using WalkN function which has the additional
+parameter, specifying the number of goroutines (concurrency).
+
+### pwalk vs pwalkdir
+
+This package is very similar to
+[pwalk](https://pkg.go.dev/github.com/opencontainers/selinux/pkg/pwalkdir),
+but utilizes `filepath.WalkDir` (added to Go 1.16), which does not call stat(2)
+on every entry and is therefore faster (up to 3x, depending on usage scenario).
+
+Users who are OK with requiring Go 1.16+ should switch to this
+implementation.
+
+### Caveats
+
+Please note the following limitations of this code:
+
+* Unlike filepath.WalkDir, the order of calls is non-deterministic;
+
+* Only primitive error handling is supported:
+
+  * fs.SkipDir is not supported;
+
+  * no errors are ever passed to WalkDirFunc;
+
+  * once any error is returned from any walkDirFunc instance, no more calls
+    to WalkDirFunc are made, and the error is returned to the caller of WalkDir;
+
+  * if more than one WalkDirFunc instance will return an error, only one
+    of such errors will be propagated to and returned by WalkDir, others
+    will be silently discarded.
+
+### Documentation
+
+For the official documentation, see
+https://pkg.go.dev/github.com/opencontainers/selinux/pkg/pwalkdir
+
+### Benchmarks
+
+For a WalkDirFunc that consists solely of the return statement, this
+implementation is about 15% slower than the standard library's
+filepath.WalkDir.
+
+Otherwise (if a WalkDirFunc is actually doing something) this is usually
+faster, except when the WalkDirN(..., 1) is used. Run `go test -bench .`
+to see how different operations can benefit from it, as well as how the
+level of paralellism affects the speed.

--- a/vendor/github.com/opencontainers/selinux/pkg/pwalkdir/pwalkdir.go
+++ b/vendor/github.com/opencontainers/selinux/pkg/pwalkdir/pwalkdir.go
@@ -1,0 +1,116 @@
+//go:build go1.16
+// +build go1.16
+
+package pwalkdir
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"sync"
+)
+
+// Walk is a wrapper for filepath.WalkDir which can call multiple walkFn
+// in parallel, allowing to handle each item concurrently. A maximum of
+// twice the runtime.NumCPU() walkFn will be called at any one time.
+// If you want to change the maximum, use WalkN instead.
+//
+// The order of calls is non-deterministic.
+//
+// Note that this implementation only supports primitive error handling:
+//
+// - no errors are ever passed to walkFn;
+//
+// - once a walkFn returns any error, all further processing stops
+// and the error is returned to the caller of Walk;
+//
+// - filepath.SkipDir is not supported;
+//
+// - if more than one walkFn instance will return an error, only one
+// of such errors will be propagated and returned by Walk, others
+// will be silently discarded.
+func Walk(root string, walkFn fs.WalkDirFunc) error {
+	return WalkN(root, walkFn, runtime.NumCPU()*2)
+}
+
+// WalkN is a wrapper for filepath.WalkDir which can call multiple walkFn
+// in parallel, allowing to handle each item concurrently. A maximum of
+// num walkFn will be called at any one time.
+//
+// Please see Walk documentation for caveats of using this function.
+func WalkN(root string, walkFn fs.WalkDirFunc, num int) error {
+	// make sure limit is sensible
+	if num < 1 {
+		return fmt.Errorf("walk(%q): num must be > 0", root)
+	}
+
+	files := make(chan *walkArgs, 2*num)
+	errCh := make(chan error, 1) // Get the first error, ignore others.
+
+	// Start walking a tree asap.
+	var (
+		err error
+		wg  sync.WaitGroup
+
+		rootLen   = len(root)
+		rootEntry *walkArgs
+	)
+	wg.Add(1)
+	go func() {
+		err = filepath.WalkDir(root, func(p string, entry fs.DirEntry, err error) error {
+			if err != nil {
+				close(files)
+				return err
+			}
+			if len(p) == rootLen {
+				// Root entry is processed separately below.
+				rootEntry = &walkArgs{path: p, entry: entry}
+				return nil
+			}
+			// Add a file to the queue unless a callback sent an error.
+			select {
+			case e := <-errCh:
+				close(files)
+				return e
+			default:
+				files <- &walkArgs{path: p, entry: entry}
+				return nil
+			}
+		})
+		if err == nil {
+			close(files)
+		}
+		wg.Done()
+	}()
+
+	wg.Add(num)
+	for i := 0; i < num; i++ {
+		go func() {
+			for file := range files {
+				if e := walkFn(file.path, file.entry, nil); e != nil {
+					select {
+					case errCh <- e: // sent ok
+					default: // buffer full
+					}
+				}
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	if err == nil {
+		err = walkFn(rootEntry.path, rootEntry.entry, nil)
+	}
+
+	return err
+}
+
+// walkArgs holds the arguments that were passed to the Walk or WalkN
+// functions.
+type walkArgs struct {
+	entry fs.DirEntry
+	path  string
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -139,6 +139,10 @@ github.com/opencontainers/runtime-spec/specs-go
 github.com/opencontainers/runtime-tools/generate
 github.com/opencontainers/runtime-tools/generate/seccomp
 github.com/opencontainers/runtime-tools/validate/capabilities
+# github.com/opencontainers/selinux v1.11.0
+## explicit; go 1.19
+github.com/opencontainers/selinux/go-selinux
+github.com/opencontainers/selinux/pkg/pwalkdir
 # github.com/pmezard/go-difflib v1.0.0
 ## explicit
 github.com/pmezard/go-difflib/difflib


### PR DESCRIPTION
Use `github.com/opencontainers/selinux/go-selinux` instead of calling the `chcon` command to set SELinux context.

This PR builds upon #789, but according to opencontainers/selinux/issues/215, a full label must be applied when using the SELinux Go package. Also, checking whether SELinux is available has been changed - the reason was discussed in detail in #847.