### PR TITLE
Allow CDI annotation prefix to be specified in helm

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -169,6 +169,10 @@ spec:
           - name: NVIDIA_CDI_HOOK_PATH
             value: {{ .Values.cdi.nvidiaHookPath }}
         {{- end }}
+        {{- if typeIs "string" .Values.cdi.annotationPrefix }}
+          - name: CDI_ANNOTATION_PREFIX
+            value: {{ .Values.cdi.annotationPrefix | quote }}
+        {{- end }}
         {{- if typeIs "bool" .Values.gdsEnabled }}
           - name: GDS_ENABLED
             value: {{ .Values.gdsEnabled | quote }}

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -156,3 +156,4 @@ cdi:
   # nvidiaHookPath specifies the path to the nvidia-cdi-hook or nvidia-ctk executables on the host.
   # This is required to ensure that the generated CDI specification refers to the correct CDI hooks.
   nvidiaHookPath: null
+  annotationPrefix: null


### PR DESCRIPTION
This change allows the CDI annotation prefix to be specified as a helm value and not only as an envvar.