### PR TITLE
Always use dedicated service account in device-plugin helm chart

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -15,7 +15,6 @@
 {{- if .Values.devicePlugin.enabled }}
 ---
 {{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
-{{- $useServiceAccount := $options.hasConfigMap }}
 {{- $configMapName := (include "nvidia-device-plugin.configMapName" .) | trim }}
 {{- $daemonsetName := printf "%s" (include "nvidia-device-plugin.fullname" .) | trunc 63 | trimSuffix "-" }}
 apiVersion: apps/v1
@@ -56,9 +55,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if $useServiceAccount }}
       serviceAccountName: {{ include "nvidia-device-plugin.fullname" . }}-service-account
-      {{- end }}
       {{- if $options.hasConfigMap }}
       shareProcessNamespace: true
       initContainers:

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
@@ -15,7 +15,6 @@
 {{- if .Values.gfd.enabled }}
 ---
 {{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
-{{- $useServiceAccount := or $options.hasConfigMap .Values.gfd.enabled }}
 {{- $configMapName := (include "nvidia-device-plugin.configMapName" .) | trim }}
 {{- $daemonsetName := printf "%s-gpu-feature-discovery" (include "nvidia-device-plugin.fullname" .) | trunc 63 | trimSuffix "-" }}
 apiVersion: apps/v1
@@ -56,9 +55,7 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if $useServiceAccount }}
       serviceAccountName: {{ include "nvidia-device-plugin.fullname" . }}-service-account
-      {{- end }}
       {{- if $options.hasConfigMap }}
       shareProcessNamespace: true
       {{- end }}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -54,11 +54,9 @@ spec:
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if $options.hasConfigMap }}
       serviceAccountName: {{ include "nvidia-device-plugin.fullname" . }}-service-account
       {{- if not .Values.mps.enableHostPID }}
       shareProcessNamespace: true
-      {{- end }}
       {{- end }}
       {{- if .Values.mps.enableHostPID }}
       hostPID: true

--- a/deployments/helm/nvidia-device-plugin/templates/role-binding.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/role-binding.yml
@@ -1,6 +1,4 @@
 ---
-{{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
-{{- if or $options.hasConfigMap .Values.gfd.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -15,4 +13,3 @@ roleRef:
   kind: ClusterRole
   name: {{ include "nvidia-device-plugin.fullname" . }}-role
   apiGroup: rbac.authorization.k8s.io
-{{- end }}

--- a/deployments/helm/nvidia-device-plugin/templates/role.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/role.yml
@@ -1,6 +1,4 @@
 ---
-{{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
-{{- if or $options.hasConfigMap .Values.gfd.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -19,4 +17,3 @@ rules:
     resources: ["pods"]
     verbs: ["get"]
   {{- end }}
-{{- end }}

--- a/deployments/helm/nvidia-device-plugin/templates/service-account.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/service-account.yml
@@ -1,6 +1,4 @@
 ---
-{{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
-{{- if or $options.hasConfigMap .Values.gfd.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,4 +6,3 @@ metadata:
   namespace: {{ include "nvidia-device-plugin.namespace" . }}
   labels:
     {{- include "nvidia-device-plugin.labels" . | nindent 4 }}
-{{- end }}


### PR DESCRIPTION
Before this change, installing the helm chart with default values would lead to the `default` service account being used. Using the `default` service account is generally discouraged as it is a shared service account that gets used by all pods in the same namespace that don't specify one. If the `default` service account was compromised in some way, e.g. given more privileges, then our device-plugin would also gain those privileges and we would not be adhering to the principle of least privilege.

This PR updates our helm chart so that a dedicated service account is always created and used. 