### PR TITLE
Helm fix identical template selector

### DIFF
--- a/deployments/helm/nvidia-device-plugin/Chart.yaml
+++ b/deployments/helm/nvidia-device-plugin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: nvidia-device-plugin
 type: application
 description: A Helm chart for the nvidia-device-plugin on Kubernetes
-version: "0.18.0"
+version: "0.18.1"
 appVersion: "0.18.0"
 kubeVersion: ">= 1.10.0-0"
 home: https://github.com/NVIDIA/k8s-device-plugin

--- a/deployments/helm/nvidia-device-plugin/templates/_helpers.tpl
+++ b/deployments/helm/nvidia-device-plugin/templates/_helpers.tpl
@@ -66,6 +66,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- end }}
 
+# PEZA: Added to fix identical template matchLabels
+{{- define "nvidia-device-plugin-mps-control-daemon.templateLabels" -}}
+app.kubernetes.io/name: {{ printf "%s-mps-control-daemon" (include "nvidia-device-plugin.name" .) }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.selectorLabelsOverrideMPSControlDaemon }}
+{{ toYaml .Values.selectorLabelsOverrideMPSControlDaemon }}
+{{- end }}
+{{- end }}
+
 {{/*
 Selector labels
 */}}
@@ -74,6 +83,15 @@ Selector labels
 {{ toYaml .Values.selectorLabelsOverride }}
 {{- else -}}
 {{ include "nvidia-device-plugin.templateLabels" . }}
+{{- end }}
+{{- end }}
+
+# PEZA: Added to fix identical template matchLabels
+{{- define "nvidia-device-plugin-mps-control-daemon.selectorLabels" -}}
+{{- if .Values.selectorLabelsOverrideMPSControlDaemon -}}
+{{ toYaml .Values.selectorLabelsOverrideMPSControlDaemon }}
+{{- else -}}
+{{ include "nvidia-device-plugin-mps-control-daemon.templateLabels" . }}
 {{- end }}
 {{- end }}
 

--- a/deployments/helm/nvidia-device-plugin/templates/_helpers.tpl
+++ b/deployments/helm/nvidia-device-plugin/templates/_helpers.tpl
@@ -75,6 +75,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- end }}
 
+# PEZA: Added to fix identical template matchLabels
+{{- define "nvidia-device-plugin-gpu-feature-discovery.templateLabels" -}}
+app.kubernetes.io/name: {{ printf "%s-gpu-feature-discovery" (include "nvidia-device-plugin.name" .) }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Values.selectorLabelsOverrideMPSControlDaemon }}
+{{ toYaml .Values.selectorLabelsOverrideMPSControlDaemon }}
+{{- end }}
+{{- end }}
+
 {{/*
 Selector labels
 */}}
@@ -92,6 +101,15 @@ Selector labels
 {{ toYaml .Values.selectorLabelsOverrideMPSControlDaemon }}
 {{- else -}}
 {{ include "nvidia-device-plugin-mps-control-daemon.templateLabels" . }}
+{{- end }}
+{{- end }}
+
+# PEZA: Added to fix identical template matchLabels
+{{- define "nvidia-device-plugin-gpu-feature-discovery.selectorLabels" -}}
+{{- if .Values.selectorLabelsOverrideMPSControlDaemon -}}
+{{ toYaml .Values.selectorLabelsOverrideMPSControlDaemon }}
+{{- else -}}
+{{ include "nvidia-device-plugin-gpu-feature-discovery.templateLabels" . }}
 {{- end }}
 {{- end }}
 

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
@@ -28,7 +28,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "nvidia-device-plugin.selectorLabels" . | nindent 6 }}
+      {{- include "nvidia-device-plugin-gpu-feature-discovery.selectorLabels" . | nindent 6 }}
   {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}
@@ -36,7 +36,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "nvidia-device-plugin.templateLabels" . | nindent 8 }}
+        {{- include "nvidia-device-plugin-gpu-feature-discovery.templateLabels" . | nindent 8 }}
       annotations:
         {{- include "nvidia-device-plugin.podAnnotations" (dict "local" . "root" .) | nindent 8 }}
     spec:

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -26,7 +26,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "nvidia-device-plugin.selectorLabels" . | nindent 6 }}
+      {{- include "nvidia-device-plugin-mps-control-daemon.selectorLabels" . | nindent 6 }}
   {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}
@@ -34,7 +34,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "nvidia-device-plugin.templateLabels" . | nindent 8 }}
+        {{- include "nvidia-device-plugin-mps-control-daemon.templateLabels" . | nindent 8 }}
       annotations:
         {{- include "nvidia-device-plugin.podAnnotations" (dict "local" . "root" .) | nindent 8 }}
     spec:

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -42,6 +42,7 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 selectorLabelsOverride: {}
+selectorLabelsOverrideMPSControlDaemon: {}
 
 allowDefaultNamespace: false
 


### PR DESCRIPTION
The helm chart used the same labels for the selector in the daemon sets 

I have fixed this for all daemon sets, being the mps and gfd.