### PR TITLE
allow stale cache to be deleted

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   stale:
     permissions:
+      actions: write
       issues: write
       pull-requests: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
See https://github.com/actions/stale/pull/1248

Our existing workflow runs fails to clean the stale cache: https://github.com/NVIDIA/k8s-device-plugin/actions/runs/22211889824/job/64247757157#step:2:1300