### PR TITLE
Fix MPS config-manager PROCESS_TO_SIGNAL target matching

### DIFF
--- a/cmd/config-manager/main.go
+++ b/cmd/config-manager/main.go
@@ -443,6 +443,16 @@ func signalProcess(f *Flags) error {
 	return nil
 }
 
+// cmdlineMatchesProcessTarget reports whether argv[0] matches the configured signal target.
+// The container command is often "mps-control-daemon" while PROCESS_TO_SIGNAL may be set to
+// "/usr/bin/mps-control-daemon"; compare basenames so shareProcessNamespace pods can signal.
+func cmdlineMatchesProcessTarget(argv0, target string) bool {
+	if argv0 == target {
+		return true
+	}
+	return filepath.Base(argv0) == filepath.Base(target)
+}
+
 func findPidToSignal(f *Flags) (int, error) {
 	procs, err := procfs.AllProcs()
 	if err != nil {
@@ -456,7 +466,7 @@ func findPidToSignal(f *Flags) (int, error) {
 		if len(cmdline) == 0 {
 			continue
 		}
-		if cmdline[0] == f.ProcessToSignal {
+		if cmdlineMatchesProcessTarget(cmdline[0], f.ProcessToSignal) {
 			return p.PID, nil
 		}
 	}

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-mps-control-daemon.yml
@@ -140,7 +140,7 @@ spec:
           - name: SIGNAL
             value: "1"
           - name: PROCESS_TO_SIGNAL
-            value: "/usr/bin/mps-control-daemon"
+            value: "mps-control-daemon"
           volumeMounts:
             - name: available-configs
               mountPath: /available-configs


### PR DESCRIPTION
## Summary

Fixes `mps-control-daemon-sidecar` (`config-manager`) exiting when it sends SIGHUP after updating the MPS config symlink.

## Problem

Helm sets `PROCESS_TO_SIGNAL=/usr/bin/mps-control-daemon`, but the container runs `command: [mps-control-daemon]`, so `argv[0]` is `mps-control-daemon`.

`findPidToSignal` compares `cmdline[0]` to the target with an exact string match. That fails, returns `no process found`, and the sidecar crashes (CrashLoopBackOff). This happens whenever `SEND_SIGNAL` runs after a real config update (including common startup races where the sidecar briefly applies `DEFAULT_CONFIG` before the node label is seen).

## Fix

- **`cmd/config-manager/main.go`**: match by exact string or **basename** (`mps-control-daemon` ↔ `/usr/bin/mps-control-daemon`)
- **Helm MPS DaemonSet**: set `PROCESS_TO_SIGNAL` to `mps-control-daemon`

## Related

- Separate panic when scanning `/proc` entries with empty cmdline: **#1822**

## Test plan

- [ ] Deploy MPS control daemon on nodes with `nvidia.com/device-plugin.config` set to `config-1` and `config-2`
- [ ] Confirm `mps-control-daemon-sidecar` is **2/2** Ready after pod create (no `no process found`)
- [ ] Verify `readlink -f /config/config.yaml` in `mps-control-daemon-ctr` matches the node label
- [ ] Change node label between two valid configs and verify sidecar reloads without crash