### PR TITLE
Allow MPS control daemonset to be explicitly disabled

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -135,8 +135,10 @@ spec:
         name: nvidia-device-plugin-ctr
         command: ["nvidia-device-plugin"]
         env:
+        {{- if .Values.mps.enabled }}
           - name: MPS_ROOT
             value: {{ .Values.mps.root }}
+        {{- end }}
         {{- if typeIs "string" .Values.migStrategy }}
           - name: MIG_STRATEGY
             value: {{ .Values.migStrategy }}
@@ -205,6 +207,7 @@ spec:
             mountPath: /driver-root
             readOnly: true
         {{- end }}
+        {{- if .Values.mps.enabled }}
           # The MPS /dev/shm is needed to allow for MPS daemon health-checking.
           - name: mps-shm
             mountPath: /dev/shm
@@ -212,6 +215,7 @@ spec:
             mountPath: /mps
           - name: cdi-root
             mountPath: /var/run/cdi
+        {{- end }}
         {{- if $options.hasConfigMap }}
           - name: available-configs
             mountPath: /available-configs
@@ -226,6 +230,7 @@ spec:
         - name: device-plugin
           hostPath:
             path: /var/lib/kubelet/device-plugins
+        {{- if .Values.mps.enabled }}
         - name: mps-root
           hostPath:
             path: {{ .Values.mps.root }}
@@ -233,15 +238,16 @@ spec:
         - name: mps-shm
           hostPath:
             path: {{ .Values.mps.root }}/shm
+        - name: cdi-root
+          hostPath:
+            path: /var/run/cdi
+            type: DirectoryOrCreate
+        {{- end }}
        {{- if typeIs "string" .Values.nvidiaDriverRoot }}
         - name: driver-root
           hostPath:
             path: {{ .Values.nvidiaDriverRoot }}
         {{- end }}
-        - name: cdi-root
-          hostPath:
-            path: /var/run/cdi
-            type: DirectoryOrCreate
       {{- if $options.hasConfigMap }}
         - name: available-configs
           configMap:

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -213,9 +213,9 @@ spec:
             mountPath: /dev/shm
           - name: mps-root
             mountPath: /mps
+        {{- end }}
           - name: cdi-root
             mountPath: /var/run/cdi
-        {{- end }}
         {{- if $options.hasConfigMap }}
           - name: available-configs
             mountPath: /available-configs
@@ -238,11 +238,11 @@ spec:
         - name: mps-shm
           hostPath:
             path: {{ .Values.mps.root }}/shm
+        {{- end }}
         - name: cdi-root
           hostPath:
             path: /var/run/cdi
             type: DirectoryOrCreate
-        {{- end }}
        {{- if typeIs "string" .Values.nvidiaDriverRoot }}
         - name: driver-root
           hostPath:

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{- if .Values.devicePlugin.enabled }}
+{{- if and .Values.devicePlugin.enabled .Values.mps.enabled }}
 ---
 {{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
 {{- $configMapName := (include "nvidia-device-plugin.configMapName" .) | trim }}

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -145,6 +145,7 @@ nfd:
           - vendor
 
 mps:
+  enabled: true
   # root specifies the location where files and folders for managing MPS will
   # be created. This includes a daemon-specific /dev/shm and pipe and log
   # directories.

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -145,6 +145,7 @@ nfd:
           - vendor
 
 mps:
+  # Enable MPS DaemonSet (user still needs to activate MPS configuration by labeling a node)
   enabled: true
   # root specifies the location where files and folders for managing MPS will
   # be created. This includes a daemon-specific /dev/shm and pipe and log


### PR DESCRIPTION
This change allows the deployment of the MPS daemon to be explicitly disabled by adding `--set mps.enabled=false` to a  Helm install / upgrade command.

The default behaviour of the plugin is to deploy the MPS control daemonset even if not MPS sharing is configured. However, the actual MPS daemon is only started if a GPU is replicated using MPS. The `mps.enabled` Helm value allows this to be explicitly disabled. 

Fixes #1177 with backward compatibility so this should be a minor change.