### PR TITLE
Remove namespace field from cluster-scoped `ClusterRole` and `ClusterRoleBinding` resources

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/role-binding.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/role-binding.yml
@@ -5,7 +5,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "nvidia-device-plugin.fullname" . }}-role-binding
-  namespace: {{ include "nvidia-device-plugin.namespace" . }}
   labels:
     {{- include "nvidia-device-plugin.labels" . | nindent 4 }}
 subjects:

--- a/deployments/helm/nvidia-device-plugin/templates/role.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/role.yml
@@ -5,7 +5,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "nvidia-device-plugin.fullname" . }}-role
-  namespace: {{ include "nvidia-device-plugin.namespace" . }}
   labels:
     {{- include "nvidia-device-plugin.labels" . | nindent 4 }}
 rules:


### PR DESCRIPTION
See:
* https://kubernetes.io/docs/reference/access-authn-authz/rbac/#clusterrole-example
* https://kubernetes.io/docs/reference/access-authn-authz/rbac/#clusterrolebinding-example
