### PR TITLE
Raise a warning instead of an error if GPU mode labeler fails

### DIFF
--- a/internal/lm/nvml.go
+++ b/internal/lm/nvml.go
@@ -215,7 +215,8 @@ func isMPSCapable(manager resource.Manager) (bool, error) {
 func newGPUModeLabeler(devices []resource.Device) (Labeler, error) {
 	classes, err := getDeviceClasses(devices)
 	if err != nil {
-		return nil, err
+		klog.Warningf("Failed to create GPU mode labeler: failed to get device classes: %v", err)
+		return Labels{"nvidia.com/gpu.mode": "unknown"}, nil
 	}
 	gpuMode := getModeForClasses(classes)
 	labels := Labels{


### PR DESCRIPTION
For environments like WSL2 where GPUs do not show up as PCI devices, creating the GPU mode labeler will fail. This change allows GFD to proceed even if it is unable to get the GPU mode label.