### PR TITLE
[gpu-feature-discovery] detect blackwell architecture

### DIFF
--- a/internal/lm/resource.go
+++ b/internal/lm/resource.go
@@ -304,6 +304,9 @@ func getArchFamily(computeMajor, computeMinor int) string {
 		return "ada-lovelace"
 	case 9:
 		return "hopper"
+	// The Blackwell GPU family is bifurcated into two cuda compute capabilities 10.0 and 12.0
+	case 10, 12:
+		return "blackwell"
 	}
 	return "undefined"
 }


### PR DESCRIPTION
Confirmed that the blackwell architecture corresponds to cuda compute with major number 10.

With the fix, we print the "blackwell" label value instead of "undefined"

![Screenshot 2025-04-18 at 3 34 38 PM](https://github.com/user-attachments/assets/c731fa9a-c88e-428a-ab53-7c197d29c5c2)
