### PR TITLE
prepare release v0.19.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
 ## Changelog
 
+### v0.19.2
+- Bump golang version to 1.26.3 (#1754)
+- Bump nvidia/distroless/go to v4.0.6-dev (#1806)
+- Bump nvidia-container-toolkit to v1.19.1 (#1798)
+- Always use a dedicated service account in the helm chart (#1804)
+
 ### v0.19.1
 - wsl: report a single "all" device to kubelet (#1699)
 - Fix CDI spec generation to respect driver root for Tegra CSV files (#1701)
 - Bump golang from 1.26.1 to 1.26.2 (#1704)
-* Bump nvidia/distroless/go from v4.0.3-dev to v4.0.4-dev (#1702)
-* Bump google.golang.org/grpc from 1.79.1 to 1.79.3 (#1711)
-* Bump the k8s.io dependencies to v1.35.4 (#1710)
+- Bump nvidia/distroless/go from v4.0.3-dev to v4.0.4-dev (#1702)
+- Bump google.golang.org/grpc from 1.79.1 to 1.79.3 (#1711)
+- Bump the k8s.io dependencies to v1.35.4 (#1710)
 
 ### v0.19.0
 - Add --sleep-interval=infinite support to GFD for running as a pod (#1603)

--- a/deployments/helm/nvidia-device-plugin/Chart.yaml
+++ b/deployments/helm/nvidia-device-plugin/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: nvidia-device-plugin
 type: application
 description: A Helm chart for the nvidia-device-plugin on Kubernetes
-version: "0.19.1"
-appVersion: "0.19.1"
+version: "0.19.2"
+appVersion: "0.19.2"
 kubeVersion: ">= 1.10.0-0"
 home: https://github.com/NVIDIA/k8s-device-plugin
 

--- a/versions.mk
+++ b/versions.mk
@@ -17,7 +17,7 @@ MODULE := github.com/NVIDIA/$(DRIVER_NAME)
 
 REGISTRY ?= nvcr.io/nvidia
 
-VERSION ?= v0.19.1
+VERSION ?= v0.19.2
 
 GOLANG_VERSION := $(shell ./hack/golang-version.sh)
 


### PR DESCRIPTION
Prepare to publish the next patch release of k8s-device-plugin.

NOTE: The rest of the k8s-device-plugin references will be updated after the new images are published