### PR TITLE
Fix IMEX injection when passing device nodes

### DIFF
--- a/internal/plugin/server.go
+++ b/internal/plugin/server.go
@@ -529,8 +529,14 @@ func (plugin *nvidiaDevicePlugin) apiDeviceSpecs(devRoot string, ids []string) [
 	for _, channel := range plugin.imexChannels {
 		spec := &pluginapi.DeviceSpec{
 			ContainerPath: channel.Path,
-			HostPath:      channel.HostPath,
-			Permissions:   "rw",
+			// TODO: The HostPath property for a channel is not the correct value to use here.
+			// The `devRoot` there represents the devRoot in the current container when discovering devices
+			// and is set to "{{ .*config.Flags.Plugin.ContainerDriverRoot }}/dev".
+			// The devRoot in this context is the {{ .config.Flags.NvidiaDevRoot }} and defines the
+			// root for device nodes on the host. This is usually / or /run/nvidia/driver when the
+			// driver container is used.
+			HostPath:    filepath.Join(devRoot, channel.Path),
+			Permissions: "rw",
 		}
 		specs = append(specs, spec)
 	}


### PR DESCRIPTION
This change fixes an incorrect HostPath for IMEX channels when passing device specs as part of the ContainerAllocateResponse.