### PR TITLE
Bump release v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### v0.17.0
+- Promote v0.17.0-rc.1 to GA
+
 ### v0.17.0-rc.1
 - Add CAP_SYS_ADMIN if volume-mounts list strategy is included
 - Remove unneeded DEVICE_PLUGIN_MODE envvar

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Once you have configured the options above on all the GPU nodes in your
 cluster, you can enable GPU support by deploying the following Daemonset:
 
 ```shell
-kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.16.2/deployments/static/nvidia-device-plugin.yml
+kubectl create -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.0/deployments/static/nvidia-device-plugin.yml
 ```
 
 **Note:** This is a simple static daemonset meant to demonstrate the basic
@@ -639,12 +639,12 @@ helm repo add nvdp https://nvidia.github.io/k8s-device-plugin
 helm repo update
 ```
 
-Then verify that the latest release (`v0.16.2`) of the plugin is available:
+Then verify that the latest release (`v0.17.0`) of the plugin is available:
 
 ```shell
 $ helm search repo nvdp --devel
 NAME                     	  CHART VERSION  APP VERSION	DESCRIPTION
-nvdp/nvidia-device-plugin	  0.16.2	 0.16.2		A Helm chart for ...
+nvdp/nvidia-device-plugin	  0.17.0	 0.17.0		A Helm chart for ...
 ```
 
 Once this repo is updated, you can begin installing packages from it to deploy
@@ -656,7 +656,7 @@ The most basic installation command without any options is then:
 helm upgrade -i nvdp nvdp/nvidia-device-plugin \
   --namespace nvidia-device-plugin \
   --create-namespace \
-  --version 0.16.2
+  --version 0.17.0
 ```
 
 **Note:** You only need the to pass the `--devel` flag to `helm search repo`
@@ -665,7 +665,7 @@ version (e.g. `<version>-rc.1`). Full releases will be listed without this.
 
 ### Configuring the device plugin's `helm` chart
 
-The `helm` chart for the latest release of the plugin (`v0.16.2`) includes
+The `helm` chart for the latest release of the plugin (`v0.17.0`) includes
 a number of customizable values.
 
 Prior to `v0.12.0` the most commonly used values were those that had direct
@@ -675,7 +675,7 @@ case of the original values is then to override an option from the `ConfigMap`
 if desired. Both methods are discussed in more detail below.
 
 The full set of values that can be set are found here:
-[here](https://github.com/NVIDIA/k8s-device-plugin/blob/v0.16.2/deployments/helm/nvidia-device-plugin/values.yaml).
+[here](https://github.com/NVIDIA/k8s-device-plugin/blob/v0.17.0/deployments/helm/nvidia-device-plugin/values.yaml).
 
 #### Passing configuration to the plugin via a `ConfigMap`
 
@@ -718,7 +718,7 @@ And deploy the device plugin via helm (pointing it at this config file and givin
 
 ```shell
 helm upgrade -i nvdp nvdp/nvidia-device-plugin \
-  --version=0.16.2 \
+  --version=0.17.0 \
   --namespace nvidia-device-plugin \
   --create-namespace \
   --set-file config.map.config=/tmp/dp-example-config0.yaml
@@ -743,7 +743,7 @@ kubectl create cm -n nvidia-device-plugin nvidia-plugin-configs \
 
 ```shell
 helm upgrade -i nvdp nvdp/nvidia-device-plugin \
-  --version=0.16.2 \
+  --version=0.17.0 \
   --namespace nvidia-device-plugin \
   --create-namespace \
   --set config.name=nvidia-plugin-configs
@@ -773,7 +773,7 @@ And redeploy the device plugin via helm (pointing it at both configs with a spec
 
 ```shell
 helm upgrade -i nvdp nvdp/nvidia-device-plugin \
-  --version=0.16.2 \
+  --version=0.17.0 \
   --namespace nvidia-device-plugin \
   --create-namespace \
   --set config.default=config0 \
@@ -795,7 +795,7 @@ kubectl create cm -n nvidia-device-plugin nvidia-plugin-configs \
 
 ```shell
 helm upgrade -i nvdp nvdp/nvidia-device-plugin \
-  --version=0.16.2 \
+  --version=0.17.0 \
   --namespace nvidia-device-plugin \
   --create-namespace \
   --set config.default=config0 \
@@ -881,7 +881,7 @@ runtimeClassName:
 ```
 
 Please take a look in the
-[`values.yaml`](https://github.com/NVIDIA/k8s-device-plugin/blob/v0.16.2/deployments/helm/nvidia-device-plugin/values.yaml)
+[`values.yaml`](https://github.com/NVIDIA/k8s-device-plugin/blob/v0.17.0/deployments/helm/nvidia-device-plugin/values.yaml)
 file to see the full set of overridable parameters for the device plugin.
 
 Examples of setting these options include:
@@ -891,7 +891,7 @@ Enabling compatibility with the `CPUManager` and running with a request for
 
 ```shell
 helm upgrade -i nvdp nvdp/nvidia-device-plugin \
-  --version=0.16.2 \
+  --version=0.17.0 \
   --namespace nvidia-device-plugin \
   --create-namespace \
   --set compatWithCPUManager=true \
@@ -903,7 +903,7 @@ Enabling compatibility with the `CPUManager` and the `mixed` `migStrategy`.
 
 ```shell
 helm upgrade -i nvdp nvdp/nvidia-device-plugin \
-  --version=0.16.2 \
+  --version=0.17.0 \
   --namespace nvidia-device-plugin \
   --create-namespace \
   --set compatWithCPUManager=true \
@@ -922,7 +922,7 @@ To enable it, simply set `gfd.enabled=true` during helm install.
 
 ```shell
 helm upgrade -i nvdp nvdp/nvidia-device-plugin \
-  --version=0.16.2 \
+  --version=0.17.0 \
   --namespace nvidia-device-plugin \
   --create-namespace \
   --set gfd.enabled=true
@@ -980,13 +980,13 @@ helm repo add nvdp https://nvidia.github.io/k8s-device-plugin
 helm repo update
 ```
 
-Then verify that the latest release (`v0.16.2`) of the plugin is available
+Then verify that the latest release (`v0.17.0`) of the plugin is available
 (Note that this includes the GFD chart):
 
 ```shell
 helm search repo nvdp --devel
 NAME                     	  CHART VERSION  APP VERSION	DESCRIPTION
-nvdp/nvidia-device-plugin	  0.16.2	 0.16.2		A Helm chart for ...
+nvdp/nvidia-device-plugin	  0.17.0	 0.17.0		A Helm chart for ...
 ```
 
 Once this repo is updated, you can begin installing packages from it to deploy
@@ -996,7 +996,7 @@ The most basic installation command without any options is then:
 
 ```shell
 helm upgrade -i nvdp nvdp/nvidia-device-plugin \
-  --version 0.16.2 \
+  --version 0.17.0 \
   --namespace gpu-feature-discovery \
   --create-namespace \
   --set devicePlugin.enabled=false
@@ -1007,7 +1007,7 @@ the default namespace.
 
 ```shell
 helm upgrade -i nvdp nvdp/nvidia-device-plugin \
-    --version=0.16.2 \
+    --version=0.17.0 \
     --set allowDefaultNamespace=true \
     --set nfd.enabled=false \
     --set migStrategy=mixed \
@@ -1031,14 +1031,14 @@ Using the default values for the flags:
 helm upgrade -i nvdp \
   --namespace nvidia-device-plugin \
   --create-namespace \
-  https://nvidia.github.io/k8s-device-plugin/stable/nvidia-device-plugin-0.16.2.tgz
+  https://nvidia.github.io/k8s-device-plugin/stable/nvidia-device-plugin-0.17.0.tgz
 ```
 
 ## Building and Running Locally
 
 The next sections are focused on building the device plugin locally and running it.
 It is intended purely for development and testing, and not required by most users.
-It assumes you are pinning to the latest release tag (i.e. `v0.16.2`), but can
+It assumes you are pinning to the latest release tag (i.e. `v0.17.0`), but can
 easily be modified to work with any available tag or branch.
 
 ### With Docker
@@ -1048,8 +1048,8 @@ easily be modified to work with any available tag or branch.
 Option 1, pull the prebuilt image from [Docker Hub](https://hub.docker.com/r/nvidia/k8s-device-plugin):
 
 ```shell
-docker pull nvcr.io/nvidia/k8s-device-plugin:v0.16.2
-docker tag nvcr.io/nvidia/k8s-device-plugin:v0.16.2 nvcr.io/nvidia/k8s-device-plugin:devel
+docker pull nvcr.io/nvidia/k8s-device-plugin:v0.17.0
+docker tag nvcr.io/nvidia/k8s-device-plugin:v0.17.0 nvcr.io/nvidia/k8s-device-plugin:devel
 ```
 
 Option 2, build without cloning the repository:
@@ -1058,7 +1058,7 @@ Option 2, build without cloning the repository:
 docker build \
   -t nvcr.io/nvidia/k8s-device-plugin:devel \
   -f deployments/container/Dockerfile.ubuntu \
-  https://github.com/NVIDIA/k8s-device-plugin.git#v0.16.2
+  https://github.com/NVIDIA/k8s-device-plugin.git#v0.17.0
 ```
 
 Option 3, if you want to modify the code:

--- a/deployments/helm/nvidia-device-plugin/Chart.yaml
+++ b/deployments/helm/nvidia-device-plugin/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nvidia-device-plugin
 type: application
 description: A Helm chart for the nvidia-device-plugin on Kubernetes
-version: "0.17.0-rc.1"
-appVersion: "0.17.0-rc.1"
+version: "0.17.0"
+appVersion: "0.17.0"
 kubeVersion: ">= 1.10.0-0"
 home: https://github.com/NVIDIA/k8s-device-plugin
 

--- a/deployments/static/gpu-feature-discovery-daemonset-with-mig-mixed.yaml
+++ b/deployments/static/gpu-feature-discovery-daemonset-with-mig-mixed.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gpu-feature-discovery
   labels:
     app.kubernetes.io/name: gpu-feature-discovery
-    app.kubernetes.io/version: 0.17.0-rc.1
+    app.kubernetes.io/version: 0.17.0
     app.kubernetes.io/part-of: nvidia-gpu
 spec:
   selector:
@@ -15,11 +15,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: gpu-feature-discovery
-        app.kubernetes.io/version: 0.17.0-rc.1
+        app.kubernetes.io/version: 0.17.0
         app.kubernetes.io/part-of: nvidia-gpu
     spec:
       containers:
-        - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.0-rc.1
+        - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.0
           name: gpu-feature-discovery
           command: ["/usr/bin/gpu-feature-discovery"]
           volumeMounts:

--- a/deployments/static/gpu-feature-discovery-daemonset-with-mig-single.yaml
+++ b/deployments/static/gpu-feature-discovery-daemonset-with-mig-single.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gpu-feature-discovery
   labels:
     app.kubernetes.io/name: gpu-feature-discovery
-    app.kubernetes.io/version: 0.17.0-rc.1
+    app.kubernetes.io/version: 0.17.0
     app.kubernetes.io/part-of: nvidia-gpu
 spec:
   selector:
@@ -15,11 +15,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: gpu-feature-discovery
-        app.kubernetes.io/version: 0.17.0-rc.1
+        app.kubernetes.io/version: 0.17.0
         app.kubernetes.io/part-of: nvidia-gpu
     spec:
       containers:
-        - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.0-rc.1
+        - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.0
           name: gpu-feature-discovery
           command: ["/usr/bin/gpu-feature-discovery"]
           volumeMounts:

--- a/deployments/static/gpu-feature-discovery-daemonset.yaml
+++ b/deployments/static/gpu-feature-discovery-daemonset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gpu-feature-discovery
   labels:
     app.kubernetes.io/name: gpu-feature-discovery
-    app.kubernetes.io/version: 0.17.0-rc.1
+    app.kubernetes.io/version: 0.17.0
     app.kubernetes.io/part-of: nvidia-gpu
 spec:
   selector:
@@ -15,11 +15,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: gpu-feature-discovery
-        app.kubernetes.io/version: 0.17.0-rc.1
+        app.kubernetes.io/version: 0.17.0
         app.kubernetes.io/part-of: nvidia-gpu
     spec:
       containers:
-        - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.0-rc.1
+        - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.0
           name: gpu-feature-discovery
           command: ["/usr/bin/gpu-feature-discovery"]
           volumeMounts:

--- a/deployments/static/gpu-feature-discovery-job.yaml.template
+++ b/deployments/static/gpu-feature-discovery-job.yaml.template
@@ -4,19 +4,19 @@ metadata:
   name: gpu-feature-discovery
   labels:
     app.kubernetes.io/name: gpu-feature-discovery
-    app.kubernetes.io/version: 0.17.0-rc.1
+    app.kubernetes.io/version: 0.17.0
     app.kubernetes.io/part-of: nvidia-gpu
 spec:
   template:
     metadata:
       labels:
         app.kubernetes.io/name: gpu-feature-discovery
-        app.kubernetes.io/version: 0.17.0-rc.1
+        app.kubernetes.io/version: 0.17.0
         app.kubernetes.io/part-of: nvidia-gpu
     spec:
       nodeName: NODE_NAME
       containers:
-        - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.0-rc.1
+        - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.0
           name: gpu-feature-discovery
           command: ["/usr/bin/gpu-feature-discovery"]
           args:

--- a/deployments/static/nvidia-device-plugin-compat-with-cpumanager.yml
+++ b/deployments/static/nvidia-device-plugin-compat-with-cpumanager.yml
@@ -38,7 +38,7 @@ spec:
       # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
       priorityClassName: "system-node-critical"
       containers:
-      - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.0-rc.1
+      - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.0
         name: nvidia-device-plugin-ctr
         env:
           - name: FAIL_ON_INIT_ERROR

--- a/deployments/static/nvidia-device-plugin.yml
+++ b/deployments/static/nvidia-device-plugin.yml
@@ -38,7 +38,7 @@ spec:
       # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
       priorityClassName: "system-node-critical"
       containers:
-      - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.0-rc.1
+      - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.0
         name: nvidia-device-plugin-ctr
         env:
           - name: FAIL_ON_INIT_ERROR

--- a/versions.mk
+++ b/versions.mk
@@ -17,7 +17,7 @@ MODULE := github.com/NVIDIA/$(DRIVER_NAME)
 
 REGISTRY ?= nvcr.io/nvidia
 
-VERSION ?= v0.17.0-rc.1
+VERSION ?= v0.17.0
 
 # vVERSION represents the version with a guaranteed v-prefix
 vVERSION := v$(VERSION:v%=%)


### PR DESCRIPTION
This bumps the versions on `main` following the `v0.17.0` release.

See #1028 