### PR TITLE
 Add optional injection of the default IMEX channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   - [Shared Access to GPUs](#shared-access-to-gpus)
     - [With CUDA Time-Slicing](#with-cuda-time-slicing)
     - [With CUDA MPS](#with-cuda-mps)
+  - [IMEX Support](#imex-support)
 - [Deployment via `helm`](#deployment-via-helm)
   - [Configuring the device plugin's `helm` chart](#configuring-the-device-plugins-helm-chart)
     - [Passing configuration to the plugin via a `ConfigMap`.](#passing-configuration-to-the-plugin-via-a-configmap)
@@ -569,6 +570,26 @@ total memory and compute resources of the GPU.
 
 **Note**: As of now, the only supported resource available for MPS are `nvidia.com/gpu`
 resources and only with full GPUs.
+
+### IMEX Support
+
+The NVIDIA GPU Device Plugin can be configured to inject IMEX channels into
+workloads.
+
+This opt-in behavior is global and affects all workloads and is controlled by
+the `imex.channelIDs` and `imex.required` configuration options.
+
+| `imex.channelIDs` | `imex.required` | Effect |
+|---|---|---|
+| `[]` | * | (default) No IMEX channels are added to workload requests. Note that the `imex.required` field has no effect in this case |
+| `[0]` | `false` | If the requested IMEX channel (`0`) is discoverable by the NVIDIA GPU Device Plugin, the channel will be added to each workload request. If the channel cannot be discovered no channels are added to workload requests. |
+| `[0]` | `true` | If the requested IMEX channel (`0`) is discoverable by the NVIDIA GPU Device Plugin, the channel will be added to each workload request. If the channel cannot be discovered an error will be raised since the channel was marked as `required`. |
+
+**Note**: At present the only valid `imex.channelIDs` configurations are `[]` and `[0]`.
+
+For the containerized NVIDIA GPU Device Plugin running to be able to successfully
+discover available IMEX channels, the corresponding device nodes must be available
+to the container.
 
 ## Deployment via `helm`
 

--- a/api/config/v1/config.go
+++ b/api/config/v1/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	Flags     Flags     `json:"flags,omitempty"     yaml:"flags,omitempty"`
 	Resources Resources `json:"resources,omitempty" yaml:"resources,omitempty"`
 	Sharing   Sharing   `json:"sharing,omitempty"   yaml:"sharing,omitempty"`
+	Imex      Imex      `json:"imex,omitempty"      yaml:"imex,omitempty"`
 }
 
 // NewConfig builds out a Config struct from a config file (or command line flags).
@@ -52,6 +53,14 @@ func NewConfig(c *cli.Context, flags []cli.Flag) (*Config, error) {
 	}
 
 	config.Flags.UpdateFromCLIFlags(c, flags)
+	// TODO: This is currently not at the flags level?
+	// Does this mean that we should move UpdateFromCLIFlags to function off Config?
+	if c.IsSet("imex-channel-ids") {
+		config.Imex.ChannelIDs = c.IntSlice("imex-channel-ids")
+	}
+	if c.IsSet("imex-required") {
+		config.Imex.Required = c.Bool("imex-required")
+	}
 
 	// If nvidiaDevRoot (the path to the device nodes on the host) is not set,
 	// we default to using the driver root on the host.

--- a/api/config/v1/imex.go
+++ b/api/config/v1/imex.go
@@ -1,0 +1,53 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package v1
+
+import (
+	"errors"
+	"fmt"
+)
+
+const (
+	ImexChannelEnvVar = "NVIDIA_IMEX_CHANNELS"
+)
+
+var errInvalidImexConfig = errors.New("invalid IMEX config")
+
+// Imex stores the configuration options for fabric-attached devices.
+type Imex struct {
+	// ChannelIDs defines a list of channel IDs to inject into containers that request NVIDIA devices.
+	// If a channel ID is specified and the associated channel device node exists, the corresponding
+	// channel will be added to the ContainerAllocateResponse for containers with access to NVIDIA
+	// devices.
+	ChannelIDs []int `json:"channelIDs,omitempty" yaml:"channelIDs,omitempty"`
+	// Required specifies whether the requested IMEX channel IDs are required or not.
+	// If a channel is required, it is expected to exist as the device plugin starts.
+	// If it is not required its injection is skipped if the device nodes do not exist or if its
+	// existence cannot be queried.
+	Required bool `json:"required,omitempty" yaml:"required,omitempty"`
+}
+
+// AssertChannelIDsIsValid checks whether the specified list of channel IDs is valid.
+func AssertChannelIDsValid(ids []int) error {
+	switch {
+	case len(ids) == 0:
+		return nil
+	case len(ids) == 1 && ids[0] == 0:
+		return nil
+	}
+	return fmt.Errorf("%w: channelIDs must be [] or [0]; found %v", errInvalidImexConfig, ids)
+}

--- a/api/config/v1/imex_test.go
+++ b/api/config/v1/imex_test.go
@@ -1,0 +1,83 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestImexUnmarshal(t *testing.T) {
+	testCases := []struct {
+		description   string
+		input         string
+		expected      Imex
+		expectedError error
+	}{
+		{
+			description: "empty json",
+			input:       "{}",
+			expected:    Imex{},
+		},
+		{
+			description: "null channel ID is valid",
+			input:       `{"channelIDs": null}`,
+			expected:    Imex{},
+		},
+		{
+			description: "empty channel ID is valid",
+			input:       `{"channelIDs": []}`,
+			expected: Imex{
+				ChannelIDs: []int{},
+			},
+		},
+		{
+			description: "single 0 channel ID is valid",
+			input:       `{"channelIDs": [0]}`,
+			expected: Imex{
+				ChannelIDs: []int{0},
+			},
+		},
+		{
+			description: "single 0 channel ID as int is valid",
+			input:       `{"channelIDs": [0]}`,
+			expected: Imex{
+				ChannelIDs: []int{0},
+			},
+		},
+		{
+			description: "invalid cases",
+			input:       `{"channelIDs": [2]}`,
+			expected: Imex{
+				ChannelIDs: []int{2},
+			},
+			expectedError: errInvalidImexConfig,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			var output Imex
+			err := json.Unmarshal([]byte(tc.input), &output)
+			require.ErrorIs(t, errors.Join(err, AssertChannelIDsValid(output.ChannelIDs)), tc.expectedError)
+			require.Equal(t, tc.expected, output)
+		})
+	}
+}

--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -149,6 +149,16 @@ func main() {
 			Usage:   "the strategy to use to discover devices: 'auto', 'nvml', or 'tegra'",
 			EnvVars: []string{"DEVICE_DISCOVERY_STRATEGY"},
 		},
+		&cli.IntSliceFlag{
+			Name:    "imex-channel-ids",
+			Usage:   "A list of IMEX channels to inject.",
+			EnvVars: []string{"IMEX_CHANNEL_IDS"},
+		},
+		&cli.BoolFlag{
+			Name:    "imex-required",
+			Usage:   "The specified IMEX channels are required",
+			EnvVars: []string{"IMEX_REQUIRED"},
+		},
 	}
 
 	err := c.Run(os.Args)
@@ -188,6 +198,10 @@ func validateFlags(infolib nvinfo.Interface, config *spec.Config) error {
 	case "tegra":
 	default:
 		return fmt.Errorf("invalid --device-discovery-strategy option %v", *config.Flags.DeviceDiscoveryStrategy)
+	}
+
+	if err := spec.AssertChannelIDsValid(config.Imex.ChannelIDs); err != nil {
+		return fmt.Errorf("invalid IMEX channel IDs: %w", err)
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	sigs.k8s.io/node-feature-discovery v0.15.4
 	sigs.k8s.io/yaml v1.4.0
 	tags.cncf.io/container-device-interface v0.8.0
+	tags.cncf.io/container-device-interface/specs-go v0.8.0
 )
 
 require (
@@ -77,5 +78,4 @@ require (
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )

--- a/internal/cdi/api.go
+++ b/internal/cdi/api.go
@@ -16,10 +16,16 @@
 
 package cdi
 
+import "github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/spec"
+
 // Interface provides the API to the 'cdi' package
 //
 //go:generate moq -stub -out api_mock.go . Interface
 type Interface interface {
 	CreateSpecFile() error
 	QualifiedName(string, string) string
+}
+
+type cdiSpecGenerator interface {
+	GetSpec() (spec.Interface, error)
 }

--- a/internal/cdi/imex.go
+++ b/internal/cdi/imex.go
@@ -1,0 +1,63 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package cdi
+
+import (
+	"tags.cncf.io/container-device-interface/specs-go"
+
+	"github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/spec"
+
+	"github.com/NVIDIA/k8s-device-plugin/internal/imex"
+)
+
+type imexChannelCDILib struct {
+	vendor       string
+	imexChannels imex.Channels
+}
+
+func (cdi *cdiHandler) newImexChannelSpecGenerator() cdiSpecGenerator {
+	lib := &imexChannelCDILib{
+		vendor:       cdi.vendor,
+		imexChannels: cdi.imexChannels,
+	}
+
+	return lib
+}
+
+// GetSpec returns the CDI specs for IMEX channels.
+func (l *imexChannelCDILib) GetSpec() (spec.Interface, error) {
+	var deviceSpecs []specs.Device
+	for _, channel := range l.imexChannels {
+		deviceSpec := specs.Device{
+			Name: channel.ID,
+			ContainerEdits: specs.ContainerEdits{
+				DeviceNodes: []*specs.DeviceNode{
+					{
+						Path:     channel.Path,
+						HostPath: channel.HostPath,
+					},
+				},
+			},
+		}
+		deviceSpecs = append(deviceSpecs, deviceSpec)
+	}
+	return spec.New(
+		spec.WithDeviceSpecs(deviceSpecs),
+		spec.WithVendor(l.vendor),
+		spec.WithClass("imex-channel"),
+	)
+}

--- a/internal/cdi/options.go
+++ b/internal/cdi/options.go
@@ -18,6 +18,7 @@ package cdi
 
 import (
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
+	"github.com/NVIDIA/k8s-device-plugin/internal/imex"
 )
 
 // Option defines a function for passing options to the New() call
@@ -90,5 +91,12 @@ func WithGdsEnabled(enabled bool) Option {
 func WithMofedEnabled(enabled bool) Option {
 	return func(c *cdiHandler) {
 		c.mofedEnabled = enabled
+	}
+}
+
+// WithImexChannels sets the IMEX channels for which CDI specs should be generated.
+func WithImexChannels(imexChannels imex.Channels) Option {
+	return func(c *cdiHandler) {
+		c.imexChannels = imexChannels
 	}
 }

--- a/internal/imex/imex.go
+++ b/internal/imex/imex.go
@@ -1,0 +1,98 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package imex
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/klog/v2"
+
+	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
+)
+
+// Channels represents a set of IMEX channels.
+type Channels []*Channel
+
+// Channel represents an IMEX channel.
+type Channel struct {
+	ID       string
+	Path     string
+	HostPath string
+}
+
+// GetChannels returns the set of channels for the given config.
+// If the selection of the default IMEX channel is disabled no channels are returned.
+func GetChannels(config *spec.Config, devRoot string) (Channels, error) {
+	var channels Channels
+	for _, channelID := range config.Imex.ChannelIDs {
+		id := fmt.Sprintf("%d", channelID)
+		channelName := "channel" + id
+		path := filepath.Join("/dev/nvidia-caps-imex-channels", channelName)
+		channel := Channel{
+			ID:       id,
+			Path:     path,
+			HostPath: filepath.Join(devRoot, path),
+		}
+		if exists, err := channel.exists(); !exists {
+			if config.Imex.Required {
+				return nil, errors.Join(err, fmt.Errorf("requested IMEX channel %v does not exist", channelName))
+			}
+			klog.Warningf("Ignoring requested IMEX channel %v (%v)", channelName, err)
+			continue
+		}
+		klog.Infof("Selecting IMEX channel %v", channelName)
+		channels = append(channels, &channel)
+	}
+	return channels, nil
+}
+
+// exists checks whether the IMEX channel exists.
+// We check both the Path and HostPath since the location of the device node
+// associated with the channel in the container is dependent on how it is
+// injected.
+// For example, if the host driver root is mounted at /driver-root the channel
+// device node would be available at /driver-root/dev even if it was not
+// injected into the container through any other mechanism.
+// For the case of management containers using CDI to inject device nodes, these
+// device nodes would exist at /dev in the container instead.
+func (c Channel) exists() (bool, error) {
+	paths := []string{c.HostPath}
+	if c.HostPath != c.Path {
+		paths = append(paths, c.Path)
+	}
+	var errs error
+	for _, path := range paths {
+		info, err := os.Stat(path)
+		if os.IsNotExist(err) {
+			continue
+		}
+		if err != nil {
+			errs = errors.Join(errs, err)
+			continue
+		}
+
+		if info.Mode()&os.ModeCharDevice == 0 {
+			errs = errors.Join(errs, fmt.Errorf("%v is not a character device", path))
+			continue
+		}
+		return true, nil
+	}
+	return false, errs
+}

--- a/internal/plugin/manager/factory.go
+++ b/internal/plugin/manager/factory.go
@@ -26,6 +26,7 @@ import (
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 	"github.com/NVIDIA/k8s-device-plugin/internal/cdi"
+	"github.com/NVIDIA/k8s-device-plugin/internal/imex"
 )
 
 type manager struct {
@@ -38,6 +39,8 @@ type manager struct {
 
 	cdiHandler cdi.Interface
 	config     *spec.Config
+
+	imexChannels imex.Channels
 
 	kubeletSocket string
 }

--- a/internal/plugin/manager/nvml.go
+++ b/internal/plugin/manager/nvml.go
@@ -34,7 +34,7 @@ func (m *nvmlmanager) GetPlugins() ([]plugin.Interface, error) {
 
 	var plugins []plugin.Interface
 	for _, r := range rms {
-		plugin, err := plugin.NewNvidiaDevicePlugin(m.config, m.kubeletSocket, r, m.cdiHandler)
+		plugin, err := plugin.NewNvidiaDevicePlugin(m.config, m.kubeletSocket, r, m.cdiHandler, m.imexChannels)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create plugin: %w", err)
 		}

--- a/internal/plugin/manager/options.go
+++ b/internal/plugin/manager/options.go
@@ -22,6 +22,7 @@ import (
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 	"github.com/NVIDIA/k8s-device-plugin/internal/cdi"
+	"github.com/NVIDIA/k8s-device-plugin/internal/imex"
 )
 
 // Option is a function that configures a manager
@@ -72,5 +73,12 @@ func WithConfig(config *spec.Config) Option {
 func WithKubeletSocket(kubeletSocket string) Option {
 	return func(m *manager) {
 		m.kubeletSocket = kubeletSocket
+	}
+}
+
+// WithImexChannels sets the imex channels for the manager.
+func WithImexChannels(imexChannels imex.Channels) Option {
+	return func(m *manager) {
+		m.imexChannels = imexChannels
 	}
 }

--- a/internal/plugin/manager/tegra.go
+++ b/internal/plugin/manager/tegra.go
@@ -34,7 +34,7 @@ func (m *tegramanager) GetPlugins() ([]plugin.Interface, error) {
 
 	var plugins []plugin.Interface
 	for _, r := range rms {
-		plugin, err := plugin.NewNvidiaDevicePlugin(m.config, m.kubeletSocket, r, m.cdiHandler)
+		plugin, err := plugin.NewNvidiaDevicePlugin(m.config, m.kubeletSocket, r, m.cdiHandler, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create plugin: %w", err)
 		}

--- a/internal/plugin/server.go
+++ b/internal/plugin/server.go
@@ -31,6 +31,7 @@ import (
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 	"github.com/NVIDIA/k8s-device-plugin/cmd/mps-control-daemon/mps"
 	"github.com/NVIDIA/k8s-device-plugin/internal/cdi"
+	"github.com/NVIDIA/k8s-device-plugin/internal/imex"
 	"github.com/NVIDIA/k8s-device-plugin/internal/rm"
 
 	"github.com/google/uuid"
@@ -67,10 +68,12 @@ type NvidiaDevicePlugin struct {
 
 	mpsDaemon   *mps.Daemon
 	mpsHostRoot mps.Root
+
+	imexChannels imex.Channels
 }
 
 // NewNvidiaDevicePlugin returns an initialized NvidiaDevicePlugin
-func NewNvidiaDevicePlugin(config *spec.Config, kubeletSocket string, resourceManager rm.ResourceManager, cdiHandler cdi.Interface) (*NvidiaDevicePlugin, error) {
+func NewNvidiaDevicePlugin(config *spec.Config, kubeletSocket string, resourceManager rm.ResourceManager, cdiHandler cdi.Interface, imexChannels imex.Channels) (*NvidiaDevicePlugin, error) {
 	_, name := resourceManager.Resource().Split()
 
 	deviceListStrategies, _ := spec.NewDeviceListStrategies(*config.Flags.Plugin.DeviceListStrategy)
@@ -99,6 +102,8 @@ func NewNvidiaDevicePlugin(config *spec.Config, kubeletSocket string, resourceMa
 		socket:               pluginPath + ".sock",
 		cdiHandler:           cdiHandler,
 		cdiAnnotationPrefix:  *config.Flags.Plugin.CDIAnnotationPrefix,
+
+		imexChannels: imexChannels,
 
 		mpsDaemon:   mpsDaemon,
 		mpsHostRoot: mpsHostRoot,
@@ -364,6 +369,7 @@ func (plugin *NvidiaDevicePlugin) getAllocateResponse(requestIds []string) (*plu
 
 	if plugin.deviceListStrategies.Includes(spec.DeviceListStrategyEnvVar) {
 		plugin.updateResponseForDeviceListEnvVar(response, deviceIDs...)
+		plugin.updateResponseForImexChannelsEnvVar(response)
 	}
 	if plugin.deviceListStrategies.Includes(spec.DeviceListStrategyVolumeMounts) {
 		plugin.updateResponseForDeviceMounts(response, deviceIDs...)
@@ -406,6 +412,9 @@ func (plugin *NvidiaDevicePlugin) updateResponseForCDI(response *pluginapi.Conta
 	var devices []string
 	for _, id := range deviceIDs {
 		devices = append(devices, plugin.cdiHandler.QualifiedName("gpu", id))
+	}
+	for _, channel := range plugin.imexChannels {
+		devices = append(devices, plugin.cdiHandler.QualifiedName("imex-channel", channel.ID))
 	}
 	if *plugin.config.Flags.GDSEnabled {
 		devices = append(devices, plugin.cdiHandler.QualifiedName("gds", "all"))
@@ -502,13 +511,32 @@ func (plugin *NvidiaDevicePlugin) updateResponseForDeviceListEnvVar(response *pl
 	response.Envs[plugin.deviceListEnvVar] = strings.Join(deviceIDs, ",")
 }
 
+// updateResponseForImexChannelsEnvVar sets the environment variable for the requested IMEX channels.
+func (plugin *NvidiaDevicePlugin) updateResponseForImexChannelsEnvVar(response *pluginapi.ContainerAllocateResponse) {
+	var channelIDs []string
+	for _, channel := range plugin.imexChannels {
+		channelIDs = append(channelIDs, channel.ID)
+	}
+	if len(channelIDs) > 0 {
+		response.Envs[spec.ImexChannelEnvVar] = strings.Join(channelIDs, ",")
+	}
+}
+
 // updateResponseForDeviceMounts sets the mounts required to request devices if volume mounts are used.
 func (plugin *NvidiaDevicePlugin) updateResponseForDeviceMounts(response *pluginapi.ContainerAllocateResponse, deviceIDs ...string) {
 	plugin.updateResponseForDeviceListEnvVar(response, deviceListAsVolumeMountsContainerPathRoot)
+
 	for _, id := range deviceIDs {
 		mount := &pluginapi.Mount{
 			HostPath:      deviceListAsVolumeMountsHostPath,
 			ContainerPath: filepath.Join(deviceListAsVolumeMountsContainerPathRoot, id),
+		}
+		response.Mounts = append(response.Mounts, mount)
+	}
+	for _, channel := range plugin.imexChannels {
+		mount := &pluginapi.Mount{
+			HostPath:      deviceListAsVolumeMountsHostPath,
+			ContainerPath: filepath.Join(deviceListAsVolumeMountsContainerPathRoot, "imex", channel.ID),
 		}
 		response.Mounts = append(response.Mounts, mount)
 	}
@@ -534,6 +562,15 @@ func (plugin *NvidiaDevicePlugin) apiDeviceSpecs(devRoot string, ids []string) [
 		spec := &pluginapi.DeviceSpec{
 			ContainerPath: p,
 			HostPath:      filepath.Join(devRoot, p),
+			Permissions:   "rw",
+		}
+		specs = append(specs, spec)
+	}
+
+	for _, channel := range plugin.imexChannels {
+		spec := &pluginapi.DeviceSpec{
+			ContainerPath: channel.Path,
+			HostPath:      channel.HostPath,
 			Permissions:   "rw",
 		}
 		specs = append(specs, spec)

--- a/internal/plugin/server_test.go
+++ b/internal/plugin/server_test.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 	"github.com/NVIDIA/k8s-device-plugin/internal/cdi"
+	"github.com/NVIDIA/k8s-device-plugin/internal/imex"
 )
 
 func TestCDIAllocateResponse(t *testing.T) {
@@ -35,6 +36,7 @@ func TestCDIAllocateResponse(t *testing.T) {
 		CDIEnabled           bool
 		GDSEnabled           bool
 		MOFEDEnabled         bool
+		imexChannels         []*imex.Channel
 		expectedResponse     pluginapi.ContainerAllocateResponse
 	}{
 		{
@@ -129,6 +131,18 @@ func TestCDIAllocateResponse(t *testing.T) {
 				},
 			},
 		},
+		{
+			description:          "imex channel is included with devices",
+			deviceListStrategies: []string{"cdi-annotations"},
+			CDIPrefix:            "cdi.k8s.io/",
+			CDIEnabled:           true,
+			imexChannels:         []*imex.Channel{{ID: "0"}},
+			expectedResponse: pluginapi.ContainerAllocateResponse{
+				Annotations: map[string]string{
+					"cdi.k8s.io/nvidia-device-plugin_uuid": "nvidia.com/imex-channel=0",
+				},
+			},
+		},
 	}
 
 	for i := range testCases {
@@ -152,6 +166,7 @@ func TestCDIAllocateResponse(t *testing.T) {
 				cdiEnabled:           tc.CDIEnabled,
 				deviceListStrategies: deviceListStrategies,
 				cdiAnnotationPrefix:  tc.CDIPrefix,
+				imexChannels:         tc.imexChannels,
 			}
 
 			response := pluginapi.ContainerAllocateResponse{}


### PR DESCRIPTION
These changes allow users to op-in to injecting the default IMEX channel (`channel0`) into workloads.

The following config options are added:
```
imex:
  channelIDs: []
  required: false
```
where `imex.channelIDs` indicates the list of channels (if any) to be injected into workload containers. The only valid values are currently `[]` and `[0]`.

If a channel is specified, the plugin will check if the corresponding device node exists and inject the channel into the `ContainerAllocateResponse` if it does. If `imex.required == true` then an error is raised if the device node does not exist.

The mechanism of injection depends on the `deviceListStrategy` as follows:
* `deviceListStrategy=envvar`: the IMEX channel is requested by setting the `NVIDIA_IMEX_CHANNELS` environment variable in `ContainerAllocateResponse`.
* `deviceListStrategy=cdi*`: the device plugin generates a CDI specification for the IMEX channel and adds a CDI device request to the `ContainerAllocateResponse`.
* `deviceListStrategy=volume-mounts`: the IMEX channel is requested by adding a `/var/run/nvidia-container-devices/imex/0` volume mount. This requires the toolkit support from https://github.com/NVIDIA/nvidia-container-toolkit/pull/740

---

**Testing**

Build the image
```shell
make -f deployments/container/Makefile build VERSION=imex-devel ARCH=arm64
```
and ensure that the `nvcr.io/nvidia/k8s-device-plugin:imex-devel-ubi9` is available to each node.

Create the following namespace for the demos:
```
kubectl create ns demo
```

Create the following config files:
```
cat << EOF > dp-default-config.yaml
version: v1
EOF
```

```
cat << EOF > dp-imex-envvar-config.yaml
version: v1
flags:
  plugin:
    deviceListStrategy:
    - envvar
imex:
  channelIDs:
  - 0
EOF
```

```
cat << EOF > dp-imex-cdi-annotations-config.yaml
version: v1
flags:
  plugin:
    deviceListStrategy:
    - cdi-annotations
imex:
  channelIDs:
  - 0
EOF
```

Deploy the device plugin:
```shell
helm upgrade nvidia-device-plugin -i deployments/helm/nvidia-device-plugin \
    --namespace nvidia-device-plugin \
    --create-namespace \
    --set nvidiaDriverRoot=/ \
    --set runtimeClassName=nvidia \
    --set image.tag=imex-devel-ubi9 \
    --set-file config.map.default=dp-default-config.yaml \
    --set-file config.map.imex-envvar-config=dp-imex-envvar-config.yaml \
    --set-file config.map.imex-cdi-annotations-config=dp-imex-cdi-annotations-config.yaml \
```

**Note:** We set `nvidiaDriverRoot` to allow for IMEX devs to be located at `/driver-root/dev`.
This is also required for CDI spec generation to function as expected.


## Default configuration

Confirm that the imex config is empty:
```shell
kubectl logs -n nvidia-device-plugin \
    $(kubectl get pods -n nvidia-device-plugin -o custom-columns=NAME:.metadata.name | tail -1) \
    -c nvidia-device-plugin-ctr | grep -A2 imex
```

```
kubectl logs -n nvidia-device-plugin     $(kubectl get pods -n nvidia-device-plugin -o custom-columns=NAME:.metadata.name | tail -1)     -c nvidia-device-plugin-ctr | grep -A2 imex
  "imex": {}
}
I1011 12:52:06.624171      44 main.go:334] Retrieving plugins.
```

### Deploy a workload

Run a no-op sample requesting a GPU:
```
cat <<EOF | kubectl apply -f -
---
apiVersion: v1
kind: Pod
metadata:
  namespace: demo
  name: demo-pod
spec:
  runtimeClassName: nvidia
  restartPolicy: OnFailure
  containers:
  - name: demo-ctr
    image: ubuntu
    command: ["sleep", "9999"]
    resources:
      limits:
        nvidia.com/gpu: 1
EOF
```

Check the container environment and which NVIDIA devices are injected:
```
kubectl exec -ti -n demo demo-pod -- bash -c "echo 'devices'; ls -al /dev/nv*; echo 'env'; env | grep NVIDIA_"
```
```
devices
crw-rw-rw- 1 root root 502,   0 Oct 10 04:14 /dev/nvidia-uvm
crw-rw-rw- 1 root root 502,   1 Oct 10 04:14 /dev/nvidia-uvm-tools
crw-rw-rw- 1 root root 195,   0 Oct 10 04:13 /dev/nvidia0
crw-rw-rw- 1 root root 195, 255 Oct 10 04:13 /dev/nvidiactl
env
NVIDIA_VISIBLE_DEVICES=GPU-101ac189-c246-adb9-6e96-f7ab66dee379
```

Remove the demo pod:
```
kubectl delete pod -n demo demo-pod
```

## DefaultChannelStrategy=enabled deviceListStrategy=envvar

Apply the required config:
```shell
kubectl label node --all --overwrite nvidia.com/device-plugin.config=imex-envvar-config
```

Confirm that the IMEX config is applied:
```
$ kubectl logs -n nvidia-device-plugin     $(kubectl get pods -n nvidia-device-plugin -o custom-columns=NAME:.metadata.name | tail -1)     -c nvidia-device-plugin-ctr | grep -A3 imex
  "imex": {}
}
I1011 12:53:22.710244      43 main.go:334] Retrieving plugins.
I1011 12:53:22.757053      43 server.go:218] Starting GRPC server for 'nvidia.com/gpu'
--
  "imex": {
    "channelIDs": [
      "0"
    ]
```
(note that since the plugin main loop is restarted, the original output is also captured)

### Deploy a workload

Run a no-op sample requesting a GPU:
```
cat <<EOF | kubectl apply -f -
---
apiVersion: v1
kind: Pod
metadata:
  namespace: demo
  name: demo-pod
spec:
  runtimeClassName: nvidia
  restartPolicy: OnFailure
  containers:
  - name: demo-ctr
    image: ubuntu
    command: ["sleep", "9999"]
    resources:
      limits:
        nvidia.com/gpu: 1
EOF
```

Check the container environment and which NVIDIA devices are injected:
```
kubectl exec -ti -n demo demo-pod -- bash -c "echo 'devices'; ls -al /dev/nv*; echo 'env'; env | grep NVIDIA_"
```
```
devices
crw-rw-rw- 1 root root 502,   0 Oct 10 04:14 /dev/nvidia-uvm
crw-rw-rw- 1 root root 502,   1 Oct 10 04:14 /dev/nvidia-uvm-tools
crw-rw-rw- 1 root root 195,   1 Oct 10 04:13 /dev/nvidia1
crw-rw-rw- 1 root root 195, 255 Oct 10 04:13 /dev/nvidiactl

/dev/nvidia-caps-imex-channels:
total 0
drwxr-xr-x 2 root root     60 Oct 10 14:21 .
drwxr-xr-x 6 root root    460 Oct 10 14:21 ..
crw-rw-rw- 1 root root 508, 0 Oct 10 04:15 channel0
env
NVIDIA_VISIBLE_DEVICES=GPU-970c1f22-f1ca-482d-ab14-aea1d83ba922
NVIDIA_IMEX_CHANNELS=0
```

Remove the demo pod:
```
kubectl delete pod -n demo demo-pod
```

## DefaultChannelStrategy=enabled deviceListStrategy=cdi-annotations

Apply the required config:
```shell
kubectl label node --all --overwrite nvidia.com/device-plugin.config=imex-cdi-annotations-config
```

Confirm that the IMEX config is applied:
```
 kubectl logs -n nvidia-device-plugin     $(kubectl get pods -n nvidia-device-plugin -o custom-columns=NAME:.metadata.name | tail -1)     -c nvidia-device-plugin-ctr | grep -i -A3 imex
  "imex": {}
}
I1011 12:53:22.710244      43 main.go:334] Retrieving plugins.
I1011 12:53:22.757053      43 server.go:218] Starting GRPC server for 'nvidia.com/gpu'
--
  "imex": {
    "channelIDs": [
      "0"
    ]
--
  "imex": {
    "channelIDs": [
      "0"
    ]
--
time="2024-10-11T12:57:26Z" level=info msg="Generating CDI spec for resource: k8s.device-plugin.nvidia.com/imex-channel"
I1011 12:57:26.876356      43 server.go:218] Starting GRPC server for 'nvidia.com/gpu'
I1011 12:57:26.876780      43 server.go:149] Starting to serve 'nvidia.com/gpu' on /var/lib/kubelet/device-plugins/nvidia-gpu.sock
I1011 12:57:26.878187      43 server.go:156] Registered device plugin for 'nvidia.com/gpu' with Kubelet
```
Note the additional logging for generating the IMEX channel CDI spec.


When this mode is configured we can check the following on one of the nodes:
```
$ nvidia-ctk cdi list 2>/dev/null
k8s.device-plugin.nvidia.com/gpu=GPU-30dcdd9d-2489-f021-8297-5ff9406e5cc9
k8s.device-plugin.nvidia.com/gpu=GPU-43f40e92-a51c-a02d-cb07-ac8c8b6b8965
k8s.device-plugin.nvidia.com/imex-channel=0
nvidia.com/gpu=0
nvidia.com/gpu=1
nvidia.com/gpu=GPU-30dcdd9d-2489-f021-8297-5ff9406e5cc9
nvidia.com/gpu=GPU-43f40e92-a51c-a02d-cb07-ac8c8b6b8965
nvidia.com/gpu=all
```
with:
```
cat /var/run/cdi/k8s.device-plugin.nvidia.com-imex-channel.json | jq
{
  "cdiVersion": "0.5.0",
  "kind": "k8s.device-plugin.nvidia.com/imex-channel",
  "devices": [
    {
      "name": "0",
      "containerEdits": {
        "deviceNodes": [
          {
            "path": "/dev/nvidia-caps-imex-channels/channel0",
            "hostPath": "/dev/nvidia-caps-imex-channels/channel0"
          }
        ]
      }
    }
  ],
  "containerEdits": {}
}
```

### Deploy a workload

Run a no-op sample requesting a GPU:
```
cat <<EOF | kubectl apply -f -
---
apiVersion: v1
kind: Pod
metadata:
  namespace: demo
  name: demo-pod
spec:
  runtimeClassName: nvidia
  restartPolicy: OnFailure
  containers:
  - name: demo-ctr
    image: ubuntu
    command: ["sleep", "9999"]
    resources:
      limits:
        nvidia.com/gpu: 1
EOF
```

Check the container environment and which NVIDIA devices are injected:
```
kubectl exec -ti -n demo demo-pod -- bash -c "echo 'devices'; ls -al /dev/nv*; echo 'env'; env | grep NVIDIA_"
```
```
devices
crw-rw-rw- 1 root root 195, 254 Oct 10 14:28 /dev/nvidia-modeset
crw-rw-rw- 1 root root 502,   0 Oct 10 14:28 /dev/nvidia-uvm
crw-rw-rw- 1 root root 502,   1 Oct 10 14:28 /dev/nvidia-uvm-tools
crw-rw-rw- 1 root root 195,   1 Oct 10 14:28 /dev/nvidia1
crw-rw-rw- 1 root root 195, 255 Oct 10 14:28 /dev/nvidiactl

/dev/nvidia-caps-imex-channels:
total 0
drwxr-xr-x 2 root root     60 Oct 10 14:28 .
drwxr-xr-x 7 root root    500 Oct 10 14:28 ..
crw-rw-rw- 1 root root 510, 0 Oct 10 14:28 channel0
env
NVIDIA_VISIBLE_DEVICES=void
```
Note that no `NVIDIA_IMEX_CHANNELS` envvar is present.

Remove the demo pod:
```
kubectl delete pod -n demo demo-pod
```



