### PR TITLE
api/config/v1: keep user-specified rename/devices for shared resources

### DIFF
--- a/api/config/v1/replicas.go
+++ b/api/config/v1/replicas.go
@@ -33,10 +33,37 @@ type ReplicatedResources struct {
 	Resources                  []ReplicatedResource `json:"resources,omitempty"                  yaml:"resources,omitempty"`
 }
 
+// mpsSharingID is the id value passed to disableResoureRenaming for the MPS
+// sharing path (see DisableResourceNamingInConfig).
+const mpsSharingID = "mps"
+
 func (rrs *ReplicatedResources) disableResoureRenaming(id string) {
 	if rrs == nil {
 		return
 	}
+
+	// The MPS control daemon can only apply a single active thread percentage
+	// per node, so per-GPU device selection and multiple rename targets are
+	// structurally unsupportable on the MPS path. Keep the historical
+	// behaviour: reset user-specified `rename` and `devices` fields.
+	if id == mpsSharingID {
+		rrs.resetRenameAndDevices(id)
+		return
+	}
+
+	// For time-slicing (and any future non-MPS sharing mode) there is no
+	// equivalent per-node constraint, so preserve user-specified `rename`
+	// and `devices` fields instead of resetting them. This enables per-UUID
+	// time-slicing, where only a subset of GPUs on a node is exposed under
+	// a renamed shared resource (e.g. nvidia.com/gpu.shared) while the
+	// remaining devices stay on the original resource name.
+	rrs.keepRenameAndDevices(id)
+}
+
+// resetRenameAndDevices restores the historical behaviour: clear any
+// user-specified `rename` field and force `Devices.All=true` on every entry,
+// emitting warnings that mirror the original messages.
+func (rrs *ReplicatedResources) resetRenameAndDevices(id string) {
 	renameByDefault := rrs.RenameByDefault
 	setsNonDefaultRename := false
 	setsDevices := false
@@ -62,7 +89,31 @@ func (rrs *ReplicatedResources) disableResoureRenaming(id string) {
 	if setsDevices {
 		klog.Warningf("Customizing the 'devices' field in sharing.%s.resources is not yet supported in the config. Ignoring...", id)
 	}
+}
 
+// keepRenameAndDevices preserves user-specified `rename` and `devices` fields,
+// emitting an informational warning so that the intent is visible in logs.
+func (rrs *ReplicatedResources) keepRenameAndDevices(id string) {
+	renameByDefault := rrs.RenameByDefault
+	setsNonDefaultRename := false
+	setsDevices := false
+	for _, r := range rrs.Resources {
+		if !renameByDefault && r.Rename != "" {
+			setsNonDefaultRename = true
+		}
+		if renameByDefault && r.Rename != r.Name.DefaultSharedRename() {
+			setsNonDefaultRename = true
+		}
+		if !r.Devices.All {
+			setsDevices = true
+		}
+	}
+	if setsNonDefaultRename {
+		klog.Warningf("sharing.%s.resources: keeping user-specified `rename` field (per-UUID time-slicing)", id)
+	}
+	if setsDevices {
+		klog.Warningf("sharing.%s.resources: keeping user-specified `devices` field (per-UUID time-slicing)", id)
+	}
 }
 
 func (rrs *ReplicatedResources) isReplicated() bool {

--- a/api/config/v1/replicas_test.go
+++ b/api/config/v1/replicas_test.go
@@ -464,3 +464,204 @@ func TestUnmarshalReplicatedResources(t *testing.T) {
 		})
 	}
 }
+
+func TestDisableResoureRenamingKeepsUserSpec(t *testing.T) {
+	const (
+		uuidA = "GPU-4cf8db2d-06c0-7d70-1a51-e59b25b2c16c"
+		uuidB = "GPU-662077db-fa3f-0d8f-9502-21ab0ef058a2"
+	)
+
+	testCases := []struct {
+		name     string
+		input    *ReplicatedResources
+		expected *ReplicatedResources
+	}{
+		{
+			name: "per-UUID rename preserved (renameByDefault=false)",
+			input: &ReplicatedResources{
+				RenameByDefault: false,
+				Resources: []ReplicatedResource{
+					{
+						Name:   NoErrorNewResourceName("nvidia.com/gpu"),
+						Rename: NoErrorNewResourceName("nvidia.com/gpu.shared"),
+						Devices: ReplicatedDevices{
+							List: []ReplicatedDeviceRef{uuidA},
+						},
+						Replicas: 2,
+					},
+				},
+			},
+			expected: &ReplicatedResources{
+				RenameByDefault: false,
+				Resources: []ReplicatedResource{
+					{
+						Name:   NoErrorNewResourceName("nvidia.com/gpu"),
+						Rename: NoErrorNewResourceName("nvidia.com/gpu.shared"),
+						Devices: ReplicatedDevices{
+							List: []ReplicatedDeviceRef{uuidA},
+						},
+						Replicas: 2,
+					},
+				},
+			},
+		},
+		{
+			name: "per-UUID devices preserved (renameByDefault=true, default rename target)",
+			input: &ReplicatedResources{
+				RenameByDefault: true,
+				Resources: []ReplicatedResource{
+					{
+						Name:   NoErrorNewResourceName("nvidia.com/gpu"),
+						Rename: NoErrorNewResourceName("nvidia.com/gpu.shared"),
+						Devices: ReplicatedDevices{
+							List: []ReplicatedDeviceRef{uuidA, uuidB},
+						},
+						Replicas: 2,
+					},
+				},
+			},
+			expected: &ReplicatedResources{
+				RenameByDefault: true,
+				Resources: []ReplicatedResource{
+					{
+						Name:   NoErrorNewResourceName("nvidia.com/gpu"),
+						Rename: NoErrorNewResourceName("nvidia.com/gpu.shared"),
+						Devices: ReplicatedDevices{
+							List: []ReplicatedDeviceRef{uuidA, uuidB},
+						},
+						Replicas: 2,
+					},
+				},
+			},
+		},
+		{
+			name: "two resource names on one node: nvidia.com/gpu full + nvidia.com/gpu.shared per-UUID",
+			input: &ReplicatedResources{
+				RenameByDefault: false,
+				Resources: []ReplicatedResource{
+					// Only the GPU identified by uuidA is sliced into
+					// nvidia.com/gpu.shared. Any other GPU on the node that
+					// is not listed here keeps its original nvidia.com/gpu
+					// resource name (no entry is required for full cards).
+					{
+						Name:   NoErrorNewResourceName("nvidia.com/gpu"),
+						Rename: NoErrorNewResourceName("nvidia.com/gpu.shared"),
+						Devices: ReplicatedDevices{
+							List: []ReplicatedDeviceRef{uuidA},
+						},
+						Replicas: 2,
+					},
+				},
+			},
+			expected: &ReplicatedResources{
+				RenameByDefault: false,
+				Resources: []ReplicatedResource{
+					{
+						Name:   NoErrorNewResourceName("nvidia.com/gpu"),
+						Rename: NoErrorNewResourceName("nvidia.com/gpu.shared"),
+						Devices: ReplicatedDevices{
+							List: []ReplicatedDeviceRef{uuidA},
+						},
+						Replicas: 2,
+					},
+				},
+			},
+		},
+		{
+			name:     "nil receiver is a no-op",
+			input:    nil,
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.input.disableResoureRenaming("timeSlicing")
+			require.Equal(t, tc.expected, tc.input)
+		})
+	}
+}
+
+func TestDisableResoureRenamingMPSStillResets(t *testing.T) {
+	// The MPS control daemon can only apply a single active_thread_percentage
+	// per node, so per-GPU device selection and custom rename targets are
+	// structurally unsupportable on the MPS path. Verify that
+	// disableResoureRenaming("mps") keeps the historical behaviour: clear
+	// user-specified Rename and force Devices.All=true on every entry,
+	// regardless of what the user configured.
+	const uuidA = "GPU-4cf8db2d-06c0-7d70-1a51-e59b25b2c16c"
+	const uuidB = "GPU-b1028956-cfa2-0990-bf4a-5da9abb51763"
+
+	testCases := []struct {
+		name     string
+		input    *ReplicatedResources
+		expected *ReplicatedResources
+	}{
+		{
+			name: "renameByDefault=false: user rename cleared, per-UUID devices forced to all",
+			input: &ReplicatedResources{
+				RenameByDefault: false,
+				Resources: []ReplicatedResource{
+					{
+						Name:   NoErrorNewResourceName("nvidia.com/gpu"),
+						Rename: NoErrorNewResourceName("nvidia.com/gpu.shared"),
+						Devices: ReplicatedDevices{
+							List: []ReplicatedDeviceRef{uuidA, uuidB},
+						},
+						Replicas: 2,
+					},
+				},
+			},
+			expected: &ReplicatedResources{
+				RenameByDefault: false,
+				Resources: []ReplicatedResource{
+					{
+						Name:     NoErrorNewResourceName("nvidia.com/gpu"),
+						Rename:   "",
+						Devices:  ReplicatedDevices{All: true},
+						Replicas: 2,
+					},
+				},
+			},
+		},
+		{
+			name: "renameByDefault=true: non-default rename reset to DefaultSharedRename, devices forced to all",
+			input: &ReplicatedResources{
+				RenameByDefault: true,
+				Resources: []ReplicatedResource{
+					{
+						Name:   NoErrorNewResourceName("nvidia.com/gpu"),
+						Rename: NoErrorNewResourceName("nvidia.com/gpu.custom-shared"),
+						Devices: ReplicatedDevices{
+							Count: 2,
+						},
+						Replicas: 2,
+					},
+				},
+			},
+			expected: &ReplicatedResources{
+				RenameByDefault: true,
+				Resources: []ReplicatedResource{
+					{
+						Name:     NoErrorNewResourceName("nvidia.com/gpu"),
+						Rename:   NoErrorNewResourceName("nvidia.com/gpu").DefaultSharedRename(),
+						Devices:  ReplicatedDevices{All: true},
+						Replicas: 2,
+					},
+				},
+			},
+		},
+		{
+			name:     "nil receiver is a no-op",
+			input:    nil,
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.input.disableResoureRenaming("mps")
+			require.Equal(t, tc.expected, tc.input)
+		})
+	}
+}


### PR DESCRIPTION
`disableResoureRenaming` currently resets the `Rename` and `Devices` fields of every entry under `sharing.timeSlicing.resources` (and `sharing.mps.resources`) to their defaults. That makes it impossible to:

  * pin a shared resource to a specific subset of GPU UUIDs (per-UUID time-slicing), and
  * expose two resource names on the same node, e.g. `nvidia.com/gpu` for full cards and `nvidia.com/gpu.shared` for the time-sliced subset.

Preserve both fields and emit a warning instead, so that user intent is honored. Downstream resource-manager code already supports per-UUID device lists and custom rename targets, so no additional plumbing is required.