### PR TITLE
feat: add mark health device function

### DIFF
--- a/internal/plugin/server.go
+++ b/internal/plugin/server.go
@@ -272,11 +272,21 @@ func (plugin *nvidiaDevicePlugin) ListAndWatch(e *pluginapi.Empty, s pluginapi.D
 			return nil
 		case d := <-plugin.health:
 			// FIXME: there is no way to recover from the Unhealthy state.
-			d.Health = pluginapi.Unhealthy
-			klog.Infof("'%s' device marked unhealthy: %s", plugin.rm.Resource(), d.ID)
-			if err := s.Send(&pluginapi.ListAndWatchResponse{Devices: plugin.apiDevices()}); err != nil {
-				return nil
+			if d.Event == rm.DeviceUnHalthy {
+				d.Device.Health = pluginapi.Unhealthy
+				klog.Infof("'%s' device marked unhealthy: %s", plugin.rm.Resource(), d.Device.ID)
+				if err := s.Send(&pluginapi.ListAndWatchResponse{Devices: plugin.apiDevices()}); err != nil {
+					return nil
+				}
 			}
+			if d.Event == rm.DeviceHealthy {
+				d.Device.Health = pluginapi.Healthy
+				klog.Infof("'%s' device marked healthy: %s", plugin.rm.Resource(), d.Device.ID)
+				if err := s.Send(&pluginapi.ListAndWatchResponse{Devices: plugin.apiDevices()}); err != nil {
+					return nil
+				}
+			}
+
 		}
 	}
 }

--- a/internal/rm/devices.go
+++ b/internal/rm/devices.go
@@ -36,6 +36,18 @@ type Device struct {
 	Replicas int
 }
 
+type DeviceEventType int
+
+const (
+	DeviceUnHalthy DeviceEventType = iota
+	DeviceHealthy
+)
+
+type DeviceEvent struct {
+	Device *Device
+	Event  DeviceEventType
+}
+
 // deviceInfo defines the information the required to construct a Device
 type deviceInfo interface {
 	GetUUID() (string, error)

--- a/internal/rm/nvml_manager.go
+++ b/internal/rm/nvml_manager.go
@@ -91,7 +91,7 @@ func (r *nvmlResourceManager) GetDevicePaths(ids []string) []string {
 }
 
 // CheckHealth performs health checks on a set of devices, writing to the 'unhealthy' channel with any unhealthy devices
-func (r *nvmlResourceManager) CheckHealth(stop <-chan interface{}, unhealthy chan<- *Device) error {
+func (r *nvmlResourceManager) CheckHealth(stop <-chan interface{}, unhealthy chan<- *DeviceEvent) error {
 	return r.checkHealth(stop, r.devices, unhealthy)
 }
 

--- a/internal/rm/rm.go
+++ b/internal/rm/rm.go
@@ -42,7 +42,7 @@ type ResourceManager interface {
 	Devices() Devices
 	GetDevicePaths([]string) []string
 	GetPreferredAllocation(available, required []string, size int) ([]string, error)
-	CheckHealth(stop <-chan interface{}, unhealthy chan<- *Device) error
+	CheckHealth(stop <-chan interface{}, unhealthy chan<- *DeviceEvent) error
 	ValidateRequest(AnnotatedIDs) error
 }
 

--- a/internal/rm/tegra_manager.go
+++ b/internal/rm/tegra_manager.go
@@ -71,6 +71,6 @@ func (r *tegraResourceManager) GetDevicePaths(ids []string) []string {
 }
 
 // CheckHealth is disabled for the tegraResourceManager
-func (r *tegraResourceManager) CheckHealth(stop <-chan interface{}, unhealthy chan<- *Device) error {
+func (r *tegraResourceManager) CheckHealth(stop <-chan interface{}, unhealthy chan<- *DeviceEvent) error {
 	return nil
 }


### PR DESCRIPTION
Is it possible to listen to nvmlEventTypeGpuRecoveryAction to determine if a device is available?

Changes between v560 and v565
The following new functionality is exposed on NVIDIA display drivers version 565 Production or later.
• Added new event type nvmlEventTypeGpuRecoveryAction.
• Added new fieldId to query GPU recovery action NVML_FI_DEV_GET_GPU_RECOVERY_ACTION.