### PR TITLE
bump version of k8s-device-plugin image references to v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 ## Changelog
 
 ### v0.19.1
-- Default to `nvml` strategy when platform cannot be detected.
-- Fix CDI spec generation on Tegra-based systems.
-- Fix cdi-* device list strategies on WSL based systems.
+- wsl: report a single "all" device to kubelet (#1699)
+- Fix CDI spec generation to respect driver root for Tegra CSV files (#1701)
+- Bump golang from 1.26.1 to 1.26.2 (#1704)
+* Bump nvidia/distroless/go from v4.0.3-dev to v4.0.4-dev (#1702)
+* Bump google.golang.org/grpc from 1.79.1 to 1.79.3 (#1711)
+* Bump the k8s.io dependencies to v1.35.4 (#1710)
 
 ### v0.19.0
 - Add --sleep-interval=infinite support to GFD for running as a pod (#1603)

--- a/deployments/static/nvidia-device-plugin-privileged-with-service-account.yml
+++ b/deployments/static/nvidia-device-plugin-privileged-with-service-account.yml
@@ -124,7 +124,7 @@ spec:
         - env:
             - name: PASS_DEVICE_SPECS
               value: "true"
-          image: nvcr.io/nvidia/k8s-device-plugin:v0.19.0
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.19.1
           name: nvidia-device-plugin-ctr
           securityContext:
             privileged: true


### PR DESCRIPTION
This is a cherrypick of 0495ac654ec00e2d5cb586f2a2f7151cbbb39851