### PR TITLE
[no-relnote] Fix GitLab Pipeline artifact names

### DIFF
--- a/.nvidia-ci.yml
+++ b/.nvidia-ci.yml
@@ -95,7 +95,7 @@ image-ubi9:
     when: always
     expire_in: 1 week
     paths:
-      - pulse-cli.logs
+      - pulse-cli.log
       - licenses.json
       - sbom.json
       - vulns.json


### PR DESCRIPTION
The pulse scanner generates a `pulse-cli.log` file and not `pulse-cli.logs`.

Backport of #1180