### PR TITLE
[ci] stage images with final version during external release pipelines

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -190,6 +190,10 @@ scan-ubi9-arm64:
     OUT_REGISTRY_TOKEN: "${NGC_REGISTRY_TOKEN}"
     OUT_REGISTRY: "${NGC_REGISTRY}"
     OUT_IMAGE_NAME: "${NGC_REGISTRY_STAGING_IMAGE_NAME}"
+  rules:
+    - if: $CI_COMMIT_TAG
+      variables:
+        OUT_IMAGE_VERSION: "${CI_COMMIT_TAG}"
 
 # Define an external release step that pushes an image to an external repository.
 # This includes a devlopment image off main.


### PR DESCRIPTION
This change ensures that images staged for external release get tagged with the release version, e.g. x.y.z, and not a commit sha.