### PR TITLE
Enable gds, gdrcopy and mofed flags by default

### DIFF
--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -103,16 +103,19 @@ func main() {
 		},
 		&cli.BoolFlag{
 			Name:    "gdrcopy-enabled",
+			Value:   true,
 			Usage:   "ensure that containers that request NVIDIA GPU resources are started with GDRCopy support",
 			EnvVars: []string{"GDRCOPY_ENABLED"},
 		},
 		&cli.BoolFlag{
 			Name:    "gds-enabled",
+			Value:   true,
 			Usage:   "ensure that containers that request NVIDIA GPU resources are started with GPUDirect Storage support",
 			EnvVars: []string{"GDS_ENABLED"},
 		},
 		&cli.BoolFlag{
 			Name:    "mofed-enabled",
+			Value:   true,
 			Usage:   "ensure that containers that request NVIDIA GPU resources are started with MOFED support",
 			EnvVars: []string{"MOFED_ENABLED"},
 		},

--- a/internal/plugin/server.go
+++ b/internal/plugin/server.go
@@ -336,6 +336,16 @@ func (plugin *nvidiaDevicePlugin) getAllocateResponse(requestIds []string) (*plu
 		plugin.updateResponseForMPS(response)
 	}
 
+	if plugin.config.Flags.GDRCopyEnabled != nil && *plugin.config.Flags.GDRCopyEnabled {
+		response.Envs["NVIDIA_GDRCOPY"] = "enabled"
+	}
+	if plugin.config.Flags.GDSEnabled != nil && *plugin.config.Flags.GDSEnabled {
+		response.Envs["NVIDIA_GDS"] = "enabled"
+	}
+	if plugin.config.Flags.MOFEDEnabled != nil && *plugin.config.Flags.MOFEDEnabled {
+		response.Envs["NVIDIA_MOFED"] = "enabled"
+	}
+
 	// The following modifications are only made if at least one non-CDI device
 	// list strategy is selected.
 	if plugin.deviceListStrategies.AllCDIEnabled() {
@@ -351,15 +361,6 @@ func (plugin *nvidiaDevicePlugin) getAllocateResponse(requestIds []string) (*plu
 	}
 	if plugin.config.Flags.Plugin.PassDeviceSpecs != nil && *plugin.config.Flags.Plugin.PassDeviceSpecs {
 		response.Devices = append(response.Devices, plugin.apiDeviceSpecs(*plugin.config.Flags.NvidiaDevRoot, requestIds)...)
-	}
-	if plugin.config.Flags.GDRCopyEnabled != nil && *plugin.config.Flags.GDRCopyEnabled {
-		response.Envs["NVIDIA_GDRCOPY"] = "enabled"
-	}
-	if plugin.config.Flags.GDSEnabled != nil && *plugin.config.Flags.GDSEnabled {
-		response.Envs["NVIDIA_GDS"] = "enabled"
-	}
-	if plugin.config.Flags.MOFEDEnabled != nil && *plugin.config.Flags.MOFEDEnabled {
-		response.Envs["NVIDIA_MOFED"] = "enabled"
 	}
 	return response, nil
 }


### PR DESCRIPTION
## Description

<!-- Brief description of the change, including context or motivation -->
With this change, we now always try to dynamically detect if the drivers are present or not.
Current code takes care of failure cases to fail-safe and we are leveraging that
for dynamic driver detection.

## Testing
- [x] Manual cluster testing (describe below)

Manually built an image with these changes and then deployed gpu-operator (once with CDI enabled and once with CDI disabled) with the image and gdrcopy driver enabled.

Verified gdrcopy specific spec is generated in /var/run/cdi when cdi and gdrcopy are enabled. Verified sample workload works fine.
Verified no spec generated when cdi is false and sample workload failing as driver is missing.