### PR TITLE
[ci] ensure that e2e tests inherit the go version from the basic checks

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -80,8 +80,9 @@ jobs:
         E2E_IMAGE_TAG: ${{ inputs.version }}
         E2E_IMAGE_PULL_POLICY: Always
         NVIDIA_DRIVER_ENABLED: true
+        GOLANG_VERSION: ${{ inputs.golang_version }}
       run: |
-        ./tests/ci-run-e2e.sh ${E2E_IMAGE_REPO} ${E2E_IMAGE_TAG} ${NVIDIA_DRIVER_ENABLED} || rc=$?
+        ./tests/ci-run-e2e.sh ${E2E_IMAGE_REPO} ${E2E_IMAGE_TAG} ${NVIDIA_DRIVER_ENABLED} ${GOLANG_VERSION} || rc=$?
         ./tests/scripts/pull.sh /tmp/logs logs
         exit $rc
     - name: Archive test logs

--- a/tests/ci-run-e2e.sh
+++ b/tests/ci-run-e2e.sh
@@ -2,14 +2,15 @@
 
 set -xe
 
-if [[ $# -ne 3 ]]; then
-	echo "E2E_IMAGE_REPO, E2E_IMAGE_TAG, NVIDIA_DRIVER_ENABLED are required"
+if [[ $# -ne 4 ]]; then
+	echo "E2E_IMAGE_REPO, E2E_IMAGE_TAG, NVIDIA_DRIVER_ENABLED, GOLANG_VERSION are required"
 	exit 1
 fi
 
 export E2E_IMAGE_REPO=${1}
 export E2E_IMAGE_TAG=${2}
 export NVIDIA_DRIVER_ENABLED=${3}
+export GOLANG_VERSION=${4}
 
 TEST_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/tests/local.sh
+++ b/tests/local.sh
@@ -11,7 +11,10 @@ source ${SCRIPT_DIR}/.local.sh
 ${SCRIPT_DIR}/push.sh
 
 # We trigger the installation of prerequisites on the remote instance
-remote SKIP_PREREQUISITES="${SKIP_PREREQUISITES}" ./tests/scripts/prerequisites.sh
+remote \
+    SKIP_PREREQUISITES="${SKIP_PREREQUISITES}" \
+    GOLANG_VERSION="${GOLANG_VERSION}" \
+       ./tests/scripts/prerequisites.sh
 
 # We trigger the specified test case on the remote instance.
 # Note: We need to ensure that the required environment variables


### PR DESCRIPTION
Without this change, we will need to bump the go version in multiple areas