### PR TITLE
use uuid.NewSHA1 package to generate uuids

### DIFF
--- a/internal/lm/fabric.go
+++ b/internal/lm/fabric.go
@@ -20,17 +20,16 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"math/rand" // nolint:gosec
 	"net"
 	"os"
 	"sort"
 	"strings"
 
-	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
-	"github.com/NVIDIA/k8s-device-plugin/internal/resource"
-
 	"github.com/google/uuid"
 	"k8s.io/klog/v2"
+
+	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
+	"github.com/NVIDIA/k8s-device-plugin/internal/resource"
 )
 
 func newImexLabeler(config *spec.Config, devices []resource.Device) (Labeler, error) {
@@ -142,18 +141,5 @@ func getImexDomainID(r io.Reader) (string, error) {
 }
 
 func generateContentUUID(seed string) string {
-	// nolint:gosec
-	rand := rand.New(rand.NewSource(hash(seed)))
-	charset := make([]byte, 16)
-	rand.Read(charset)
-	uuid, _ := uuid.FromBytes(charset)
-	return uuid.String()
-}
-
-func hash(s string) int64 {
-	h := int64(0)
-	for _, c := range s {
-		h = 31*h + int64(c)
-	}
-	return h
+	return uuid.NewSHA1(uuid.Nil, []byte(seed)).String()
 }

--- a/internal/lm/fabric_test.go
+++ b/internal/lm/fabric_test.go
@@ -32,7 +32,7 @@ func TestGerenerateDomainUUID(t *testing.T) {
 		{
 			description: "single IP",
 			ips:         []string{"10.130.3.24"},
-			expected:    "4dbd3d31-fbb3-8a40-33bb-bcc0dd7b68b8",
+			expected:    "60ad7226-0130-54d0-b762-2a5385a3a26f",
 		},
 		{
 			description: "multiple IPs",
@@ -44,7 +44,7 @@ func TestGerenerateDomainUUID(t *testing.T) {
 				"10.130.3.27",
 				"10.130.3.25",
 			},
-			expected: "42401dd1-8a08-1889-4341-8429de2b6f42",
+			expected: "8a7363e9-1003-5814-9354-175fdff19204",
 		},
 	}
 


### PR DESCRIPTION
~Here is a [post](https://go.dev/blog/randv2) that goes into detail on the security limitations of the `math/rand` package.~

~Since the IMEX changes haven't publicised yet, I thought this would be a safe starting point to implement this change~