### PR TITLE
Helm chart: add volumeMounts for nvidiaDriverRoot + custom env. for NFD pod

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -207,7 +207,7 @@ spec:
           - name: kubelet-device-plugins-dir
             mountPath: /var/lib/kubelet/device-plugins
         {{- if typeIs "string" .Values.nvidiaDriverRoot }}
-          # We always mount the driver root at /driver-root in the container.
+          # We mount the driver root at /driver-root in the container.
           # This is required for CDI detection to work correctly.
           - name: driver-root
             mountPath: /driver-root
@@ -242,12 +242,12 @@ spec:
         - name: mps-shm
           hostPath:
             path: {{ .Values.mps.root }}/shm
-        {{- if typeIs "string" .Values.nvidiaDriverRoot }}
+      {{- if typeIs "string" .Values.nvidiaDriverRoot }}
         - name: driver-root
           hostPath:
-            path: {{ .Values.nvidiaDriverRoot }}
+            path: {{ .Values.nvidiaDriverRoot | toYaml }}
             type: Directory
-        {{- end }}
+      {{- end }}
         - name: cdi-root
           hostPath:
             path: /var/run/cdi

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
@@ -177,11 +177,18 @@ spec:
           - name: DEVICE_DISCOVERY_STRATEGY
             value: {{ .Values.deviceDiscoveryStrategy }}
         {{- end }}
+        {{- .Values.gfd.env | toYaml | nindent 10 }}
         securityContext:
           {{- include "gpu-feature-discovery.securityContext" . | nindent 10 }}
         volumeMounts:
           - name: output-dir
             mountPath: "/etc/kubernetes/node-feature-discovery/features.d"
+        {{- if typeIs "string" .Values.nvidiaDriverRoot }}
+          # We mount the driver root at /driver-root in the container.
+          - name: driver-root
+            mountPath: /driver-root
+            readOnly: true
+        {{- end }}
           - name: host-sys
             mountPath: "/sys"
         {{- if $options.hasConfigMap }}
@@ -203,10 +210,12 @@ spec:
           hostPath:
             path: "/sys"
             type: Directory
+      {{- if typeIs "string" .Values.nvidiaDriverRoot }}
         - name: driver-root
           hostPath:
-            path: {{ clean ( join "/" ( list "/" .Values.nvidiaDriverRoot ) ) | quote }}
+            path: {{ .Values.nvidiaDriverRoot | toYaml }}
             type: Directory
+      {{- end }}
       {{- if $options.hasConfigMap }}
         - name: available-configs
           configMap:

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -109,6 +109,8 @@ gfd:
   namespaceOverride: ""
   noTimestamp: null
   sleepInterval: null
+  # custom env. needed (for example: LD_PRELOAD=/driver-root/usr/lib64/libnvidia-ml.so.1 when deviceListStrategy=cdi-cri)
+  env: []
   securityContext:
     # privileged access is required for the gpu-feature-discovery to access the
     # vgpu info on a host.


### PR DESCRIPTION
This is a proposed fix for https://github.com/NVIDIA/k8s-device-plugin/issues/1677

With this patch, I can specify something like the following in the Helm chart custom values.yaml:

```yaml
deviceListStrategy: cdi-cri
nvidiaDriverRoot: "/"
gfd:
  enabled: true
  env:
    # when deviceListStrategy=cdi-cri, there is no runc wrapper to inject the library
    - name: LD_PRELOAD
      value: /driver-root/usr/lib64/libnvidia-ml.so.1
```

...and the gfd Pod is happy.

I also cleaned-up and aligned the logic of this part of template with device plugin template.