### PR TITLE
Fix golang-ci-lint errors

### DIFF
--- a/internal/lm/nvml.go
+++ b/internal/lm/nvml.go
@@ -121,17 +121,17 @@ func newVersionLabeler(manager resource.Manager) (Labeler, error) {
 		"nvidia.com/cuda.driver.major":  driverMajor,
 		"nvidia.com/cuda.driver.minor":  driverMinor,
 		"nvidia.com/cuda.driver.rev":    driverRev,
-		"nvidia.com/cuda.runtime.major": fmt.Sprintf("%d", *cudaMajor),
-		"nvidia.com/cuda.runtime.minor": fmt.Sprintf("%d", *cudaMinor),
+		"nvidia.com/cuda.runtime.major": fmt.Sprintf("%d", cudaMajor),
+		"nvidia.com/cuda.runtime.minor": fmt.Sprintf("%d", cudaMinor),
 
 		// New labels
 		"nvidia.com/cuda.driver-version.major":    driverMajor,
 		"nvidia.com/cuda.driver-version.minor":    driverMinor,
 		"nvidia.com/cuda.driver-version.revision": driverRev,
 		"nvidia.com/cuda.driver-version.full":     driverVersion,
-		"nvidia.com/cuda.runtime-version.major":   fmt.Sprintf("%d", *cudaMajor),
-		"nvidia.com/cuda.runtime-version.minor":   fmt.Sprintf("%d", *cudaMinor),
-		"nvidia.com/cuda.runtime-version.full":    fmt.Sprintf("%d.%d", *cudaMajor, *cudaMinor),
+		"nvidia.com/cuda.runtime-version.major":   fmt.Sprintf("%d", cudaMajor),
+		"nvidia.com/cuda.runtime-version.minor":   fmt.Sprintf("%d", cudaMinor),
+		"nvidia.com/cuda.runtime-version.full":    fmt.Sprintf("%d.%d", cudaMajor, cudaMinor),
 	}
 	return labels, nil
 }

--- a/internal/resource/cuda-lib.go
+++ b/internal/resource/cuda-lib.go
@@ -51,16 +51,16 @@ func (l *cudaLib) GetDevices() ([]Device, error) {
 }
 
 // GetCudaDriverVersion returns the CUDA driver version
-func (l *cudaLib) GetCudaDriverVersion() (*uint, *uint, error) {
+func (l *cudaLib) GetCudaDriverVersion() (int, int, error) {
 	version, r := cuda.DriverGetVersion()
 	if r != cuda.SUCCESS {
-		return nil, nil, fmt.Errorf("failed to get driver version: %v", r)
+		return 0, 0, fmt.Errorf("failed to get driver version: %v", r)
 	}
 
-	major := uint(version) / 1000
-	minor := uint(version) % 100 / 10
+	major := version / 1000
+	minor := version % 100 / 10
 
-	return &major, &minor, nil
+	return major, minor, nil
 }
 
 // GetDriverVersion returns the driver version.

--- a/internal/resource/fallback.go
+++ b/internal/resource/fallback.go
@@ -54,7 +54,7 @@ func (m *withFallBack) GetDevices() ([]Device, error) {
 }
 
 // GetCudaDriverVersion delegates to the wrapped manager
-func (m *withFallBack) GetCudaDriverVersion() (*uint, *uint, error) {
+func (m *withFallBack) GetCudaDriverVersion() (int, int, error) {
 	return m.wraps.GetCudaDriverVersion()
 }
 

--- a/internal/resource/manager_mock.go
+++ b/internal/resource/manager_mock.go
@@ -17,7 +17,7 @@ var _ Manager = &ManagerMock{}
 //
 //		// make and configure a mocked Manager
 //		mockedManager := &ManagerMock{
-//			GetCudaDriverVersionFunc: func() (*uint, *uint, error) {
+//			GetCudaDriverVersionFunc: func() (int, int, error) {
 //				panic("mock out the GetCudaDriverVersion method")
 //			},
 //			GetDevicesFunc: func() ([]Device, error) {
@@ -40,7 +40,7 @@ var _ Manager = &ManagerMock{}
 //	}
 type ManagerMock struct {
 	// GetCudaDriverVersionFunc mocks the GetCudaDriverVersion method.
-	GetCudaDriverVersionFunc func() (*uint, *uint, error)
+	GetCudaDriverVersionFunc func() (int, int, error)
 
 	// GetDevicesFunc mocks the GetDevices method.
 	GetDevicesFunc func() ([]Device, error)
@@ -80,7 +80,7 @@ type ManagerMock struct {
 }
 
 // GetCudaDriverVersion calls GetCudaDriverVersionFunc.
-func (mock *ManagerMock) GetCudaDriverVersion() (*uint, *uint, error) {
+func (mock *ManagerMock) GetCudaDriverVersion() (int, int, error) {
 	if mock.GetCudaDriverVersionFunc == nil {
 		panic("ManagerMock.GetCudaDriverVersionFunc: method is nil but Manager.GetCudaDriverVersion was just called")
 	}

--- a/internal/resource/null.go
+++ b/internal/resource/null.go
@@ -47,8 +47,8 @@ func (l *null) GetDevices() ([]Device, error) {
 }
 
 // GetCudaDriverVersion is not supported
-func (l *null) GetCudaDriverVersion() (*uint, *uint, error) {
-	return nil, nil, fmt.Errorf("GetCudaDriverVersion is unsupported")
+func (l *null) GetCudaDriverVersion() (int, int, error) {
+	return 0, 0, fmt.Errorf("GetCudaDriverVersion is unsupported")
 }
 
 // GetDriverVersion is not supported

--- a/internal/resource/nvml-lib.go
+++ b/internal/resource/nvml-lib.go
@@ -36,15 +36,15 @@ func NewNVMLManager(nvmllib nvml.Interface, devicelib device.Interface) Manager 
 }
 
 // GetCudaDriverVersion : Return the cuda v using NVML
-func (l nvmlLib) GetCudaDriverVersion() (*uint, *uint, error) {
+func (l nvmlLib) GetCudaDriverVersion() (int, int, error) {
 	v, ret := l.Interface.SystemGetCudaDriverVersion()
 	if ret != nvml.SUCCESS {
-		return nil, nil, ret
+		return 0, 0, ret
 	}
-	major := uint(v / 1000)
-	minor := uint(v % 1000 / 10)
+	major := v / 1000
+	minor := v % 1000 / 10
 
-	return &major, &minor, nil
+	return major, minor, nil
 }
 
 // GetDevices returns the NVML devices for the manager

--- a/internal/resource/nvml-mig-device.go
+++ b/internal/resource/nvml-mig-device.go
@@ -124,13 +124,17 @@ func totalMemory(attr map[string]interface{}) (uint64, error) {
 		return 0, fmt.Errorf("no 'memory' attribute available")
 	}
 
-	switch t := totalMemory.(type) {
+	switch totalMemory := totalMemory.(type) {
 	case uint64:
-		return totalMemory.(uint64), nil
+		return totalMemory, nil
 	case int:
-		return uint64(totalMemory.(int)), nil
+		if totalMemory < 0 {
+			return 0, fmt.Errorf("unexpected memory value %v", totalMemory)
+		}
+		//nolint:gosec  // Here we are sure that the value will fit in memory and be positive.
+		return uint64(totalMemory), nil
 	default:
-		return 0, fmt.Errorf("unsupported attribute type %v", t)
+		return 0, fmt.Errorf("unsupported attribute type %v", totalMemory)
 	}
 }
 

--- a/internal/resource/sysfs-lib.go
+++ b/internal/resource/sysfs-lib.go
@@ -64,9 +64,8 @@ func (l *vfioLib) GetDevices() ([]Device, error) {
 }
 
 // GetCudaDriverVersion is not supported
-func (l *vfioLib) GetCudaDriverVersion() (*uint, *uint, error) {
-	unknown := uint(0)
-	return &unknown, &unknown, nil
+func (l *vfioLib) GetCudaDriverVersion() (int, int, error) {
+	return 0, 0, nil
 }
 
 // GetDriverVersion is not supported

--- a/internal/resource/testing/resource-testing.go
+++ b/internal/resource/testing/resource-testing.go
@@ -123,10 +123,8 @@ func NewManagerMockWithDevices(devices ...resource.Device) *ManagerMock {
 		GetDevicesFunc: func() ([]resource.Device, error) {
 			return devices, nil
 		},
-		GetCudaDriverVersionFunc: func() (*uint, *uint, error) {
-			var major uint = 8
-			var minor uint = 0
-			return &major, &minor, nil
+		GetCudaDriverVersionFunc: func() (int, int, error) {
+			return 8, 0, nil
 		},
 	}}
 	return &manager

--- a/internal/resource/types.go
+++ b/internal/resource/types.go
@@ -18,13 +18,13 @@ package resource
 
 // Manager defines an interface for managing devices
 //
-//go:generate moq -out manager_mock.go . Manager
+//go:generate moq -rm -out manager_mock.go . Manager
 type Manager interface {
 	Init() error
 	Shutdown() error
 	GetDevices() ([]Device, error)
 	GetDriverVersion() (string, error)
-	GetCudaDriverVersion() (*uint, *uint, error)
+	GetCudaDriverVersion() (int, int, error)
 }
 
 // Device defines an interface for a device with which labels are associated


### PR DESCRIPTION
This PR makes the following changes to address `golangci-lint` errors:

* updates the `GetCudaDriverVersion` return type to `(int, int, error)` instead of `(*uint, *uint, error)`. This prevents unneeded type conversions and pointer operations.
* adds an explicit check in the testing-only `int` -> `uint64` type conversion for MIG memory.