### PR TITLE
bump version of k8s-device-plugin image references to v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### v0.19.1
+- wsl: report a single "all" device to kubelet (#1699)
+- Fix CDI spec generation to respect driver root for Tegra CSV files (#1701)
+- Bump golang from 1.26.1 to 1.26.2 (#1704)
+* Bump nvidia/distroless/go from v4.0.3-dev to v4.0.4-dev (#1702)
+* Bump google.golang.org/grpc from 1.79.1 to 1.79.3 (#1711)
+* Bump the k8s.io dependencies to v1.35.4 (#1710)
+
 ### v0.19.0
 - Add --sleep-interval=infinite support to GFD for running as a pod (#1603)
 - Fix image tag in static deployment (#1604)

--- a/deployments/helm/nvidia-device-plugin/Chart.yaml
+++ b/deployments/helm/nvidia-device-plugin/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nvidia-device-plugin
 type: application
 description: A Helm chart for the nvidia-device-plugin on Kubernetes
-version: "0.19.0"
-appVersion: "0.19.0"
+version: "0.19.1"
+appVersion: "0.19.1"
 kubeVersion: ">= 1.10.0-0"
 home: https://github.com/NVIDIA/k8s-device-plugin
 

--- a/deployments/static/gpu-feature-discovery-daemonset-with-mig-mixed.yaml
+++ b/deployments/static/gpu-feature-discovery-daemonset-with-mig-mixed.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gpu-feature-discovery
   labels:
     app.kubernetes.io/name: gpu-feature-discovery
-    app.kubernetes.io/version: 0.19.0
+    app.kubernetes.io/version: 0.19.1
     app.kubernetes.io/part-of: nvidia-gpu
 spec:
   selector:
@@ -15,11 +15,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: gpu-feature-discovery
-        app.kubernetes.io/version: 0.19.0
+        app.kubernetes.io/version: 0.19.1
         app.kubernetes.io/part-of: nvidia-gpu
     spec:
       containers:
-        - image: nvcr.io/nvidia/k8s-device-plugin:v0.19.0
+        - image: nvcr.io/nvidia/k8s-device-plugin:v0.19.1
           name: gpu-feature-discovery
           command: ["/usr/bin/gpu-feature-discovery"]
           volumeMounts:

--- a/deployments/static/gpu-feature-discovery-daemonset-with-mig-single.yaml
+++ b/deployments/static/gpu-feature-discovery-daemonset-with-mig-single.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gpu-feature-discovery
   labels:
     app.kubernetes.io/name: gpu-feature-discovery
-    app.kubernetes.io/version: 0.19.0
+    app.kubernetes.io/version: 0.19.1
     app.kubernetes.io/part-of: nvidia-gpu
 spec:
   selector:
@@ -15,11 +15,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: gpu-feature-discovery
-        app.kubernetes.io/version: 0.19.0
+        app.kubernetes.io/version: 0.19.1
         app.kubernetes.io/part-of: nvidia-gpu
     spec:
       containers:
-        - image: nvcr.io/nvidia/k8s-device-plugin:v0.19.0
+        - image: nvcr.io/nvidia/k8s-device-plugin:v0.19.1
           name: gpu-feature-discovery
           command: ["/usr/bin/gpu-feature-discovery"]
           volumeMounts:

--- a/deployments/static/gpu-feature-discovery-daemonset.yaml
+++ b/deployments/static/gpu-feature-discovery-daemonset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gpu-feature-discovery
   labels:
     app.kubernetes.io/name: gpu-feature-discovery
-    app.kubernetes.io/version: 0.19.0
+    app.kubernetes.io/version: 0.19.1
     app.kubernetes.io/part-of: nvidia-gpu
 spec:
   selector:
@@ -15,11 +15,11 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: gpu-feature-discovery
-        app.kubernetes.io/version: 0.19.0
+        app.kubernetes.io/version: 0.19.1
         app.kubernetes.io/part-of: nvidia-gpu
     spec:
       containers:
-        - image: nvcr.io/nvidia/k8s-device-plugin:v0.19.0
+        - image: nvcr.io/nvidia/k8s-device-plugin:v0.19.1
           name: gpu-feature-discovery
           command: ["/usr/bin/gpu-feature-discovery"]
           volumeMounts:

--- a/deployments/static/gpu-feature-discovery-job.yaml.template
+++ b/deployments/static/gpu-feature-discovery-job.yaml.template
@@ -4,19 +4,19 @@ metadata:
   name: gpu-feature-discovery
   labels:
     app.kubernetes.io/name: gpu-feature-discovery
-    app.kubernetes.io/version: 0.19.0
+    app.kubernetes.io/version: 0.19.1
     app.kubernetes.io/part-of: nvidia-gpu
 spec:
   template:
     metadata:
       labels:
         app.kubernetes.io/name: gpu-feature-discovery
-        app.kubernetes.io/version: 0.19.0
+        app.kubernetes.io/version: 0.19.1
         app.kubernetes.io/part-of: nvidia-gpu
     spec:
       nodeName: NODE_NAME
       containers:
-        - image: nvcr.io/nvidia/k8s-device-plugin:v0.19.0
+        - image: nvcr.io/nvidia/k8s-device-plugin:v0.19.1
           name: gpu-feature-discovery
           command: ["/usr/bin/gpu-feature-discovery"]
           args:

--- a/deployments/static/nvidia-device-plugin-compat-with-cpumanager.yml
+++ b/deployments/static/nvidia-device-plugin-compat-with-cpumanager.yml
@@ -38,7 +38,7 @@ spec:
       # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
       priorityClassName: "system-node-critical"
       containers:
-      - image: nvcr.io/nvidia/k8s-device-plugin:v0.19.0
+      - image: nvcr.io/nvidia/k8s-device-plugin:v0.19.1
         name: nvidia-device-plugin-ctr
         env:
           - name: PASS_DEVICE_SPECS

--- a/deployments/static/nvidia-device-plugin-privileged-with-service-account.yml
+++ b/deployments/static/nvidia-device-plugin-privileged-with-service-account.yml
@@ -124,7 +124,7 @@ spec:
         - env:
             - name: PASS_DEVICE_SPECS
               value: "true"
-          image: nvcr.io/nvidia/k8s-device-plugin:v0.19.0
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.19.1
           name: nvidia-device-plugin-ctr
           securityContext:
             privileged: true

--- a/deployments/static/nvidia-device-plugin.yml
+++ b/deployments/static/nvidia-device-plugin.yml
@@ -38,7 +38,7 @@ spec:
       # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
       priorityClassName: "system-node-critical"
       containers:
-      - image: nvcr.io/nvidia/k8s-device-plugin:v0.19.0
+      - image: nvcr.io/nvidia/k8s-device-plugin:v0.19.1
         name: nvidia-device-plugin-ctr
         env: []
         securityContext:

--- a/versions.mk
+++ b/versions.mk
@@ -17,7 +17,7 @@ MODULE := github.com/NVIDIA/$(DRIVER_NAME)
 
 REGISTRY ?= nvcr.io/nvidia
 
-VERSION ?= v0.19.0
+VERSION ?= v0.19.1
 
 GOLANG_VERSION := $(shell ./hack/golang-version.sh)
 


### PR DESCRIPTION
This change was missed when releasing v0.19.1 of k8s-device-plugin