### PR TITLE
[no-relnote] Fix image tag in tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -59,7 +59,7 @@ jobs:
       env:
         KUBECONFIG: ${{ github.workspace }}/kubeconfig
         E2E_IMAGE_REPO: ghcr.io/nvidia/k8s-device-plugin
-        E2E_IMAGE_TAG: ${{ inputs.version }}-ubi9
+        E2E_IMAGE_TAG: ${{ inputs.version }}
         LOG_ARTIFACTS: ${{ github.workspace }}/e2e_logs
       run: |
         make test-e2e


### PR DESCRIPTION
This change removes the `-ubi9` image tag suffix specified in tests since this was removed when switching to distroless images.