### PR TITLE
include component-specific DaemonSet selector labels

### DIFF
--- a/deployments/helm/nvidia-device-plugin/templates/_helpers.tpl
+++ b/deployments/helm/nvidia-device-plugin/templates/_helpers.tpl
@@ -78,6 +78,16 @@ Selector labels
 {{- end }}
 
 {{/*
+Optional component label for DaemonSet selector and template labels.
+*/}}
+{{- define "nvidia-device-plugin.componentLabel" -}}
+{{- $root := .root -}}
+{{- if and $root.Values.componentSelectorLabels.enabled (not $root.Values.selectorLabelsOverride) -}}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+{{- end }}
+
+{{/*
 Full image name with tag
 */}}
 {{- define "nvidia-device-plugin.fullimage" -}}

--- a/deployments/helm/nvidia-device-plugin/templates/_helpers.tpl
+++ b/deployments/helm/nvidia-device-plugin/templates/_helpers.tpl
@@ -78,6 +78,17 @@ Selector labels
 {{- end }}
 
 {{/*
+Optional component label for DaemonSet selector and template labels.
+*/}}
+{{- define "nvidia-device-plugin.componentLabel" -}}
+{{- $root := .root -}}
+{{- $componentSelectorLabels := default (dict) $root.Values.componentSelectorLabels -}}
+{{- if and (get $componentSelectorLabels "enabled") (not $root.Values.selectorLabelsOverride) -}}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+{{- end }}
+
+{{/*
 Full image name with tag
 */}}
 {{- define "nvidia-device-plugin.fullimage" -}}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -29,6 +29,9 @@ spec:
   selector:
     matchLabels:
       {{- include "nvidia-device-plugin.selectorLabels" . | nindent 6 }}
+      {{- with (include "nvidia-device-plugin.componentLabel" (dict "root" . "component" "device-plugin") | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
   {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}
@@ -37,6 +40,9 @@ spec:
     metadata:
       labels:
         {{- include "nvidia-device-plugin.templateLabels" . | nindent 8 }}
+        {{- with (include "nvidia-device-plugin.componentLabel" (dict "root" . "component" "device-plugin") | trim) }}
+        {{- . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- include "nvidia-device-plugin.podAnnotations" (dict "local" . "root" .) | nindent 8 }}
     spec:

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -29,6 +29,9 @@ spec:
   selector:
     matchLabels:
       {{- include "nvidia-device-plugin.selectorLabels" . | nindent 6 }}
+      {{- with (include "nvidia-device-plugin.componentLabel" (dict "root" . "component" "k8s-device-plugin") | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
   {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}
@@ -37,6 +40,9 @@ spec:
     metadata:
       labels:
         {{- include "nvidia-device-plugin.templateLabels" . | nindent 8 }}
+        {{- with (include "nvidia-device-plugin.componentLabel" (dict "root" . "component" "k8s-device-plugin") | trim) }}
+        {{- . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- include "nvidia-device-plugin.podAnnotations" (dict "local" . "root" .) | nindent 8 }}
     spec:

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-gfd.yml
@@ -29,6 +29,9 @@ spec:
   selector:
     matchLabels:
       {{- include "nvidia-device-plugin.selectorLabels" . | nindent 6 }}
+      {{- with (include "nvidia-device-plugin.componentLabel" (dict "root" . "component" "gpu-feature-discovery") | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
   {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}
@@ -37,6 +40,9 @@ spec:
     metadata:
       labels:
         {{- include "nvidia-device-plugin.templateLabels" . | nindent 8 }}
+        {{- with (include "nvidia-device-plugin.componentLabel" (dict "root" . "component" "gpu-feature-discovery") | trim) }}
+        {{- . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- include "nvidia-device-plugin.podAnnotations" (dict "local" . "root" .) | nindent 8 }}
     spec:

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -27,6 +27,9 @@ spec:
   selector:
     matchLabels:
       {{- include "nvidia-device-plugin.selectorLabels" . | nindent 6 }}
+      {{- with (include "nvidia-device-plugin.componentLabel" (dict "root" . "component" "mps-control-daemon") | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
   {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}
@@ -35,6 +38,9 @@ spec:
     metadata:
       labels:
         {{- include "nvidia-device-plugin.templateLabels" . | nindent 8 }}
+        {{- with (include "nvidia-device-plugin.componentLabel" (dict "root" . "component" "mps-control-daemon") | trim) }}
+        {{- . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- include "nvidia-device-plugin.podAnnotations" (dict "local" . "root" .) | nindent 8 }}
     spec:

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -29,6 +29,9 @@ spec:
   selector:
     matchLabels:
       {{- include "nvidia-device-plugin.selectorLabels" . | nindent 6 }}
+      {{- with (include "nvidia-device-plugin.componentLabel" (dict "root" . "component" "mps-control-daemon") | trim) }}
+      {{- . | nindent 6 }}
+      {{- end }}
   {{- with .Values.updateStrategy }}
   updateStrategy:
     {{- toYaml . | nindent 4 }}
@@ -37,6 +40,9 @@ spec:
     metadata:
       labels:
         {{- include "nvidia-device-plugin.templateLabels" . | nindent 8 }}
+        {{- with (include "nvidia-device-plugin.componentLabel" (dict "root" . "component" "mps-control-daemon") | trim) }}
+        {{- . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- include "nvidia-device-plugin.podAnnotations" (dict "local" . "root" .) | nindent 8 }}
     spec:

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -42,6 +42,13 @@ nameOverride: ""
 fullnameOverride: ""
 namespaceOverride: ""
 selectorLabelsOverride: {}
+componentSelectorLabels:
+  # enabled controls whether DaemonSet selectors include app.kubernetes.io/component
+  # to avoid overlap between device-plugin, gpu-feature-discovery, and mps-control-daemon.
+  # NOTE: This is disabled by default for upgrade compatibility because DaemonSet
+  # selectors are immutable and enabling this on an existing release requires
+  # DaemonSet recreation.
+  enabled: false
 
 allowDefaultNamespace: false
 


### PR DESCRIPTION
include component-specific DaemonSet selector labels to avoid selector overlap

Changes include:
- opt-in Helm setting to include component-specific DaemonSet selector labels to avoid selector overlap across device-plugin, GFD, and MPS control daemon
- disabled by default to avoid breaking upgrades (DaemonSet selectors are immutable and enabling requires DaemonSet recreation)