### PR TITLE
add glibc/lib to library search paths

### DIFF
--- a/cmd/nvidia-device-plugin/root.go
+++ b/cmd/nvidia-device-plugin/root.go
@@ -59,6 +59,7 @@ func (r root) tryResolveLibrary(libraryName string) string {
 		"/lib64",
 		"/lib/x86_64-linux-gnu",
 		"/lib/aarch64-linux-gnu",
+		"/glibc/lib",
 	}
 
 	for _, d := range librarySearchPaths {


### PR DESCRIPTION
## Issue
When running Talos Linux, the Nvidia driver libraries are located under /usr/local/glibc/lib, and the binaries under /usr/local/bin. Using the default search paths, and a `driver-root` value of `/usr/local` the validator is able to locate the binaries, but not the libraries.

## Proposed solution
Add "glibc/lib" to the library search path. This has been tested to work on a Talos cluster running 1.8.1, production drivers (550.90.07) and H100 GPUs

This PR is part of a set of PRs to better support Talos Linux for the GPU Operator.

After the related PRs in [nvidia-container-toolkit](https://github.com/NVIDIA/nvidia-container-toolkit/pull/751) and [go-nvlib](https://github.com/NVIDIA/go-nvlib/pull/47) have been merged and published as updated go packages, the golang dependencies for this repo will have to be updated accordingly to support these changes.