### PR TITLE
Build multiarch images on native GitHub runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,6 @@ jobs:
     secrets: inherit
     with:
       version: ${{ needs.basic.outputs.version }}
-      build_multi_arch_images: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release-') }}
 
   e2e-test:
     needs:

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -20,13 +20,15 @@ on:
       version:
         required: true
         type: string
-      build_multi_arch_images:
-        required: true
-        type: string
 
 jobs:
   build:
-    runs-on: linux-amd64-cpu4
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - arm64
+    runs-on: linux-${{ matrix.arch }}-cpu4
     permissions:
       contents: read
       id-token: write
@@ -34,12 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         name: Check out code
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:master
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -52,10 +48,32 @@ jobs:
       - name: Build image
         env:
           IMAGE_NAME: ghcr.io/nvidia/k8s-device-plugin
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ inputs.version }}-${{ matrix.arch }}
           PUSH_ON_BUILD: true
-          BUILD_MULTI_ARCH_IMAGES: ${{ inputs.build_multi_arch_images }}
           GOPROXY: ${{ steps.setup-go-proxy.outputs.goproxy-url }}
+          DOCKER_BUILD_PLATFORM_OPTIONS: "--platform=linux/${{ matrix.arch }}"
         run: |
           echo "${VERSION}"
           make -f deployments/container/Makefile build
+
+  create-manifest:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        name: Check out code
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Manifest
+        env:
+          MULTIARCH_IMAGE: ghcr.io/nvidia/k8s-device-plugin:${{ inputs.version }}
+        run: |
+          docker manifest create \
+            ${MULTIARCH_IMAGE} \
+            ghcr.io/nvidia/k8s-device-plugin:${{ inputs.version }}-amd64 \
+            ghcr.io/nvidia/k8s-device-plugin:${{ inputs.version }}-arm64
+          docker manifest push ${MULTIARCH_IMAGE}

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -14,10 +14,6 @@
 
 BUILD_MULTI_ARCH_IMAGES ?= no
 DOCKER ?= docker
-BUILDX  =
-ifeq ($(BUILD_MULTI_ARCH_IMAGES),true)
-BUILDX = buildx
-endif
 MKDIR    ?= mkdir
 
 ##### Global variables #####
@@ -72,8 +68,7 @@ DOCKERFILE = $(CURDIR)/deployments/container/Dockerfile
 
 # Use a generic build target to build the relevant images
 $(IMAGE_TARGETS): image-%:
-	DOCKER_BUILDKIT=1 \
-		$(DOCKER) $(BUILDX) build --pull \
+		$(DOCKER) build --pull \
 		--provenance=false --sbom=false \
 		$(DOCKER_BUILD_OPTIONS) \
 		$(DOCKER_BUILD_PLATFORM_OPTIONS) \

--- a/deployments/container/multi-arch.mk
+++ b/deployments/container/multi-arch.mk
@@ -14,6 +14,6 @@
 
 PUSH_ON_BUILD ?= false
 DOCKER_BUILD_OPTIONS = --output=type=image,push=$(PUSH_ON_BUILD)
-DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64,linux/arm64
+DOCKER_BUILD_PLATFORM_OPTIONS ?= --platform=linux/amd64,linux/arm64
 
 $(BUILD_TARGETS): build-%: image-%


### PR DESCRIPTION
This commit makes the following changes:

1. Builds multiarch images for non-release commits/PRs, in addition to released versions.
2. Runs the docker build for an arch on the respective GitHub runner (e.g. a linux/amd64 docker image will be built on a linux/amd64 runner). This native build reduces build times due to not requring emulation.
3. Removes explicit use if buildx for docker build. Buildx is now the default builder in Docker. Also removes the related QEMU setup.