### PR TITLE
[no-relnote] Set git user name and email in subfolder repo

### DIFF
--- a/.github/workflows/publish-helm.yaml
+++ b/.github/workflows/publish-helm.yaml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Update helm index
       env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         git config user.name "Github Actions"
         git config user.email "no-reply@github.com"

--- a/hack/update-helm-index.sh
+++ b/hack/update-helm-index.sh
@@ -144,6 +144,10 @@ if [[ -z ${VERSION} ]]; then
 	VERSION="v$VERSION"
 fi
 
+# We need to ensure that the user the folder is correct:
+git -C ${HELM_REPO_PATH} config user.email "$(git config --get user.email)"
+git -C ${HELM_REPO_PATH} config user.name "$(git config --get user.name)"
+
 # Create a new commit
 echo "Committing changes: \n${changes}"
 git -C $HELM_REPO_PATH add index.yaml stable


### PR DESCRIPTION
Backports #1032 to remove the need to future manual interventions when releasing off the `release-0.17` branch.