### PR TITLE
[no-relnote] Allow ARCH to be specified for single image

### DIFF
--- a/deployments/container/native-only.mk
+++ b/deployments/container/native-only.mk
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 PUSH_ON_BUILD ?= false
-DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64
+ARCH ?= $(shell uname -m)
+DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/$(ARCH)
 
 ifeq ($(PUSH_ON_BUILD),true)
 $(BUILD_TARGETS): build-%: image-%


### PR DESCRIPTION
This changes allows the image architecture to be specified when building a "native" image. This is usefull when testing accross architectures.