### PR TITLE
Enable NodeFeature API by default in GFD

### DIFF
--- a/cmd/gpu-feature-discovery/main.go
+++ b/cmd/gpu-feature-discovery/main.go
@@ -99,6 +99,7 @@ func main() {
 		},
 		&cli.BoolFlag{
 			Name:    "use-node-feature-api",
+			Value:   true,
 			Usage:   "Use NFD NodeFeature API to publish labels",
 			EnvVars: []string{"GFD_USE_NODE_FEATURE_API", "USE_NODE_FEATURE_API"},
 		},

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
@@ -15,7 +15,7 @@
 {{- if .Values.gfd.enabled }}
 ---
 {{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
-{{- $useServiceAccount := or ( $options.hasConfigMap ) ( and .Values.gfd.enabled .Values.nfd.enableNodeFeatureApi ) }}
+{{- $useServiceAccount := or $options.hasConfigMap .Values.gfd.enabled }}
 {{- $configMapName := (include "nvidia-device-plugin.configMapName" .) | trim }}
 {{- $daemonsetName := printf "%s-gpu-feature-discovery" (include "nvidia-device-plugin.fullname" .) | trunc 63 | trimSuffix "-" }}
 apiVersion: apps/v1
@@ -160,10 +160,6 @@ spec:
         {{- if or (typeIs "string" .Values.sleepInterval) (typeIs "int" .Values.sleepInterval) }}
           - name: GFD_SLEEP_INTERVAL
             value: {{ .Values.sleepInterval | quote }}
-        {{- end }}
-        {{- if typeIs "bool" .Values.nfd.enableNodeFeatureApi }}
-          - name: GFD_USE_NODE_FEATURE_API
-            value: {{ .Values.nfd.enableNodeFeatureApi | quote }}
         {{- end }}
         {{- if $options.hasConfigMap }}
           - name: CONFIG_FILE

--- a/deployments/helm/nvidia-device-plugin/templates/role-binding.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/role-binding.yml
@@ -1,6 +1,6 @@
 ---
 {{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
-{{- if or $options.hasConfigMap ( and .Values.gfd.enabled .Values.nfd.enableNodeFeatureApi ) }}
+{{- if or $options.hasConfigMap .Values.gfd.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/deployments/helm/nvidia-device-plugin/templates/role.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/role.yml
@@ -1,6 +1,6 @@
 ---
 {{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
-{{- if or $options.hasConfigMap ( and .Values.gfd.enabled .Values.nfd.enableNodeFeatureApi ) }}
+{{- if or $options.hasConfigMap .Values.gfd.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -11,7 +11,7 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
-  {{- if and .Values.gfd.enabled .Values.nfd.enableNodeFeatureApi }}
+  {{- if .Values.gfd.enabled }}
   - apiGroups: ["nfd.k8s-sigs.io"]
     resources: ["nodefeatures"]
     verbs: ["get", "list", "watch", "create", "update"]

--- a/deployments/helm/nvidia-device-plugin/templates/service-account.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/service-account.yml
@@ -1,6 +1,6 @@
 ---
 {{- $options := (include "nvidia-device-plugin.options" . | fromJson) }}
-{{- if or $options.hasConfigMap ( and .Values.gfd.enabled .Values.nfd.enableNodeFeatureApi ) }}
+{{- if or $options.hasConfigMap .Values.gfd.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -118,7 +118,6 @@ gfd:
 # Helm dependency
 nfd:
   nameOverride: node-feature-discovery
-  enableNodeFeatureApi: false
   master:
     serviceAccount:
       name: node-feature-discovery


### PR DESCRIPTION
This change enables NodeFeature API in GFD. This results in GFD creating
in a new NodeFeature CR on startup.

This commit also removes the redundant `enableNodeFeatureApi` helm value
NodeFeature is now enabled by default in NFD since it's v0.17.0 release.
The k8s-device-plugin helm chart has been using NFD v0.17.3 subchart
since k8s-device-plugin's v0.18.0 release, so NodeFeature API has been
enabled by default since then and this helm value has had no effect.

Verification steps:

1. Deploy gpu-operator that uses GFD image built by this PR.
2. Verify new `NodeFeature` CR is created.
3. Verify no file is added by GFD in `/etc/kubernetes/node-feature-discovery/features.d/`.