### PR TITLE
Remove FAIL_ON_INIT_ERROR from static examples

### DIFF
--- a/deployments/static/nvidia-device-plugin-compat-with-cpumanager.yml
+++ b/deployments/static/nvidia-device-plugin-compat-with-cpumanager.yml
@@ -41,8 +41,6 @@ spec:
       - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.1
         name: nvidia-device-plugin-ctr
         env:
-          - name: FAIL_ON_INIT_ERROR
-            value: "false"
           - name: PASS_DEVICE_SPECS
             value: "true"
         securityContext:

--- a/deployments/static/nvidia-device-plugin.yml
+++ b/deployments/static/nvidia-device-plugin.yml
@@ -40,9 +40,7 @@ spec:
       containers:
       - image: nvcr.io/nvidia/k8s-device-plugin:v0.17.1
         name: nvidia-device-plugin-ctr
-        env:
-          - name: FAIL_ON_INIT_ERROR
-            value: "false"
+        env: []
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
This change removes FAIL_ON_INIT_ERROR=false from the static examples. This is a non-recommended setting as failures in loading GPU information is silently ignored.

See https://nvbugspro.nvidia.com/bug/5129637