### PR TITLE
revert default enablement of features mofed, gdrcopy and mofed (#1837)

### DIFF
--- a/cmd/nvidia-device-plugin/main.go
+++ b/cmd/nvidia-device-plugin/main.go
@@ -103,19 +103,16 @@ func main() {
 		},
 		&cli.BoolFlag{
 			Name:    "gdrcopy-enabled",
-			Value:   true,
 			Usage:   "ensure that containers that request NVIDIA GPU resources are started with GDRCopy support",
 			EnvVars: []string{"GDRCOPY_ENABLED"},
 		},
 		&cli.BoolFlag{
 			Name:    "gds-enabled",
-			Value:   true,
 			Usage:   "ensure that containers that request NVIDIA GPU resources are started with GPUDirect Storage support",
 			EnvVars: []string{"GDS_ENABLED"},
 		},
 		&cli.BoolFlag{
 			Name:    "mofed-enabled",
-			Value:   true,
 			Usage:   "ensure that containers that request NVIDIA GPU resources are started with MOFED support",
 			EnvVars: []string{"MOFED_ENABLED"},
 		},


### PR DESCRIPTION
(cherry picked from commit 8d844dca549ccd35eeb6f44bd65b0af97234c77c)