### PR TITLE
Allow MPS failRequestsGreaterThanOne to be configured

### DIFF
--- a/api/config/v1/config.go
+++ b/api/config/v1/config.go
@@ -69,12 +69,10 @@ func NewConfig(c *cli.Context, flags []cli.Flag) (*Config, error) {
 		config.Flags.NvidiaDevRoot = config.Flags.NvidiaDriverRoot
 	}
 
-	// We explicitly set sharing.mps.failRequestsGreaterThanOne = true
-	// This can be relaxed in certain cases -- such as a single GPU -- but
-	// requires additional logic around when it's OK to combine requests and
-	// makes the semantics of a request unclear.
-	if config.Sharing.MPS != nil {
-		config.Sharing.MPS.FailRequestsGreaterThanOne = true
+	// Preserve the historical MPS behavior unless the config explicitly relaxes it.
+	if config.Sharing.MPS != nil && config.Sharing.MPS.FailRequestsGreaterThanOne == nil {
+		t := true
+		config.Sharing.MPS.FailRequestsGreaterThanOne = &t
 	}
 
 	return config, nil

--- a/api/config/v1/config_test.go
+++ b/api/config/v1/config_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	cli "github.com/urfave/cli/v2"
+)
+
+func TestNewConfigDefaultsMPSFailRequestsGreaterThanOne(t *testing.T) {
+	config, err := newConfigForTest(t, `
+version: v1
+sharing:
+  mps:
+    resources:
+      - name: nvidia.com/gpu
+        replicas: 2
+`)
+	require.NoError(t, err)
+	require.NotNil(t, config.Sharing.MPS)
+	require.NotNil(t, config.Sharing.MPS.FailRequestsGreaterThanOne)
+	require.True(t, *config.Sharing.MPS.FailRequestsGreaterThanOne)
+}
+
+func TestNewConfigHonorsExplicitMPSFailRequestsGreaterThanOneFalse(t *testing.T) {
+	config, err := newConfigForTest(t, `
+version: v1
+sharing:
+  mps:
+    failRequestsGreaterThanOne: false
+    resources:
+      - name: nvidia.com/gpu
+        replicas: 2
+`)
+	require.NoError(t, err)
+	require.NotNil(t, config.Sharing.MPS)
+	require.NotNil(t, config.Sharing.MPS.FailRequestsGreaterThanOne)
+	require.False(t, *config.Sharing.MPS.FailRequestsGreaterThanOne)
+}
+
+func newConfigForTest(t *testing.T, contents string) (*Config, error) {
+	t.Helper()
+
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "config.yaml")
+	err := os.WriteFile(configFile, []byte(contents), 0o600)
+	require.NoError(t, err)
+
+	set := flag.NewFlagSet("test", flag.ContinueOnError)
+	set.String("config-file", "", "")
+	err = set.Set("config-file", configFile)
+	require.NoError(t, err)
+
+	ctx := cli.NewContext(cli.NewApp(), set, nil)
+	return NewConfig(ctx, nil)
+}

--- a/api/config/v1/replicas.go
+++ b/api/config/v1/replicas.go
@@ -29,7 +29,7 @@ import (
 // ReplicatedResources defines generic options for replicating devices.
 type ReplicatedResources struct {
 	RenameByDefault            bool                 `json:"renameByDefault,omitempty"            yaml:"renameByDefault,omitempty"`
-	FailRequestsGreaterThanOne bool                 `json:"failRequestsGreaterThanOne,omitempty" yaml:"failRequestsGreaterThanOne,omitempty"`
+	FailRequestsGreaterThanOne *bool                `json:"failRequestsGreaterThanOne,omitempty" yaml:"failRequestsGreaterThanOne,omitempty"`
 	Resources                  []ReplicatedResource `json:"resources,omitempty"                  yaml:"resources,omitempty"`
 }
 
@@ -180,14 +180,11 @@ func (s *ReplicatedResources) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	failRequestsGreaterThanOne, exists := ts["failRequestsGreaterThanOne"]
-	if !exists {
-		failRequestsGreaterThanOne = []byte(`false`)
-	}
-
-	err = json.Unmarshal(failRequestsGreaterThanOne, &s.FailRequestsGreaterThanOne)
-	if err != nil {
-		return err
+	if failRequestsGreaterThanOne, exists := ts["failRequestsGreaterThanOne"]; exists {
+		err = json.Unmarshal(failRequestsGreaterThanOne, &s.FailRequestsGreaterThanOne)
+		if err != nil {
+			return err
+		}
 	}
 
 	resources, exists := ts["resources"]

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/kubelet v0.35.2
 	k8s.io/mount-utils v0.35.2
+	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4
 	sigs.k8s.io/node-feature-discovery v0.18.3
 	sigs.k8s.io/node-feature-discovery/api/nfd v0.18.3
 	sigs.k8s.io/yaml v1.6.0
@@ -74,7 +75,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
-	k8s.io/utils v0.0.0-20251002143259-bc988d571ff4 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect

--- a/internal/rm/rm.go
+++ b/internal/rm/rm.go
@@ -92,20 +92,14 @@ func (r *resourceManager) ValidateRequest(ids AnnotatedIDs) error {
 	// error out if more than one resource is being allocated.
 	includesReplicas := ids.AnyHasAnnotations()
 	numRequestedDevices := len(ids)
+	failRequestsGTOne := r.config.Sharing.ReplicatedResources().FailRequestsGreaterThanOne
 	switch r.config.Sharing.SharingStrategy() {
 	case spec.SharingStrategyTimeSlicing:
-		if includesReplicas && numRequestedDevices > 1 && r.config.Sharing.ReplicatedResources().FailRequestsGreaterThanOne {
+		if includesReplicas && numRequestedDevices > 1 && failRequestsGTOne != nil && *failRequestsGTOne {
 			return fmt.Errorf("%w: maximum request size for shared resources is 1; found %d", errInvalidRequest, numRequestedDevices)
 		}
 	case spec.SharingStrategyMPS:
-		// For MPS sharing, we explicitly ignore the FailRequestsGreaterThanOne
-		// value in the sharing settings.
-		// This setting was added to timeslicing after the initial release and
-		// is set to `false` to maintain backward compatibility with existing
-		// deployments. If we do extend MPS to allow multiple devices to be
-		// requested, the MPS API will be extended separately from the
-		// time-slicing API.
-		if includesReplicas && numRequestedDevices > 1 {
+		if includesReplicas && numRequestedDevices > 1 && failRequestsGTOne != nil && *failRequestsGTOne {
 			return fmt.Errorf("%w: maximum request size for shared resources is 1; found %d", errInvalidRequest, numRequestedDevices)
 		}
 	}

--- a/internal/rm/rm_test.go
+++ b/internal/rm/rm_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 
 	spec "github.com/NVIDIA/k8s-device-plugin/api/config/v1"
 )
@@ -94,7 +95,7 @@ func TestValidateRequest(t *testing.T) {
 			description: "timeslicing with two devices -- failRequestsGreaterThanOne",
 			sharing: spec.Sharing{
 				TimeSlicing: spec.ReplicatedResources{
-					FailRequestsGreaterThanOne: true,
+					FailRequestsGreaterThanOne: ptr.To(true),
 					Resources: []spec.ReplicatedResource{
 						{
 							Name:     "nvidia.com/gpu",
@@ -151,13 +152,12 @@ func TestValidateRequest(t *testing.T) {
 				"device1::1": nil,
 			},
 			requestDevicesIDs: []string{"device0::1", "device1::0"},
-			expectedError:     errInvalidRequest,
 		},
 		{
 			description: "MPS with two devices -- failRequestsGreaterThanOne",
 			sharing: spec.Sharing{
 				MPS: &spec.ReplicatedResources{
-					FailRequestsGreaterThanOne: true,
+					FailRequestsGreaterThanOne: ptr.To(true),
 					Resources: []spec.ReplicatedResource{
 						{
 							Name:     "nvidia.com/gpu",


### PR DESCRIPTION
## Summary
- preserve the existing conservative MPS default by treating an omitted `sharing.mps.failRequestsGreaterThanOne` as `true`
- honor an explicit `sharing.mps.failRequestsGreaterThanOne: false` for MPS configs
- validate MPS multi-unit shared GPU requests using the configured value instead of always rejecting them

## Motivation
This makes the MPS setting authoritative in the same way operators would expect from the config field, while keeping current default behavior unchanged. It is related to #1695.

## Tests
- `go test ./api/config/v1 ./internal/rm`