### PR TITLE
[no-relnote] Use ubi8 image in tests

### DIFF
--- a/.github/workflows/staging_e2e.yaml
+++ b/.github/workflows/staging_e2e.yaml
@@ -60,7 +60,7 @@ jobs:
         env:
           KUBECONFIG: ${{ github.workspace }}/kubeconfig
           E2E_IMAGE_REPO: ghcr.io/nvidia/k8s-device-plugin
-          E2E_IMAGE_TAG: ${COMMIT_SHORT_SHA}-ubuntu22.04
+          E2E_IMAGE_TAG: ${COMMIT_SHORT_SHA}-ubi8
           LOG_ARTIFACTS: ${{ github.workspace }}/e2e_logs
         run: |
           make test-e2e
@@ -84,5 +84,5 @@ jobs:
           channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
           slack-message: |
             :red_target: On repository ${{ github.repository }} the Workflow *${{ github.workflow }}* has failed.
-  
+
             Details: ${{ env.SUMMARY_URL }}


### PR DESCRIPTION
With https://github.com/NVIDIA/k8s-device-plugin/pull/884 we removed the ubuntu22.04 images.
This change uses the ubi8 images since these are now the only images.