### PR TITLE
Allow CDI hooks to be disabled

### DIFF
--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -45,6 +45,7 @@ type options struct {
 	configFile      string
 	kubeletSocket   string
 	cdiFeatureFlags cli.StringSlice
+	cdiDisableHooks cli.StringSlice
 }
 
 func main() {
@@ -179,6 +180,12 @@ func main() {
 			Usage:       "A set of feature flags to be passed to the CDI spec generation logic",
 			EnvVars:     []string{"CDI_FEATURE_FLAGS"},
 			Destination: &o.cdiFeatureFlags,
+		},
+		&cli.StringSliceFlag{
+			Name:        "cdi-disable-hooks",
+			Usage:       "A set of OCI hooks to disable when generating CDI specifications; if the value 'all' is specified, then the CDI specification will exclude all OCI hooks.",
+			EnvVars:     []string{"CDI_DISABLE_HOOKS"},
+			Destination: &o.cdiDisableHooks,
 		},
 	}
 	o.flags = c.Flags

--- a/cmd/nvidia-device-plugin/plugin-manager.go
+++ b/cmd/nvidia-device-plugin/plugin-manager.go
@@ -63,6 +63,7 @@ func GetPlugins(ctx context.Context, infolib info.Interface, nvmllib nvml.Interf
 		cdi.WithMofedEnabled(*config.Flags.MOFEDEnabled),
 		cdi.WithImexChannels(imexChannels),
 		cdi.WithFeatureFlags(o.cdiFeatureFlags.Value()...),
+		cdi.WithDisabledHooks(o.cdiDisableHooks.Value()...),
 		cdi.WithDeviceDiscoveryStrategy(resolvedStrategy),
 	)
 	if err != nil {

--- a/internal/cdi/cdi.go
+++ b/internal/cdi/cdi.go
@@ -62,6 +62,9 @@ type cdiHandler struct {
 	// nvcdiFeatureFlags allows finer control over CDI spec generation.
 	nvcdiFeatureFlags []string
 
+	// nvcdiDisabledHooks is a list of hooks to omit when generating CDI specs
+	nvcdiDisabledHooks []string
+
 	gdsEnabled     bool
 	mofedEnabled   bool
 	gdrcopyEnabled bool
@@ -126,6 +129,7 @@ func New(infolib info.Interface, nvmllib nvml.Interface, devicelib device.Interf
 		nvcdi.WithDevRoot(c.devRoot),
 		nvcdi.WithDriverRoot(c.driverRoot),
 		nvcdi.WithFeatureFlags(c.nvcdiFeatureFlags...),
+		nvcdi.WithDisabledHooks(c.nvcdiDisabledHooks...),
 		nvcdi.WithInfoLib(c.infolib),
 		nvcdi.WithLogger(c.logger),
 		nvcdi.WithNVIDIACDIHookPath(c.nvidiaCTKPath),

--- a/internal/cdi/options.go
+++ b/internal/cdi/options.go
@@ -32,6 +32,14 @@ func WithFeatureFlags(featureFlags ...string) Option {
 	}
 }
 
+// WithDisabledHooks provides and option to disable hooks for the nvcdi
+// spec generation instance.
+func WithDisabledHooks(disabledHooks ...string) Option {
+	return func(c *cdiHandler) {
+		c.nvcdiDisabledHooks = disabledHooks
+	}
+}
+
 // WithDeviceListStrategies provides an Option to set the enabled flag used by the 'cdi' interface
 func WithDeviceListStrategies(deviceListStrategies spec.DeviceListStrategies) Option {
 	return func(c *cdiHandler) {


### PR DESCRIPTION
### Testing

```
$ grep "ModifyDeviceFile" /proc/driver/nvidia/params
ModifyDeviceFiles: 1

$ cat pod.yaml
apiVersion: v1
kind: Pod
metadata:
  name: gpu-sleep
spec:
  restartPolicy: Never
  containers:
    - name: main
      image: ubuntu
      command: ["sh", "-c", "sleep infinity"]
      resources:
        limits:
          nvidia.com/gpu: 1

$ kubectl apply -f pod.yaml
pod/gpu-sleep created

$ kubectl exec -it gpu-sleep -- grep "ModifyDeviceFile" /proc/driver/nvidia/params
ModifyDeviceFiles: 0

$ kubectl delete -f pod.yaml
pod "gpu-sleep" deleted from default namespace

// add below env to device-plugin daemonset
// env:
// - name: CDI_DISABLE_HOOKS
     value: "disable-device-node-modification, update-ldcache"

// after plugin restarts, observe that boths hooks are omitted from the generated CDI spec

$ kubectl apply -f pod.yaml
pod/gpu-sleep created

$ kubectl exec -it gpu-sleep -- grep "ModifyDeviceFile" /proc/driver/nvidia/params
ModifyDeviceFiles: 1
```