### PR TITLE
[ci] run e2e tests remotely on the provisioned holodeck host

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -55,24 +55,41 @@ jobs:
         aws_ssh_key: ${{ secrets.AWS_SSH_KEY }}
         holodeck_config: "tests/e2e/infra/aws.yaml"
 
+    - name: Get public dns name
+      id: get_public_dns_name
+      uses: mikefarah/yq@v4
+      with:
+        cmd: yq '.status.properties[] | select(.name == "public-dns-name") | .value' /github/workspace/.cache/holodeck.yaml
+
+    - name: Set test environment
+      env:
+        PUBLIC_DNS_NAME: ${{ steps.get_public_dns_name.outputs.result }}
+      run: |
+        echo "instance_hostname=ubuntu@${PUBLIC_DNS_NAME}" >> $GITHUB_ENV
+        echo "private_key=${{ github.workspace }}/key.pem" >> $GITHUB_ENV
+
+    - name: Write SSH key
+      env:
+        AWS_SSH_KEY: ${{ secrets.AWS_SSH_KEY }}
+      run: |
+        echo "${AWS_SSH_KEY}" > ${private_key} && chmod 400 ${private_key}
+
     - name: Run e2e tests
       env:
-        KUBECONFIG: ${{ github.workspace }}/kubeconfig
-        HELM_CHART: ${{ github.workspace }}/deployments/helm/nvidia-device-plugin
         E2E_IMAGE_REPO: ghcr.io/nvidia/k8s-device-plugin
         E2E_IMAGE_TAG: ${{ inputs.version }}
         E2E_IMAGE_PULL_POLICY: Always
         NVIDIA_DRIVER_ENABLED: true
-        LOG_ARTIFACTS: ${{ github.workspace }}/e2e_logs
       run: |
-        make -f tests/e2e/Makefile test
-
+        ./tests/ci-run-e2e.sh ${E2E_IMAGE_REPO} ${E2E_IMAGE_TAG} ${NVIDIA_DRIVER_ENABLED} || rc=$?
+        ./tests/scripts/pull.sh /tmp/logs logs
+        exit $rc
     - name: Archive test logs
       if: ${{ failure() }}
       uses: actions/upload-artifact@v7
       with:
         name: e2e-test-logs
-        path: ./e2e_logs/
+        path: ./logs/
         retention-days: 15
 
     - name: Archive Ginkgo logs

--- a/tests/ci-run-e2e.sh
+++ b/tests/ci-run-e2e.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -xe
+
+if [[ $# -ne 3 ]]; then
+	echo "E2E_IMAGE_REPO, E2E_IMAGE_TAG, NVIDIA_DRIVER_ENABLED are required"
+	exit 1
+fi
+
+export E2E_IMAGE_REPO=${1}
+export E2E_IMAGE_TAG=${2}
+export NVIDIA_DRIVER_ENABLED=${3}
+
+TEST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+${TEST_DIR}/local.sh

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -220,7 +220,7 @@ func getTestEnv() {
 	defer GinkgoRecover()
 	var err error
 
-	Kubeconfig = getRequiredEnvvar[string]("KUBECONFIG")
+	Kubeconfig = getEnvVarOrDefault[string]("KUBECONFIG", clientcmd.RecommendedHomeFile)
 
 	Timeout = time.Duration(getEnvVarOrDefault("E2E_TIMEOUT_SECONDS", 1800)) * time.Second
 

--- a/tests/local.sh
+++ b/tests/local.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+export TEST_JOB="make -f tests/e2e/Makefile test"
+export PROJECT="k8s-device-plugin"
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/scripts && pwd )"
+source ${SCRIPT_DIR}/.definitions.sh
+source ${SCRIPT_DIR}/.local.sh
+
+# Sync the project folder to the remote
+${SCRIPT_DIR}/push.sh
+
+# We trigger the installation of prerequisites on the remote instance
+remote SKIP_PREREQUISITES="${SKIP_PREREQUISITES}" ./tests/scripts/prerequisites.sh
+
+# We trigger the specified test case on the remote instance.
+# Note: We need to ensure that the required environment variables
+# are forwarded to the remote shell.
+remote \
+    PROJECT="${PROJECT}" \
+    HELM_CHART="~/${PROJECT}/deployments/helm/nvidia-device-plugin" \
+    E2E_IMAGE_REPO=${E2E_IMAGE_REPO} \
+    E2E_IMAGE_TAG="${E2E_IMAGE_TAG}" \
+    E2E_IMAGE_PULL_POLICY="${E2E_IMAGE_PULL_POLICY}" \
+    NVIDIA_DRIVER_ENABLED="${NVIDIA_DRIVER_ENABLED}" \
+    LOG_ARTIFACTS="${LOG_ARTIFACTS}" \
+    LOG_ARTIFACTS_DIR="${LOG_ARTIFACTS_DIR}" \
+        ${TEST_JOB}

--- a/tests/scripts/.definitions.sh
+++ b/tests/scripts/.definitions.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+[[ -z "${DEBUG:-}" ]] || set -x
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TEST_DIR="$( cd "${SCRIPT_DIR}/.." && pwd )"
+PROJECT_DIR="$( cd "${TEST_DIR}/.." && pwd )"
+
+# Set default values if not defined
+: ${PROJECT:="$(basename "${PROJECT_DIR}")"}
+: ${GOLANG_VERSION:="1.26.3"}
+: ${E2E_IMAGE_PULL_POLICY:="Always"}
+: ${LOG_ARTIFACTS:=/tmp/logs}
+: ${LOG_ARTIFACTS_DIR:="${LOG_ARTIFACTS}/e2e-logs"}

--- a/tests/scripts/.local.sh
+++ b/tests/scripts/.local.sh
@@ -1,0 +1,5 @@
+#!/usr/env bash
+
+function remote() {
+    ${SCRIPT_DIR}/remote.sh "cd ${PROJECT} && "$@""
+}

--- a/tests/scripts/.rsync-excludes
+++ b/tests/scripts/.rsync-excludes
@@ -1,0 +1,7 @@
+vendor/
+.cache
+.git
+bin/
+cnt-ci
+key.pem
+kubeconfig

--- a/tests/scripts/prerequisites.sh
+++ b/tests/scripts/prerequisites.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+if [[ "${SKIP_PREREQUISITES}" == "true" ]]; then
+    echo "Skipping prerequisites: SKIP_PREREQUISITES=${SKIP_PREREQUISITES}"
+    exit 0
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source "${SCRIPT_DIR}"/.definitions.sh
+
+echo "Create log dir ${LOG_ARTIFACTS_DIR}"
+mkdir -p "${LOG_ARTIFACTS_DIR}"
+
+export DEBIAN_FRONTEND=noninteractive
+
+echo "Install dependencies"
+sudo apt update && sudo apt install -y make
+
+sudo rm -rf /usr/local/go
+arch="$(uname -m)"
+case "${arch##*-}" in \
+    x86_64 | amd64) ARCH='amd64' ;; \
+    ppc64el | ppc64le) ARCH='ppc64le' ;; \
+    aarch64 | arm64) ARCH='arm64' ;; \
+    *) echo "unsupported architecture" ; exit 1 ;; \
+esac;
+wget -nv -O - https://go.dev/dl/go${GOLANG_VERSION}.linux-${ARCH}.tar.gz | sudo tar -C /usr/local -xz
+
+# Non-interactive SSH sessions do not source ~/.bashrc; put go on the default PATH.
+sudo ln -sf /usr/local/go/bin/go /usr/local/bin/go

--- a/tests/scripts/pull.sh
+++ b/tests/scripts/pull.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ $# -ne 2 ]]; then
+    echo "Pull requires a source and destination"
+    exit 1
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source ${SCRIPT_DIR}/.definitions.sh
+source ${SCRIPT_DIR}/.local.sh
+
+${SCRIPT_DIR}/sync.sh ${instance_hostname}:${1} ${2}

--- a/tests/scripts/push.sh
+++ b/tests/scripts/push.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source ${SCRIPT_DIR}/.definitions.sh
+source ${SCRIPT_DIR}/.local.sh
+
+REMOTE_PROJECT_FOLDER="~/${PROJECT}"
+
+# Copy over the contents of the project folder
+${SCRIPT_DIR}/sync.sh \
+        "${PROJECT_DIR}/" \
+        "${instance_hostname}:${REMOTE_PROJECT_FOLDER}"

--- a/tests/scripts/remote.sh
+++ b/tests/scripts/remote.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source ${SCRIPT_DIR}/.definitions.sh
+source ${SCRIPT_DIR}/.local.sh
+
+ssh -i ${private_key} ${instance_hostname} "${@}"

--- a/tests/scripts/sync.sh
+++ b/tests/scripts/sync.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [[ "${SKIP_SYNC}" == "true" ]]; then
+    echo "Skipping sync: SKIP_SYNC=${SKIP_SYNC}"
+    exit 0
+fi
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source ${SCRIPT_DIR}/.definitions.sh
+
+source ${SCRIPT_DIR}/.local.sh
+
+rsync -e "ssh -i ${private_key} -o StrictHostKeyChecking=no" \
+    -avz --delete \
+    --exclude-from="${SCRIPT_DIR}/.rsync-excludes" \
+        ${@}


### PR DESCRIPTION
This PR addresses the failing e2e tests that started surfacing since merging the holodeck version bump PR

#### Problem

The new versions of Holodeck include various security tightening improvements. Part of this is [restricting](https://github.com/NVIDIA/holodeck/pull/629) the permissions of the generated `kubeconfig` file from Holodeck. Given that the generated kubeconfigs are no longer world readable, we can no longer access the kubeconfig that is generated by holodeck from outside.


#### Solution

To address this, we copy the files from the github workspace over to the EC2 instance created by holodeck and run the e2e tests from inside that EC2 instance. This model of e2e test execution is already followed in [gpu-operator](https://github.com/NVIDIA/gpu-operator/tree/main/tests/scripts), so we follow the same approach here
