### PR TITLE
helm template: add missing quote for failOnInitError

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -143,7 +143,7 @@ spec:
         {{- end }}
         {{- if typeIs "bool" .Values.failOnInitError }}
           - name: FAIL_ON_INIT_ERROR
-            value: {{ .Values.failOnInitError }}
+            value: {{ .Values.failOnInitError | quote }}
         {{- end }}
         {{- if typeIs "bool" .Values.compatWithCPUManager }}
           - name: PASS_DEVICE_SPECS


### PR DESCRIPTION
When using "failOnInitError" the Helm template for the daemonset currently fails because of missing quotation on this boolean value.