### PR TITLE
fix: avoid panic on empty cmdline in config-manager findPidToSignal

### DIFF
--- a/cmd/config-manager/main.go
+++ b/cmd/config-manager/main.go
@@ -453,6 +453,12 @@ func findPidToSignal(f *Flags) (int, error) {
 		if err != nil {
 			return -1, fmt.Errorf("error getting cmdline: %v", err)
 		}
+		// Skip processes with an empty cmdline (e.g. kernel threads or
+		// processes that exited between AllProcs() and CmdLine()) to
+		// avoid an index-out-of-range panic on cmdline[0].
+		if len(cmdline) == 0 {
+			continue
+		}
 		if cmdline[0] == f.ProcessToSignal {
 			return p.PID, nil
 		}


### PR DESCRIPTION
Fixes #1726.

`procfs.Proc.CmdLine()` returns an empty slice for kernel threads and processes that exit between `AllProcs()` and `CmdLine()`. The current code in `findPidToSignal` indexes `cmdline[0]` without a length check, which panics with `index out of range [0] with length 0` and crashes the config-manager into `CrashLoopBackOff` when dynamically switching to a config such as `mps-10x`.

Skip processes with an empty cmdline and continue the scan so the manager can either locate the target PID or fall through to the existing `no process found` error.

```
panic: runtime error: index out of range [0] with length 0
goroutine 1 [running]:
main.findPidToSignal(...)
        /build/cmd/config-manager/main.go:456 +0x206
```