### PR TITLE
Correct go doc comment for `func (plugin *nvidiaDevicePlugin) Allocate`

### DIFF
--- a/internal/plugin/server.go
+++ b/internal/plugin/server.go
@@ -301,7 +301,7 @@ func (plugin *nvidiaDevicePlugin) GetPreferredAllocation(ctx context.Context, r 
 	return response, nil
 }
 
-// Allocate which return list of devices.
+// Allocate returns a list of devices.
 func (plugin *nvidiaDevicePlugin) Allocate(ctx context.Context, reqs *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
 	responses := pluginapi.AllocateResponse{}
 	for _, req := range reqs.ContainerRequests {


### PR DESCRIPTION
Looks like there is some typo in the go doc comment for `func (plugin *nvidiaDevicePlugin) Allocate`. This PR tries to fix it.