### PR TITLE
feat: add device filter support for selecting/excluding GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
       - [Single Config File Example](#single-config-file-example)
       - [Multiple Config File Example](#multiple-config-file-example)
       - [Updating Per-Node Configuration With a Node Label](#updating-per-node-configuration-with-a-node-label)
+      - [Filtering Devices on specific nodes with Per-Node Configuration](#filtering-devices-on-specific-nodes-with-per-node-configuration)
     - [Setting other helm chart values](#setting-other-helm-chart-values)
     - [Deploying with gpu-feature-discovery for automatic node labels](#deploying-with-gpu-feature-discovery-for-automatic-node-labels)
     - [Deploying gpu-feature-discovery in standalone mode](#deploying-gpu-feature-discovery-in-standalone-mode)
@@ -213,15 +214,18 @@ deploying the plugin via `helm`.
 
 ### As command line flags or envvars
 
-| Flag                     | Environment Variable    | Default Value   |
-|--------------------------|-------------------------|-----------------|
-| `--mig-strategy`         | `$MIG_STRATEGY`         | `"none"`        |
-| `--fail-on-init-error`   | `$FAIL_ON_INIT_ERROR`   | `true`          |
-| `--nvidia-driver-root`   | `$NVIDIA_DRIVER_ROOT`   | `"/"`           |
-| `--pass-device-specs`    | `$PASS_DEVICE_SPECS`    | `false`         |
-| `--device-list-strategy` | `$DEVICE_LIST_STRATEGY` | `"envvar"`      |
-| `--device-id-strategy`   | `$DEVICE_ID_STRATEGY`   | `"uuid"`        |
-| `--config-file`          | `$CONFIG_FILE`          | `""`            |
+| Flag                              | Environment Variable             | Default Value   |
+|-----------------------------------|----------------------------------|-----------------|
+| `--mig-strategy`                  | `$MIG_STRATEGY`                  | `"none"`        |
+| `--fail-on-init-error`            | `$FAIL_ON_INIT_ERROR`            | `true`          |
+| `--nvidia-driver-root`            | `$NVIDIA_DRIVER_ROOT`            | `"/"`           |
+| `--pass-device-specs`             | `$PASS_DEVICE_SPECS`             | `false`         |
+| `--device-list-strategy`          | `$DEVICE_LIST_STRATEGY`          | `"envvar"`      |
+| `--device-id-strategy`            | `$DEVICE_ID_STRATEGY`            | `"uuid"`        |
+| `--config-file`                   | `$CONFIG_FILE`                   | `""`            |
+| `--device-filter-enabled`         | `$DEVICE_FILTER_ENABLED`         | `false`         |
+| `--device-filter-select-devices`  | `$DEVICE_FILTER_SELECT_DEVICES`  | `""`            |
+| `--device-filter-exclude-devices` | `$DEVICE_FILTER_EXCLUDE_DEVICES` | `""`            |
 
 ### As a configuration file
 
@@ -235,6 +239,10 @@ flags:
     passDeviceSpecs: false
     deviceListStrategy: "envvar"
     deviceIDStrategy: "uuid"
+  deviceFilter:
+    enabled: false
+    selectDevices: ""
+    excludeDevices: ""
 ```
 
 **Note:** The configuration file has an explicit `plugin` section because it
@@ -351,6 +359,47 @@ options outside of this section are shared.
   pre-defined configuration file, but then override the values set in it at
   launch time. As described below, a `ConfigMap` can be used to point the
   plugin at a desired configuration file when deploying via `helm`.
+
+**`DEVICE_FILTER_ENABLED`**:
+  enable device filter (select/exclude) from node's discovered devices
+
+  `[true | false] (default 'false')`
+
+  This flag allows enable device filter feature. When set to `false`, it does
+  nothing even if the belows flags `DEVICE_FILTER_SELECT_DEVICES`
+  and `DEVICE_FILTER_EXCLUDE_DEVICES` are set.
+
+**`DEVICE_FILTER_SELECT_DEVICES`**:
+  the desired subset of devices will be selected from node's devices
+
+  `(default '')`
+
+  The `DEVICE_FILTER_SELECT_DEVICES` flag allows one to **select** a subset of devices
+  which are discovered from the Device Plugin or MPS Control Daemon. It accepts
+  input format as a comma-separated string contains device's Index ("0,1,2,3"),
+  ID ("GPU-XXX,GPU-YYY"), or even mixed of both ("0,GPU-XXX,1,3,GPU-YYY") - but
+  the last one is not recommended. If not set, it will use the default value
+  (`''`, an empty string), which means **all** devices are selected.
+
+**`DEVICE_FILTER_EXCLUDE_DEVICES`**:
+  the desired subset of devices will be excluded from node's devices
+
+  `(default '')`
+
+  The `DEVICE_FILTER_EXCLUDE_DEVICES` flags allows one to **exclude** a subset of devices
+  which are discovered from the Device Plugin or MPS Control Daemon. The format is
+  similar to the above `DEVICE_FILTER_SELECT_DEVICES` flag. If not set, it will use
+  the default value (`''`, an empty string), which means **no** devices is excluded.
+
+  **Note:** If a device appears in both `DEVICE_FILTER_EXCLUDE_DEVICES`
+  and `DEVICE_FILTER_SELECT_DEVICES` then it will be excluded in the final selected
+  devices result. For example: if `DEVICE_FILTER_SELECT_DEVICES="1,2,3,4"`
+  and `DEVICE_FILTER_EXCLUDE_DEVICES="1,4,6"`, then the final result is `2,3`.
+
+  **Important:** Device filter is applied **before** creating time-slicing or MPS replicas.
+  This means only the filtered devices will be replicated. For example, if you select 2 GPUs
+  and configure 10 replicas for time-slicing, you will get 20 shared resources (not 80 from
+  all 8 GPUs).
 
 ### Shared Access to GPUs
 
@@ -839,6 +888,97 @@ started to get the desired configuration applied on the node. Anytime it
 changes value, the plugin will immediately be updated to start serving the
 desired configuration. If it is set to an unknown value, it will skip
 reconfiguration. If it is ever unset, it will fallback to the default.
+
+##### Filtering Devices on specific nodes with Per-Node Configuration
+
+In most cases, the device filter feature is used to filter on some specific
+nodes instead of the whole cluster. By creating different configurations and
+using the above Node Label to apply which configuration for each node, it can solve
+the case when a node needs to select or exclude some devices.
+
+For example, node A needs to select only GPUs `2,3,5,6`; node B needs to exclude GPUs `1,7`:
+
+Create custom configs:
+
+The `default` config for all nodes:
+
+```shell
+cat << EOF > /tmp/dp-example-default.yaml
+version: v1
+EOF
+```
+
+**Note:** This `default` config is mandatory because all remaining nodes (except node A and B)
+are needed to provide a "default" config (althogh it can be empty as above example or with
+other configs if desired).
+
+The `device-filter-node-a` config for node A:
+
+```shell
+cat << EOF > /tmp/dp-example-df-node-a.yaml
+version: v1
+flags:
+  deviceFilter:
+    enabled: true
+    selectDevices: "2,3,5,6"
+EOF
+```
+
+The `device-filter-node-b` config for node B:
+```shell
+cat << EOF > /tmp/dp-example-df-node-b.yaml
+version: v1
+flags:
+  deviceFilter:
+    enabled: true
+    excludeDevices: "1,7"
+EOF
+```
+
+And redeploy the device plugin via helm (pointing it at all configs with a specified default):
+
+```shell
+helm upgrade -i nvdp nvdp/nvidia-device-plugin \
+  --version=0.17.0 \
+  --namespace nvidia-device-plugin \
+  --create-namespace \
+  --set config.default=default \
+  --set-file config.map.default=/tmp/dp-example-default.yaml \
+  --set-file config.map.device-filter-node-a=/tmp/dp-example-df-node-a.yaml \
+  --set-file config.map.device-filter-node-b=/tmp/dp-example-df-node-b.yaml
+```
+
+or with pre-created `ConfigMap`s if desired:
+
+```shell
+kubectl create cm -n nvidia-device-plugin nvidia-plugin-configs \
+  --from-file=default=/tmp/dp-example-default.yaml \
+  --from-file=device-filter-node-a=/tmp/dp-example-df-node-a.yaml \
+  --from-file=device-filter-node-b=/tmp/dp-example-df-node-b.yaml
+```
+
+```shell
+helm upgrade -i nvdp nvdp/nvidia-device-plugin \
+  --version=0.17.0 \
+  --namespace nvidia-device-plugin \
+  --create-namespace \
+  --set config.default=default \
+  --set config.name=nvidia-plugin-configs
+```
+
+After the above setup, plugins on all nodes will have `default` configured for them
+by default. However, the following label need be set to change which configuration
+is applied for each node:
+
+```shell
+kubectl label nodes node-A –-overwrite \
+  nvidia.com/device-plugin.config=device-filter-node-a
+```
+
+```shell
+kubectl label nodes node-B –-overwrite \
+  nvidia.com/device-plugin.config=device-filter-node-b
+```
 
 #### Setting other helm chart values
 

--- a/api/config/v1/flags.go
+++ b/api/config/v1/flags.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	flg "github.com/NVIDIA/k8s-device-plugin/internal/flags"
 	cli "github.com/urfave/cli/v2"
 )
 
@@ -69,6 +70,7 @@ type CommandLineFlags struct {
 	DeviceDiscoveryStrategy *string                 `json:"deviceDiscoveryStrategy"    yaml:"deviceDiscoveryStrategy"`
 	Plugin                  *PluginCommandLineFlags `json:"plugin,omitempty"           yaml:"plugin,omitempty"`
 	GFD                     *GFDCommandLineFlags    `json:"gfd,omitempty"              yaml:"gfd,omitempty"`
+	DeviceFilter            *flg.DeviceFilter       `json:"deviceFilter,omitempty"     yaml:"deviceFilter,omitempty"`
 }
 
 // PluginCommandLineFlags holds the list of command line flags specific to the device plugin.
@@ -173,6 +175,18 @@ func (f *Flags) UpdateFromCLIFlags(c *cli.Context, flags []cli.Flag) {
 				updateFromCLIFlag(&f.GFD.NoTimestamp, c, n)
 			case "machine-type-file":
 				updateFromCLIFlag(&f.GFD.MachineTypeFile, c, n)
+			}
+			// DeviceFilter specific flags
+			if f.DeviceFilter == nil {
+				f.DeviceFilter = &flg.DeviceFilter{}
+			}
+			switch n {
+			case "device-filter-enabled":
+				updateFromCLIFlag(&f.DeviceFilter.Enabled, c, n)
+			case "device-filter-select-devices":
+				updateFromCLIFlag(&f.DeviceFilter.SelectDevices, c, n)
+			case "device-filter-exclude-devices":
+				updateFromCLIFlag(&f.DeviceFilter.ExcludeDevices, c, n)
 			}
 		}
 	}

--- a/cmd/mps-control-daemon/main.go
+++ b/cmd/mps-control-daemon/main.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/NVIDIA/k8s-device-plugin/cmd/mps-control-daemon/mount"
 	"github.com/NVIDIA/k8s-device-plugin/cmd/mps-control-daemon/mps"
+	"github.com/NVIDIA/k8s-device-plugin/internal/flags"
 	"github.com/NVIDIA/k8s-device-plugin/internal/info"
 	"github.com/NVIDIA/k8s-device-plugin/internal/rm"
 	"github.com/NVIDIA/k8s-device-plugin/internal/watch"
@@ -76,6 +77,8 @@ func main() {
 		},
 	}
 	c.Flags = config.flags
+
+	c.Flags = append(c.Flags, (&flags.DeviceFilter{}).Flags()...)
 
 	klog.InfoS(c.Name, "version", c.Version)
 	err := c.Run(os.Args)

--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -34,6 +34,7 @@ import (
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
+	"github.com/NVIDIA/k8s-device-plugin/internal/flags"
 	"github.com/NVIDIA/k8s-device-plugin/internal/info"
 	"github.com/NVIDIA/k8s-device-plugin/internal/plugin"
 	"github.com/NVIDIA/k8s-device-plugin/internal/rm"
@@ -181,6 +182,9 @@ func main() {
 			Destination: &o.cdiFeatureFlags,
 		},
 	}
+
+	c.Flags = append(c.Flags, (&flags.DeviceFilter{}).Flags()...)
+
 	o.flags = c.Flags
 
 	err := c.Run(os.Args)

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -205,6 +205,14 @@ spec:
             value: all
           - name: NVIDIA_DRIVER_CAPABILITIES
             value: compute,utility
+        {{- if and (typeIs "bool" .Values.deviceFilter.enabled) (eq .Values.deviceFilter.enabled true) }}
+          - name: DEVICE_FILTER_ENABLED
+            value: {{ .Values.deviceFilter.enabled | quote }}
+          - name: DEVICE_FILTER_SELECT_DEVICES
+            value: {{ .Values.deviceFilter.selectDevices | quote }}
+          - name: DEVICE_FILTER_EXCLUDE_DEVICES
+            value: {{ .Values.deviceFilter.excludeDevices | quote }}
+        {{- end }}
         securityContext:
           {{- include "nvidia-device-plugin.securityContext" . | nindent 10 }}
         volumeMounts:

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -175,6 +175,14 @@ spec:
             value: all
           - name: NVIDIA_DRIVER_CAPABILITIES
             value: compute,utility
+        {{- if and (typeIs "bool" .Values.deviceFilter.enabled) (eq .Values.deviceFilter.enabled true) }}
+          - name: DEVICE_FILTER_ENABLED
+            value: {{ .Values.deviceFilter.enabled | quote }}
+          - name: DEVICE_FILTER_SELECT_DEVICES
+            value: {{ .Values.deviceFilter.selectDevices | quote }}
+          - name: DEVICE_FILTER_EXCLUDE_DEVICES
+            value: {{ .Values.deviceFilter.excludeDevices | quote }}
+        {{- end }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -177,3 +177,14 @@ cdi:
   # featureFlags allows CDI feature flags to be specified for CDI specification generation.
   # This is specified as a comma-separated list of strings.
   featureFlags: null
+
+# deviceFilter allows selecting or/and excluding a subset of devices (per-node) to use for the device-plugin-daemon and mps-control-daemon
+# NOTE: Only use this configiguration for applying a same filter to all nodes!
+# For more granular filter for some specific nodes, use per-node configuration with a node label instead,
+# see: https://github.com/NVIDIA/k8s-device-plugin?tab=readme-ov-file#updating-per-node-configuration-with-a-node-label
+deviceFilter:
+  enabled: false
+  # Comma separated list of devices
+  # Accept formats: Index ("0,1,3,7"), ID ("GPU-XXX,GPU-YYY"), or even mixed of both ("0,GPU-XXX,GPU-YYY,6" - but not recommended)
+  selectDevices: ""
+  excludeDevices: ""

--- a/internal/flags/device_filter.go
+++ b/internal/flags/device_filter.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package flags
+
+import (
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	DevicesSeparator = ","
+)
+
+type DeviceFilter struct {
+	Enabled        *bool   `json:"enabled" yaml:"enabled"`
+	SelectDevices  *string `json:"selectDevices,omitempty" yaml:"selectDevices,omitempty"`
+	ExcludeDevices *string `json:"excludeDevices,omitempty" yaml:"excludeDevices,omitempty"`
+}
+
+func (f DeviceFilter) GetSelectDevicesList() []string {
+	if f.SelectDevices == nil {
+		return nil
+	}
+	return strings.Split(*f.SelectDevices, DevicesSeparator)
+}
+
+func (f DeviceFilter) GetExcludeDevicesList() []string {
+	if f.ExcludeDevices == nil {
+		return nil
+	}
+	return strings.Split(*f.ExcludeDevices, DevicesSeparator)
+}
+
+func (f *DeviceFilter) Flags() []cli.Flag {
+	flags := []cli.Flag{
+		&cli.BoolFlag{
+			Name:        "device-filter-enabled",
+			Usage:       "Enable device filter",
+			Value:       false,
+			Destination: f.Enabled,
+			EnvVars:     []string{"DEVICE_FILTER_ENABLED"},
+		},
+		&cli.StringFlag{
+			Name:        "device-filter-select-devices",
+			Usage:       "The comma separated list used for the selected devices.",
+			Value:       "",
+			Destination: f.SelectDevices,
+			EnvVars:     []string{"DEVICE_FILTER_SELECT_DEVICES"},
+		},
+		&cli.StringFlag{
+			Name:        "device-filter-exclude-devices",
+			Usage:       "The comma separated list used for the excluded devices.",
+			Value:       "",
+			Destination: f.ExcludeDevices,
+			EnvVars:     []string{"DEVICE_FILTER_EXCLUDE_DEVICES"},
+		},
+	}
+	return flags
+}

--- a/internal/rm/device_map.go
+++ b/internal/rm/device_map.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog/v2"
 	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 
+	flg "github.com/NVIDIA/k8s-device-plugin/internal/flags"
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 )
 
@@ -33,6 +34,7 @@ type deviceMapBuilder struct {
 	migStrategy         *string
 	resources           *spec.Resources
 	replicatedResources *spec.ReplicatedResources
+	deviceFilter        *flg.DeviceFilter
 
 	newGPUDevice func(i int, gpu nvml.Device) (string, deviceInfo)
 }
@@ -52,6 +54,7 @@ func NewDeviceMap(devicelib device.Interface, config *spec.Config, platform info
 		migStrategy:         config.Flags.MigStrategy,
 		resources:           &config.Resources,
 		replicatedResources: config.Sharing.ReplicatedResources(),
+		deviceFilter:        config.Flags.DeviceFilter,
 		newGPUDevice:        newGPUDevice,
 	}
 
@@ -64,6 +67,17 @@ func (b *deviceMapBuilder) build() (DeviceMap, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error building device map from config.resources: %v", err)
 	}
+
+	// Apply device filter before creating replicas
+	if b.deviceFilter != nil && b.deviceFilter.Enabled != nil && *b.deviceFilter.Enabled {
+		for resourceName, devs := range devices {
+			devices[resourceName] = devs.FilterByIDOrIndex(
+				b.deviceFilter.GetSelectDevicesList(),
+				b.deviceFilter.GetExcludeDevicesList(),
+			)
+		}
+	}
+
 	devices, err = updateDeviceMapWithReplicas(b.replicatedResources, devices)
 	if err != nil {
 		return nil, fmt.Errorf("error updating device map with replicas from replicatedResources config: %v", err)

--- a/internal/rm/devices.go
+++ b/internal/rm/devices.go
@@ -128,6 +128,15 @@ func (ds Devices) GetByIndex(index string) *Device {
 	return nil
 }
 
+// GetByIDOrIndex returns a reference to the device matching the either specified ID or Index (nil otherwise).
+func (ds Devices) GetByIDOrIndex(in string) *Device {
+	d := ds.GetByID(in)
+	if d != nil {
+		return d
+	}
+	return ds.GetByIndex(in)
+}
+
 // Subset returns the subset of devices in Devices matching the provided ids.
 // If any id in ids is not in Devices, then the subset that did match will be returned.
 func (ds Devices) Subset(ids []string) Devices {
@@ -148,6 +157,37 @@ func (ds Devices) Difference(ods Devices) Devices {
 			res[id] = ds[id]
 		}
 	}
+	return res
+}
+
+// FilterByIDOrIndex returns the subset of devices matching the selected devices but not in excluded devices.
+// Basically, this is the combination of the above Subset and Difference methods.
+// It accepts inputs with the device format as ID(s) and Index(es).
+func (ds Devices) FilterByIDOrIndex(selected []string, excluded []string) Devices {
+	filterFunc := func(ds Devices, filter []string) Devices {
+		res := make(Devices)
+		for _, item := range filter {
+			if d := ds.GetByIDOrIndex(item); d != nil {
+				res[d.ID] = d
+			}
+		}
+		return res
+	}
+
+	res := ds
+
+	// Only perform filtering when selected is not an empty slice ([]string{""})
+	if !(len(selected) == 1 && selected[0] == "") {
+		f := filterFunc(ds, selected)
+		res = res.Subset(f.GetIDs())
+	}
+
+	// Only perform filtering when excluded is not an empty slice ([]string{""})
+	if !(len(excluded) == 1 && excluded[0] == "") {
+		f := filterFunc(ds, excluded)
+		res = res.Difference(f)
+	}
+
 	return res
 }
 


### PR DESCRIPTION
inspired by pr-1189
- Add device filter feature to select or exclude specific GPUs by index or UUID
- Apply filter before creating time-slicing/MPS replicas
- Add Helm chart values for deviceFilter configuration
- Update README with documentation and usage examples