### PR TITLE
Bump nvidia/cuda in /deployments/container

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG GOLANG_VERSION=1.22.6
-FROM nvcr.io/nvidia/cuda:12.6.2-base-ubi9 AS build
+FROM nvcr.io/nvidia/cuda:12.6.3-base-ubi9 AS build
 
 RUN yum install -y \
     wget make git gcc \
@@ -51,7 +51,7 @@ RUN rpm -qa --queryformat='^%{NAME}-\[0-9\].*\.%{ARCH}$\n' | sort -u > /tmp/pack
 RUN rpm -qa | sort -u > /tmp/package-list.minimal
 
 # We define the following image as a base image and remove unneeded packages.
-FROM nvcr.io/nvidia/cuda:12.6.2-base-ubi9 AS base
+FROM nvcr.io/nvidia/cuda:12.6.3-base-ubi9 AS base
 
 WORKDIR /cleanup
 


### PR DESCRIPTION
Bumps nvidia/cuda from 12.6.2-base-ubi9 to 12.6.3-base-ubi9.

---
updated-dependencies:
- dependency-name: nvidia/cuda dependency-type: direct:production update-type: version-update:semver-patch ...