### PR TITLE
Added an ngc-publish stage to trigger the NGC Automation scripts for publishing

### DIFF
--- a/.common-ci.yml
+++ b/.common-ci.yml
@@ -160,9 +160,9 @@ scan-ubi9-arm64:
   before_script:
     - !reference [.regctl-setup, before_script]
 
-    # We ensure that the OUT_IMAGE_VERSION is set
+    # We ensure that the OUT_IMAGE_VERSION and OUT_IMAGE_NAME are set
     - 'echo Version: ${OUT_IMAGE_VERSION} ; [[ -n "${OUT_IMAGE_VERSION}" ]] || exit 1'
-
+    - 'echo Version: ${OUT_IMAGE_NAME} ; [[ -n "${OUT_IMAGE_NAME}" ]] || exit 1'
     # In the case where we are deploying a different version to the CI_COMMIT_SHA, we
     # need to tag the image.
     # Note: a leading 'v' is stripped from the version if present
@@ -185,10 +185,10 @@ scan-ubi9-arm64:
   extends:
     - .release
   variables:
-    OUT_REGISTRY_USER: "${CI_REGISTRY_USER}"
-    OUT_REGISTRY_TOKEN: "${CI_REGISTRY_PASSWORD}"
-    OUT_REGISTRY: "${CI_REGISTRY}"
-    OUT_IMAGE_NAME: "${CI_REGISTRY_IMAGE}/staging/k8s-device-plugin"
+    OUT_REGISTRY_USER: "${NGC_REGISTRY_USER}"
+    OUT_REGISTRY_TOKEN: "${NGC_REGISTRY_TOKEN}"
+    OUT_REGISTRY: "${NGC_REGISTRY}"
+    OUT_IMAGE_NAME: "${NGC_REGISTRY_STAGING_IMAGE_NAME}"
 
 # Define an external release step that pushes an image to an external repository.
 # This includes a devlopment image off main.
@@ -209,3 +209,24 @@ release:staging-ubi9:
     - .dist-ubi9
   needs:
     - image-ubi9
+
+# Triggers the downstream container-dev/ngc-automation pipeline to publish the image to NGC
+# This stage is triggered specifically on tags   
+trigger-downstream-publishing-pipeline:
+  extends:
+    - .dist-ubi9
+  needs:
+    - release:staging-ubi9
+  stage: release
+  rules:
+    - if: $CI_COMMIT_TAG
+  variables:
+    PROJECT_NAME: "k8s-device-plugin"
+    SOURCE_VERSION: "${CI_COMMIT_SHORT_SHA}"
+    TARGET_VERSION: "${CI_COMMIT_TAG}"
+    IMAGE_DIST_LIST: ",${DIST}"
+  trigger: 
+    project: "dl/container-dev/ngc-automation"
+    strategy: depend
+    forward:
+      pipeline_variables: true


### PR DESCRIPTION
This MR adds an ngc-publish stage to trigger the NGC Automation scripts as part of the publishing workflow. The NGC Automation scripts will raise an MR against the NGC configs repo for publishing per the new NGC requirements. The pipeline workflow was tested [here](https://gitlab-master.nvidia.com/dl/container-dev/kubernetes/device-plugin/-/pipelines/27471789).