### PR TITLE
Allow CDI feature flags to be set

### DIFF
--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -169,6 +169,11 @@ func main() {
 			Usage:   "The specified IMEX channels are required",
 			EnvVars: []string{"IMEX_REQUIRED"},
 		},
+		&cli.StringSliceFlag{
+			Name:    "cdi-feature-flags",
+			Usage:   "A set of feature flags to be passed to the CDI spec generation logic",
+			EnvVars: []string{"CDI_FEATURE_FLAGS"},
+		},
 	}
 	o.flags = c.Flags
 

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -169,6 +169,10 @@ spec:
           - name: NVIDIA_CDI_HOOK_PATH
             value: {{ .Values.cdi.nvidiaHookPath }}
         {{- end }}
+        {{- if typeIs "string" .Values.cdi.featureFlags }}
+          - name: CDI_FEATURE_FLAGS
+            value: {{ .Values.cdi.featureFlags }}
+        {{- end }}
         {{- if typeIs "bool" .Values.gdrcopyEnabled }}
           - name: GDRCOPY_ENABLED
             value: {{ .Values.gdrcopyEnabled | quote }}

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -163,3 +163,6 @@ cdi:
   # nvidiaHookPath specifies the path to the nvidia-cdi-hook or nvidia-ctk executables on the host.
   # This is required to ensure that the generated CDI specification refers to the correct CDI hooks.
   nvidiaHookPath: null
+  # featureFlags allows CDI feature flags to be specified for CDI specification generation.
+  # This is specified as a comma-separated list of strings.
+  featureFlags: null

--- a/internal/cdi/cdi.go
+++ b/internal/cdi/cdi.go
@@ -57,6 +57,9 @@ type cdiHandler struct {
 
 	deviceListStrategies spec.DeviceListStrategies
 
+	// nvcdiFeatureFlags allows finer control over CDI spec generation.
+	nvcdiFeatureFlags []string
+
 	gdsEnabled     bool
 	mofedEnabled   bool
 	gdrcopyEnabled bool
@@ -117,6 +120,7 @@ func New(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interf
 		nvcdi.WithDeviceLib(c.devicelib),
 		nvcdi.WithDevRoot(c.devRoot),
 		nvcdi.WithDriverRoot(c.driverRoot),
+		nvcdi.WithFeatureFlags(c.nvcdiFeatureFlags...),
 		nvcdi.WithInfoLib(c.infolib),
 		nvcdi.WithLogger(c.logger),
 		nvcdi.WithNVIDIACDIHookPath(c.nvidiaCTKPath),

--- a/internal/cdi/options.go
+++ b/internal/cdi/options.go
@@ -24,6 +24,14 @@ import (
 // Option defines a function for passing options to the New() call
 type Option func(*cdiHandler)
 
+// WithFeatureFlags provides and option to set the feature flags for the nvcdi
+// spec generation instance.
+func WithFeatureFlags(featureFlags ...string) Option {
+	return func(c *cdiHandler) {
+		c.nvcdiFeatureFlags = featureFlags
+	}
+}
+
 // WithDeviceListStrategies provides an Option to set the enabled flag used by the 'cdi' interface
 func WithDeviceListStrategies(deviceListStrategies spec.DeviceListStrategies) Option {
 	return func(c *cdiHandler) {


### PR DESCRIPTION
This change allows specific nvcdi feature flags to be set. These are relevant when the device plugin is configured with a device strategy of cdi-cri or cdi-annotations.