### PR TITLE
pass a single context throughout the device-plugin method call stack

### DIFF
--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -354,7 +354,7 @@ func startPlugins(c *cli.Context, o *options) ([]plugin.Interface, bool, error) 
 
 	// Get the set of plugins.
 	klog.Info("Retrieving plugins.")
-	plugins, err := GetPlugins(infolib, nvmllib, devicelib, config)
+	plugins, err := GetPlugins(c.Context, infolib, nvmllib, devicelib, config)
 	if err != nil {
 		return nil, false, fmt.Errorf("error getting plugins: %v", err)
 	}

--- a/cmd/nvidia-device-plugin/plugin-manager.go
+++ b/cmd/nvidia-device-plugin/plugin-manager.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
@@ -30,7 +31,7 @@ import (
 )
 
 // GetPlugins returns a set of plugins for the specified configuration.
-func GetPlugins(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interface, config *spec.Config) ([]plugin.Interface, error) {
+func GetPlugins(ctx context.Context, infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interface, config *spec.Config) ([]plugin.Interface, error) {
 	// TODO: We could consider passing this as an argument since it should already be used to construct nvmllib.
 	driverRoot := root(*config.Flags.Plugin.ContainerDriverRoot)
 
@@ -61,7 +62,7 @@ func GetPlugins(infolib info.Interface, nvmllib nvml.Interface, devicelib device
 		return nil, fmt.Errorf("unable to create cdi handler: %v", err)
 	}
 
-	plugins, err := plugin.New(infolib, nvmllib, devicelib,
+	plugins, err := plugin.New(ctx, infolib, nvmllib, devicelib,
 		plugin.WithCDIHandler(cdiHandler),
 		plugin.WithConfig(config),
 		plugin.WithDeviceListStrategies(deviceListStrategies),

--- a/internal/plugin/factory.go
+++ b/internal/plugin/factory.go
@@ -17,6 +17,7 @@
 package plugin
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
@@ -46,7 +47,7 @@ type options struct {
 }
 
 // New a new set of plugins with the supplied options.
-func New(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interface, opts ...Option) ([]Interface, error) {
+func New(ctx context.Context, infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interface, opts ...Option) ([]Interface, error) {
 	o := &options{
 		infolib:   infolib,
 		nvmllib:   nvmllib,
@@ -72,7 +73,7 @@ func New(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interf
 
 	var plugins []Interface
 	for _, resourceManager := range resourceManagers {
-		plugin, err := o.devicePluginForResource(resourceManager)
+		plugin, err := o.devicePluginForResource(ctx, resourceManager)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create plugin: %w", err)
 		}


### PR DESCRIPTION
This change follows the Go best practices. With a single ctx reference, we allow for the proper propagation of cancellations and graceful terminations across all goroutines of the device-plugin application.