### PR TITLE
Honor fail-on-init-error when no resources are found

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,9 @@ linters-settings:
     local-prefixes: github.com/NVIDIA/k8s-device-plugin
 
 issues:
+  exclude:
+  # Exclude all integer overflow errors on this branch.
+  - "G115: integer overflow conversion"
   exclude-rules:
   # We use math/rand instead of crypto/rand for unique names in e2e tests.
   - path: tests/e2e/

--- a/cmd/gpu-feature-discovery/main.go
+++ b/cmd/gpu-feature-discovery/main.go
@@ -155,7 +155,10 @@ func start(c *cli.Context, cfg *Config) error {
 		}
 		klog.Infof("\nRunning with config:\n%v", string(configJSON))
 
-		manager := resource.NewManager(config)
+		manager, err := resource.NewManager(config)
+		if err != nil {
+			return err
+		}
 		vgpul := vgpu.NewVGPULib(vgpu.NewNvidiaPCILib())
 
 		var clientSets flags.ClientSets

--- a/tests/e2e/framework/framework.go
+++ b/tests/e2e/framework/framework.go
@@ -190,7 +190,7 @@ func (f *Framework) AfterEach(ctx context.Context) {
 			for namespaceKey, namespaceErr := range nsDeletionErrors {
 				messages = append(messages, fmt.Sprintf("Couldn't delete ns: %q: %s (%#v)", namespaceKey, namespaceErr, namespaceErr))
 			}
-			e2elog.Failf(strings.Join(messages, ","))
+			e2elog.Fail(strings.Join(messages, ","))
 		}
 	}()
 


### PR DESCRIPTION
As implemented GFD will not fail if no resources are detected -- even if fail-on-init-error is set. This change ensures that fail-on-init-error is honored if no resources are detected.

This backports #1033 to the release-0.15 branch