### PR TITLE
Allow setting the NVIDIA_DRIVER_CAPABILITIES environment variable

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -199,8 +199,10 @@ spec:
         {{- end }}
           - name: NVIDIA_VISIBLE_DEVICES
             value: all
+        {{ if typeIs "string" .Values.nvidiaDriverCapabilties }}
           - name: NVIDIA_DRIVER_CAPABILITIES
-            value: compute,utility
+            value: {{ .Values.nvidiaDriverCapabilities }}
+        {{- end }}
         securityContext:
           {{- include "nvidia-device-plugin.securityContext" . | nindent 10 }}
         volumeMounts:

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -37,6 +37,7 @@ gdrcopyEnabled: null
 gdsEnabled: null
 mofedEnabled: null
 deviceDiscoveryStrategy: null
+nvidiaDriverCapabilities: "compute,utility"
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
This will allow setting the NVIDIA_DRIVER_CAPABILITIES environment variable on the nvidia-device-plugin-ctr container in the daemonset.

In my environment I need to change it from the default of "compute,utility" to "all".

This is required in my environment where I am using MiG. If this is not set then we get Insufficient Permissions errors from the container when trying to read memory information.