### PR TITLE
ci: expose pages deploy workflow input

### DIFF
--- a/.github/workflows/deploy-to-pages.yaml
+++ b/.github/workflows/deploy-to-pages.yaml
@@ -29,6 +29,7 @@ on:
 
   # Allow this workflow to be run from the Actions tab.
   workflow_dispatch:
+    inputs:
       git_ref_to_deploy:
         description: The git reference to deploy
         required: false


### PR DESCRIPTION
Summary:
- add the missing `inputs:` mapping under `workflow_dispatch` in the Pages deploy workflow
- keep the existing `git_ref_to_deploy` input shared with the workflow-call default

Verification:
- `actionlint .github/workflows/deploy-to-pages.yaml`
- `git diff --check`

This was implemented with Codex assistance, with the patch kept focused and manually reviewed before posting.

Closes #1713
