### PR TITLE
[Feature] Add device filter for selecting or excluding a subset of devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ options outside of this section are shared.
 
   This flag allows enable device filter feature. When set to `false`, it does
   nothing even if the belows flags `DEVICE_FILTER_SELECT_DEVICES`
-  and `DEVICE_FILTER_SELECT_DEVICES` are set.
+  and `DEVICE_FILTER_EXCLUDE_DEVICES` are set.
 
 **`DEVICE_FILTER_SELECT_DEVICES`**:
   the desired subset of devices will be selected from node's devices

--- a/api/config/v1/flags.go
+++ b/api/config/v1/flags.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	flg "github.com/NVIDIA/k8s-device-plugin/internal/flags"
 	cli "github.com/urfave/cli/v2"
 )
 
@@ -66,6 +67,7 @@ type CommandLineFlags struct {
 	DeviceDiscoveryStrategy *string                 `json:"deviceDiscoveryStrategy"    yaml:"deviceDiscoveryStrategy"`
 	Plugin                  *PluginCommandLineFlags `json:"plugin,omitempty"           yaml:"plugin,omitempty"`
 	GFD                     *GFDCommandLineFlags    `json:"gfd,omitempty"              yaml:"gfd,omitempty"`
+	DeviceFilter            *flg.DeviceFilter       `json:"deviceFilter,omitempty"     yaml:"deviceFilter,omitempty"`
 }
 
 // PluginCommandLineFlags holds the list of command line flags specific to the device plugin.
@@ -168,6 +170,18 @@ func (f *Flags) UpdateFromCLIFlags(c *cli.Context, flags []cli.Flag) {
 				updateFromCLIFlag(&f.GFD.NoTimestamp, c, n)
 			case "machine-type-file":
 				updateFromCLIFlag(&f.GFD.MachineTypeFile, c, n)
+			}
+			// DeviceFilter specific flags
+			if f.DeviceFilter == nil {
+				f.DeviceFilter = &flg.DeviceFilter{}
+			}
+			switch n {
+			case "device-filter-enabled":
+				updateFromCLIFlag(&f.DeviceFilter.Enabled, c, n)
+			case "device-filter-select-devices":
+				updateFromCLIFlag(&f.DeviceFilter.SelectDevices, c, n)
+			case "device-filter-exclude-devices":
+				updateFromCLIFlag(&f.DeviceFilter.ExcludeDevices, c, n)
 			}
 		}
 	}

--- a/cmd/mps-control-daemon/main.go
+++ b/cmd/mps-control-daemon/main.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/NVIDIA/k8s-device-plugin/cmd/mps-control-daemon/mount"
 	"github.com/NVIDIA/k8s-device-plugin/cmd/mps-control-daemon/mps"
+	"github.com/NVIDIA/k8s-device-plugin/internal/flags"
 	"github.com/NVIDIA/k8s-device-plugin/internal/info"
 	"github.com/NVIDIA/k8s-device-plugin/internal/logger"
 	"github.com/NVIDIA/k8s-device-plugin/internal/rm"
@@ -77,6 +78,8 @@ func main() {
 		},
 	}
 	c.Flags = config.flags
+
+	c.Flags = append(c.Flags, (&flags.DeviceFilter{}).Flags()...)
 
 	klog.InfoS(c.Name, "version", c.Version)
 	err := c.Run(os.Args)

--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -34,6 +34,7 @@ import (
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
+	"github.com/NVIDIA/k8s-device-plugin/internal/flags"
 	"github.com/NVIDIA/k8s-device-plugin/internal/info"
 	"github.com/NVIDIA/k8s-device-plugin/internal/logger"
 	"github.com/NVIDIA/k8s-device-plugin/internal/plugin"
@@ -166,6 +167,9 @@ func main() {
 			EnvVars: []string{"IMEX_REQUIRED"},
 		},
 	}
+
+	c.Flags = append(c.Flags, (&flags.DeviceFilter{}).Flags()...)
+
 	o.flags = c.Flags
 
 	err := c.Run(os.Args)

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -193,6 +193,14 @@ spec:
             value: all
           - name: NVIDIA_DRIVER_CAPABILITIES
             value: compute,utility
+        {{- if and (typeIs "bool" .Values.deviceFilter.enabled) (eq .Values.deviceFilter.enabled true) }}
+          - name: DEVICE_FILTER_ENABLED
+            value: {{ .Values.deviceFilter.enabled | quote }}
+          - name: DEVICE_FILTER_SELECT_DEVICES
+            value: {{ .Values.deviceFilter.selectDevices | quote }}
+          - name: DEVICE_FILTER_EXCLUDE_DEVICES
+            value: {{ .Values.deviceFilter.excludeDevices | quote }}
+        {{- end }}
         securityContext:
           {{- include "nvidia-device-plugin.securityContext" . | nindent 10 }}
         volumeMounts:

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -171,6 +171,14 @@ spec:
             value: all
           - name: NVIDIA_DRIVER_CAPABILITIES
             value: compute,utility
+        {{- if and (typeIs "bool" .Values.deviceFilter.enabled) (eq .Values.deviceFilter.enabled true) }}
+          - name: DEVICE_FILTER_ENABLED
+            value: {{ .Values.deviceFilter.enabled | quote }}
+          - name: DEVICE_FILTER_SELECT_DEVICES
+            value: {{ .Values.deviceFilter.selectDevices | quote }}
+          - name: DEVICE_FILTER_EXCLUDE_DEVICES
+            value: {{ .Values.deviceFilter.excludeDevices | quote }}
+        {{- end }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -162,3 +162,14 @@ cdi:
   # nvidiaHookPath specifies the path to the nvidia-cdi-hook or nvidia-ctk executables on the host.
   # This is required to ensure that the generated CDI specification refers to the correct CDI hooks.
   nvidiaHookPath: null
+
+# deviceFilter allows selecting or/and excluding a subset of devices (per-node) to use for the device-plugin-daemon and mps-control-daemon
+# NOTE: Only use this configiguration for applying a same filter to all nodes!
+# For more granular filter for some specific nodes, use per-node configuration with a node label instead,
+# see: https://github.com/NVIDIA/k8s-device-plugin?tab=readme-ov-file#updating-per-node-configuration-with-a-node-label
+deviceFilter:
+  enabled: false
+  # Comma separated list of devices
+  # Accept formats: Index ("0,1,3,7"), ID ("GPU-XXX,GPU-YYY"), or even mixed of both ("0,GPU-XXX,GPU-YYY,6" - but not recommended)
+  selectDevices: ""
+  excludeDevices: ""

--- a/internal/flags/device_filter.go
+++ b/internal/flags/device_filter.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2025 NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package flags
+
+import (
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	DevicesSeparator = ","
+)
+
+type DeviceFilter struct {
+	Enabled        *bool   `json:"enabled" yaml:"enabled"`
+	SelectDevices  *string `json:"selectDevices,omitempty" yaml:"selectDevices,omitempty"`
+	ExcludeDevices *string `json:"excludeDevices,omitempty" yaml:"excludeDevices,omitempty"`
+}
+
+func (f DeviceFilter) GetSelectDevicesList() []string {
+	return strings.Split(*f.SelectDevices, DevicesSeparator)
+}
+
+func (f DeviceFilter) GetExcludeDevicesList() []string {
+	return strings.Split(*f.ExcludeDevices, DevicesSeparator)
+}
+
+func (f *DeviceFilter) Flags() []cli.Flag {
+	flags := []cli.Flag{
+		&cli.BoolFlag{
+			Name:        "device-filter-enabled",
+			Usage:       "Enable device filter",
+			Value:       false,
+			Destination: f.Enabled,
+			EnvVars:     []string{"DEVICE_FILTER_ENABLED"},
+		},
+		&cli.StringFlag{
+			Name:        "device-filter-select-devices",
+			Usage:       "The comma separated list used for the selected devices.",
+			Value:       "",
+			Destination: f.SelectDevices,
+			EnvVars:     []string{"DEVICE_FILTER_SELECT_DEVICES"},
+		},
+		&cli.StringFlag{
+			Name:        "device-filter-exclude-devices",
+			Usage:       "The comma separated list used for the excluded devices.",
+			Value:       "",
+			Destination: f.ExcludeDevices,
+			EnvVars:     []string{"DEVICE_FILTER_EXCLUDE_DEVICES"},
+		},
+	}
+	return flags
+}

--- a/internal/rm/devices.go
+++ b/internal/rm/devices.go
@@ -174,15 +174,19 @@ func (ds Devices) FilterByIDOrIndex(selected []string, excluded []string) Device
 	}
 
 	res := ds
-	// Skip on the edge cases when seleted/excluded is an empty slice ([]string{""})
+
+	// Only perform filtering when selected is not an empty slice ([]string{""})
 	if !(len(selected) == 1 && selected[0] == "") {
 		f := filterFunc(ds, selected)
 		res = res.Subset(f.GetIDs())
 	}
+
+	// Only perform filtering when excluded is not an empty slice ([]string{""})
 	if !(len(excluded) == 1 && excluded[0] == "") {
 		f := filterFunc(ds, excluded)
 		res = res.Difference(f)
 	}
+
 	return res
 }
 

--- a/internal/rm/nvml_manager.go
+++ b/internal/rm/nvml_manager.go
@@ -58,6 +58,14 @@ func NewNVMLResourceManagers(infolib info.Interface, nvmllib nvml.Interface, dev
 		if len(devices) == 0 {
 			continue
 		}
+
+		if *config.Flags.DeviceFilter.Enabled {
+			devices = devices.FilterByIDOrIndex(
+				config.Flags.DeviceFilter.GetSelectDevicesList(),
+				config.Flags.DeviceFilter.GetExcludeDevicesList(),
+			)
+		}
+
 		r := &nvmlResourceManager{
 			resourceManager: resourceManager{
 				config:   config,


### PR DESCRIPTION
# Fix
- https://github.com/NVIDIA/k8s-device-plugin/issues/197
- https://github.com/NVIDIA/k8s-device-plugin/issues/236
- https://github.com/NVIDIA/k8s-device-plugin/issues/435
- https://github.com/NVIDIA/k8s-device-plugin/issues/935
- https://github.com/NVIDIA/gpu-operator/issues/612 (related project)

# Description
Selecting and excluding some specific devices on specific nodes is a common use case when users want to share GPUs for other purposes outside K8S or for testing/debugging.

This PR introduces new flags (and configurations) for the above feature.
By using combine with [Per-Node Configuration With a Node Label](https://github.com/NVIDIA/k8s-device-plugin?tab=readme-ov-file#updating-per-node-configuration-with-a-node-label), it allows more granular control on selecting/excluding devices on some specific nodes