### PR TITLE
set device-plugin kubeletRootDir configurable in helm chart

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -225,7 +225,7 @@ spec:
       volumes:
         - name: device-plugin
           hostPath:
-            path: /var/lib/kubelet/device-plugins
+            path: {{ .Values.devicePlugin.kubeletRootDir }}/device-plugins
         - name: mps-root
           hostPath:
             path: {{ .Values.mps.root }}

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -101,6 +101,7 @@ runtimeClassName: null
 
 devicePlugin:
   enabled: true
+  kubeletRootDir: "/var/lib/kubelet"
 
 gfd:
   enabled: false


### PR DESCRIPTION
Our k8s kubelet --root-dir is not default "/var/lib/kubelet", it's "/data01/kubelet" instead, so it should be configurable of kubeletRootDir when I install device-plugin with helm chart.