### PR TITLE
Added an ngc-publish stage to trigger the NGC Automation scripts for publishing

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -161,8 +161,7 @@ scan-ubi9-arm64:
     - !reference [.regctl-setup, before_script]
 
     # We ensure that the OUT_IMAGE_VERSION and OUT_IMAGE_NAME are set
-    - 'echo Version: ${OUT_IMAGE_VERSION} ; [[ -n "${OUT_IMAGE_VERSION}" ]] || exit 1'
-    - 'echo Version: ${OUT_IMAGE_NAME} ; [[ -n "${OUT_IMAGE_NAME}" ]] || exit 1'
+    - 'echo "Version: ${OUT_IMAGE_VERSION}, Image: ${OUT_IMAGE_NAME}" ; [[ -n "${OUT_IMAGE_VERSION}" && -n "${OUT_IMAGE_NAME}" ]] || exit 1'
 
     # In the case where we are deploying a different version to the CI_COMMIT_SHA, we
     # need to tag the image.

--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -29,6 +29,7 @@ stages:
   - scan
   - release
   - sign
+  - ngc-publish
 
 .pipeline-trigger-rules:
   rules:
@@ -209,3 +210,14 @@ release:staging-ubi9:
     - .dist-ubi9
   needs:
     - image-ubi9
+
+# Triggers the downstream container-dev/ngc-automation pipeline to publish the image to NGC
+# This stage is triggered specifically on tags   
+trigger-downstream-publishing-pipeline:
+  stage: ngc-publish
+  #rules:
+  #  - if: $CI_COMMIT_TAG
+  variables:
+    PROJECT_NAME: "k8s-device-plugin"
+    SOURCE_VERSION: "test"  # "${CI_COMMIT_TAG}"
+  trigger: dl/container-dev/ngc-automation

--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -219,5 +219,9 @@ trigger-downstream-publishing-pipeline:
   #  - if: $CI_COMMIT_TAG
   variables:
     PROJECT_NAME: "k8s-device-plugin"
-    SOURCE_VERSION: "test"  # "${CI_COMMIT_TAG}"
-  trigger: dl/container-dev/ngc-automation
+    SOURCE_VERSION: "test"  # "${CI_COMMIT_TAG}" 
+  trigger: 
+    project: "dl/container-dev/ngc-automation"
+    strategy: depend
+    forward:
+      pipeline_variables: true

--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -215,11 +215,11 @@ release:staging-ubi9:
 # This stage is triggered specifically on tags   
 trigger-downstream-publishing-pipeline:
   stage: ngc-publish
-  #rules:
-  #  - if: $CI_COMMIT_TAG
+  rules:
+    - if: $CI_COMMIT_TAG
   variables:
     PROJECT_NAME: "k8s-device-plugin"
-    SOURCE_VERSION: "test"  # "${CI_COMMIT_TAG}" 
+    SOURCE_VERSION: "${CI_COMMIT_TAG}"
   trigger: 
     project: "dl/container-dev/ngc-automation"
     strategy: depend

--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -160,8 +160,9 @@ scan-ubi9-arm64:
   before_script:
     - !reference [.regctl-setup, before_script]
 
-    # We ensure that the OUT_IMAGE_VERSION is set
+    # We ensure that the OUT_IMAGE_VERSION and OUT_IMAGE_NAME are set
     - 'echo Version: ${OUT_IMAGE_VERSION} ; [[ -n "${OUT_IMAGE_VERSION}" ]] || exit 1'
+    - 'echo Version: ${OUT_IMAGE_NAME} ; [[ -n "${OUT_IMAGE_NAME}" ]] || exit 1'
 
     # In the case where we are deploying a different version to the CI_COMMIT_SHA, we
     # need to tag the image.
@@ -185,10 +186,10 @@ scan-ubi9-arm64:
   extends:
     - .release
   variables:
-    OUT_REGISTRY_USER: "${CI_REGISTRY_USER}"
-    OUT_REGISTRY_TOKEN: "${CI_REGISTRY_PASSWORD}"
-    OUT_REGISTRY: "${CI_REGISTRY}"
-    OUT_IMAGE_NAME: "${CI_REGISTRY_IMAGE}/staging/k8s-device-plugin"
+    OUT_REGISTRY_USER: "${NGC_REGISTRY_USER}"
+    OUT_REGISTRY_TOKEN: "${NGC_REGISTRY_TOKEN}"
+    OUT_REGISTRY: "${NGC_REGISTRY}"
+    OUT_IMAGE_NAME: "${NGC_REGISTRY_STAGING_IMAGE_NAME}"
 
 # Define an external release step that pushes an image to an external repository.
 # This includes a devlopment image off main.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.configureOnOpen": true
+}


### PR DESCRIPTION
In .common-ci.yml, an ngc-publish stage was added to trigger the ngc automation scripts for publishing. The ngc automation scripts will raise an MR against the NGC Configs repo for publishing. The changes were tested [here](https://gitlab-master.nvidia.com/dl/container-dev/kubernetes/device-plugin/-/pipelines/27471789). The changes are needed to ensure the project publishing infrastructure is in line with the new NGC requirements.