### PR TITLE
Add `--sleep-interval=infinite` support to GFD for running as a pod

### DIFF
--- a/api/config/v1/flags.go
+++ b/api/config/v1/flags.go
@@ -39,7 +39,9 @@ func updateFromCLIFlag[T any](pflag **T, c *cli.Context, flagName string) {
 		case **bool:
 			*flag = ptr(c.Bool(flagName))
 		case **Duration:
-			*flag = ptr(Duration(c.Duration(flagName)))
+			if gf, ok := c.Generic(flagName).(*DurationValue); ok && gf.Value != nil {
+				*flag = gf.Value
+			}
 		case **deviceListStrategyFlag:
 			*flag = ptr((deviceListStrategyFlag)(c.StringSlice(flagName)))
 		default:

--- a/api/config/v1/flags_test.go
+++ b/api/config/v1/flags_test.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -101,6 +102,20 @@ func TestUnmarshalFlags(t *testing.T) {
 				CommandLineFlags{
 					GFD: &GFDCommandLineFlags{
 						SleepInterval: ptr(Duration(5 * time.Second)),
+					},
+				},
+			},
+		},
+		{
+			input: `{
+				"gfd": {
+					"sleepInterval": "infinite"
+				}
+			}`,
+			output: Flags{
+				CommandLineFlags{
+					GFD: &GFDCommandLineFlags{
+						SleepInterval: ptr(Duration(math.MaxInt64)),
 					},
 				},
 			},
@@ -213,6 +228,31 @@ func TestMarshalFlags(t *testing.T) {
 					"noTimestamp": null,
 					"outputFile": null,
 					"sleepInterval": "5ns",
+					"machineTypeFile": null
+				}
+			}`,
+		},
+		{
+			input: Flags{
+				CommandLineFlags{
+					GFD: &GFDCommandLineFlags{
+						SleepInterval: ptr(Duration(math.MaxInt64)),
+					},
+				},
+			},
+			output: `{
+				"migStrategy": null,
+				"failOnInitError": null,
+				"gdrcopyEnabled": null,
+				"gdsEnabled": null,
+				"mofedEnabled": null,
+				"useNodeFeatureAPI": null,
+				"deviceDiscoveryStrategy": null,
+				"gfd": {
+					"oneshot": null,
+					"noTimestamp": null,
+					"outputFile": null,
+					"sleepInterval": "infinite",
 					"machineTypeFile": null
 				}
 			}`,


### PR DESCRIPTION
 Reuse the existing --sleep-interval flag with support for 'infinite' as a special value.  This causes GFD to label once and sleep indefinitely, which is useful for running as a Kubernetes pod that should not exit.