### PR TITLE
Fix healthchecking on old devices

### DIFF
--- a/internal/rm/health.go
+++ b/internal/rm/health.go
@@ -102,10 +102,10 @@ func (r *nvmlResourceManager) checkHealth(stop <-chan interface{}, devices Devic
 		}
 
 		ret = gpu.RegisterEvents(eventMask&supportedEvents, eventSet)
-		if ret == nvml.ERROR_NOT_SUPPORTED {
+		switch {
+		case ret == nvml.ERROR_NOT_SUPPORTED:
 			klog.Warningf("Device %v is too old to support healthchecking.", d.ID)
-		}
-		if ret != nvml.SUCCESS {
+		case ret != nvml.SUCCESS:
 			klog.Infof("Marking device %v as unhealthy: %v", d.ID, ret)
 			unhealthy <- d
 		}


### PR DESCRIPTION
In cases where registering events for a device are not supported, we should not mark the device as unhealthy, but skip the device instead.