### PR TITLE
scripts/create-kind-cluster: use nvidia-ctk stable channel & `--config-source=command` cli arg

### DIFF
--- a/demo/clusters/kind/scripts/create-kind-cluster.sh
+++ b/demo/clusters/kind/scripts/create-kind-cluster.sh
@@ -46,11 +46,14 @@ docker exec -it "${KIND_CLUSTER_NAME}-worker" bash -c " \
     apt-get update \
   && apt-get install -y nvidia-container-toolkit"
 
-# We configure the NVIDIA Container Runtime to only trigger on the nvidia.cdi.k8s.io annotation and enable CDI in containerd.
+# We configure the NVIDIA Container Runtime to only trigger on the nvidia.cdi.k8s.io
+# annotation and enable CDI in containerd. --config-source=command obtains the
+# containerd base config dynamically from containerd itself, via
+# `containerd config dump`. See https://github.com/NVIDIA/nvidia-container-toolkit/pull/686
 docker exec -it "${KIND_CLUSTER_NAME}-worker" bash -c "\
 	nvidia-ctk config --set nvidia-container-runtime.modes.cdi.annotation-prefixes=nvidia.cdi.k8s.io/ \
 	&& \
-	nvidia-ctk runtime configure --runtime=containerd --cdi.enabled \
+	nvidia-ctk runtime configure --runtime=containerd --cdi.enabled --config-source=command \
 	&& \
 	systemctl restart containerd"
 


### PR DESCRIPTION
Without this patch, containerd starts up with an erroneous runc config and `systemctl status containerd` shows
```
Feb 04 13:15:38 k8s-device-plugin-cluster-worker containerd[1278]:
    time="2025-02-04T13:15:38.716063472Z" level=warning
    msg="failed to load plugin io.containerd.grpc.v1.cri"
    error="invalid plugin config: no corresponding runtime configured in `containerd.runtimes` for `containerd` `default_runtime_name = \"runc\""
```
We debugged this yesterday and @elezar recommended to switch to the `stable` release channel for the toolkit, and to use the `--config-source=command` arg when invoking `nvidia-ctk runtime configure`.

Also see https://github.com/NVIDIA/nvidia-container-toolkit/pull/686.