### PR TITLE
Surface NVML error when MIG device placement cannot be determined

### DIFF
--- a/internal/rm/health.go
+++ b/internal/rm/health.go
@@ -295,29 +295,37 @@ func (r *nvmlResourceManager) getMigDeviceParts(d *Device) (string, uint32, uint
 	uuid := d.GetUUID()
 	// For older driver versions, the call to DeviceGetHandleByUUID will fail for MIG devices.
 	mig, ret := r.nvml.DeviceGetHandleByUUID(uuid)
-	if ret == nvml.SUCCESS {
-		parentHandle, ret := mig.GetDeviceHandleFromMigDeviceHandle()
-		if ret != nvml.SUCCESS {
-			return "", 0, 0, fmt.Errorf("failed to get parent device handle: %v", ret)
+	if ret != nvml.SUCCESS {
+		// Fall back to parsing the legacy MIG UUID format (MIG-GPU-<parent-uuid>/<gi>/<ci>).
+		// Modern drivers assign opaque MIG UUIDs that carry no placement information,
+		// so if parsing fails the NVML error above must not be masked: it is the
+		// actual reason the device placement could not be determined.
+		parentUUID, gi, ci, err := parseMigDeviceUUID(uuid)
+		if err != nil {
+			return "", 0, 0, fmt.Errorf("failed to get MIG device handle for %s: %s; %w", uuid, nvml.ErrorString(ret), err)
 		}
-
-		parentUUID, ret := parentHandle.GetUUID()
-		if ret != nvml.SUCCESS {
-			return "", 0, 0, fmt.Errorf("failed to get parent uuid: %v", ret)
-		}
-		gi, ret := mig.GetGpuInstanceId()
-		if ret != nvml.SUCCESS {
-			return "", 0, 0, fmt.Errorf("failed to get GPU Instance ID: %v", ret)
-		}
-
-		ci, ret := mig.GetComputeInstanceId()
-		if ret != nvml.SUCCESS {
-			return "", 0, 0, fmt.Errorf("failed to get Compute Instance ID: %v", ret)
-		}
-		//nolint:gosec  // We know that the values returned from Get*InstanceId are within the valid uint32 range.
-		return parentUUID, uint32(gi), uint32(ci), nil
+		return parentUUID, gi, ci, nil
 	}
-	return parseMigDeviceUUID(uuid)
+	parentHandle, ret := mig.GetDeviceHandleFromMigDeviceHandle()
+	if ret != nvml.SUCCESS {
+		return "", 0, 0, fmt.Errorf("failed to get parent device handle: %v", ret)
+	}
+
+	parentUUID, ret := parentHandle.GetUUID()
+	if ret != nvml.SUCCESS {
+		return "", 0, 0, fmt.Errorf("failed to get parent uuid: %v", ret)
+	}
+	gi, ret := mig.GetGpuInstanceId()
+	if ret != nvml.SUCCESS {
+		return "", 0, 0, fmt.Errorf("failed to get GPU Instance ID: %v", ret)
+	}
+
+	ci, ret := mig.GetComputeInstanceId()
+	if ret != nvml.SUCCESS {
+		return "", 0, 0, fmt.Errorf("failed to get Compute Instance ID: %v", ret)
+	}
+	//nolint:gosec  // We know that the values returned from Get*InstanceId are within the valid uint32 range.
+	return parentUUID, uint32(gi), uint32(ci), nil
 }
 
 // parseMigDeviceUUID splits the MIG device UUID into the parent device UUID and ci and gi

--- a/internal/rm/health_test.go
+++ b/internal/rm/health_test.go
@@ -21,7 +21,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/stretchr/testify/require"
+	pluginapi "k8s.io/kubelet/pkg/apis/deviceplugin/v1beta1"
 )
 
 func TestNewHealthCheckXIDs(t *testing.T) {
@@ -218,6 +220,192 @@ func TestGetDisabledHealthCheckXids(t *testing.T) {
 				disabled[xid] = xids.IsDisabled(xid)
 			}
 			require.Equal(t, tc.expectedDisabled, disabled)
+		})
+	}
+}
+
+func TestParseMigDeviceUUID(t *testing.T) {
+	testCases := []struct {
+		description    string
+		uuid           string
+		expectedParent string
+		expectedGi     uint32
+		expectedCi     uint32
+		expectError    bool
+	}{
+		{
+			description:    "legacy MIG UUID format",
+			uuid:           "MIG-GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f/3/0",
+			expectedParent: "GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f",
+			expectedGi:     3,
+			expectedCi:     0,
+		},
+		{
+			description: "opaque MIG UUID format carries no placement information",
+			uuid:        "MIG-30d00c09-8a98-59b8-8c1a-1d64b4ec3ad2",
+			expectError: true,
+		},
+		{
+			description: "full device UUID",
+			uuid:        "GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f",
+			expectError: true,
+		},
+		{
+			description: "legacy format with missing compute instance",
+			uuid:        "MIG-GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f/3",
+			expectError: true,
+		},
+		{
+			description: "legacy format with non-numeric instance ids",
+			uuid:        "MIG-GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f/a/b",
+			expectError: true,
+		},
+		{
+			description: "empty string",
+			uuid:        "",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			parent, gi, ci, err := parseMigDeviceUUID(tc.uuid)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedParent, parent)
+			require.Equal(t, tc.expectedGi, gi)
+			require.Equal(t, tc.expectedCi, ci)
+		})
+	}
+}
+
+// fakeNvmlLib is a minimal nvml.Interface test double; only
+// DeviceGetHandleByUUID is used by getMigDeviceParts.
+type fakeNvmlLib struct {
+	nvml.Interface
+	handle nvml.Device
+	ret    nvml.Return
+}
+
+func (f *fakeNvmlLib) DeviceGetHandleByUUID(string) (nvml.Device, nvml.Return) {
+	return f.handle, f.ret
+}
+
+// fakeMigHandle is a minimal nvml.Device test double for a MIG device handle.
+type fakeMigHandle struct {
+	nvml.Device
+	parentUUID string
+	gi         int
+	ci         int
+}
+
+func (f *fakeMigHandle) GetDeviceHandleFromMigDeviceHandle() (nvml.Device, nvml.Return) {
+	return &fakeParentHandle{uuid: f.parentUUID}, nvml.SUCCESS
+}
+
+func (f *fakeMigHandle) GetGpuInstanceId() (int, nvml.Return) {
+	return f.gi, nvml.SUCCESS
+}
+
+func (f *fakeMigHandle) GetComputeInstanceId() (int, nvml.Return) {
+	return f.ci, nvml.SUCCESS
+}
+
+type fakeParentHandle struct {
+	nvml.Device
+	uuid string
+}
+
+func (f *fakeParentHandle) GetUUID() (string, nvml.Return) {
+	return f.uuid, nvml.SUCCESS
+}
+
+func TestGetMigDeviceParts(t *testing.T) {
+	newMigDevice := func(uuid string) *Device {
+		return &Device{
+			Device: pluginapi.Device{ID: uuid},
+			Index:  "0:0",
+		}
+	}
+
+	testCases := []struct {
+		description      string
+		device           *Device
+		nvmlRet          nvml.Return
+		expectedParent   string
+		expectedGi       uint32
+		expectedCi       uint32
+		expectError      bool
+		expectedInErrMsg []string
+	}{
+		{
+			description:    "placement resolved via NVML handle",
+			device:         newMigDevice("MIG-30d00c09-8a98-59b8-8c1a-1d64b4ec3ad2"),
+			nvmlRet:        nvml.SUCCESS,
+			expectedParent: "GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f",
+			expectedGi:     3,
+			expectedCi:     0,
+		},
+		{
+			description:    "NVML lookup fails but legacy UUID format is parseable",
+			device:         newMigDevice("MIG-GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f/3/0"),
+			nvmlRet:        nvml.ERROR_NOT_SUPPORTED,
+			expectedParent: "GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f",
+			expectedGi:     3,
+			expectedCi:     0,
+		},
+		{
+			description: "NVML lookup fails for opaque UUID: the NVML error is surfaced",
+			device:      newMigDevice("MIG-30d00c09-8a98-59b8-8c1a-1d64b4ec3ad2"),
+			nvmlRet:     nvml.ERROR_NO_PERMISSION,
+			expectError: true,
+			expectedInErrMsg: []string{
+				"MIG-30d00c09-8a98-59b8-8c1a-1d64b4ec3ad2",
+				nvml.ErrorString(nvml.ERROR_NO_PERMISSION),
+			},
+		},
+		{
+			description: "full device is rejected",
+			device: &Device{
+				Device: pluginapi.Device{ID: "GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f"},
+				Index:  "0",
+			},
+			nvmlRet:     nvml.SUCCESS,
+			expectError: true,
+			expectedInErrMsg: []string{
+				"cannot get GI and CI of full device",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			r := &nvmlResourceManager{
+				nvml: &fakeNvmlLib{
+					handle: &fakeMigHandle{
+						parentUUID: "GPU-5c89852c-d268-c3f3-1b07-005d5ae1dc3f",
+						gi:         3,
+						ci:         0,
+					},
+					ret: tc.nvmlRet,
+				},
+			}
+
+			parent, gi, ci, err := r.getMigDeviceParts(tc.device)
+			if tc.expectError {
+				require.Error(t, err)
+				for _, msg := range tc.expectedInErrMsg {
+					require.Contains(t, err.Error(), msg)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedParent, parent)
+			require.Equal(t, tc.expectedGi, gi)
+			require.Equal(t, tc.expectedCi, ci)
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does

When the health check cannot resolve a MIG device's placement, the NVML error from `DeviceGetHandleByUUID` is silently discarded and `getMigDeviceParts` falls back to parsing the legacy MIG UUID format (`MIG-GPU-<parent-uuid>/<gi>/<ci>`). Modern drivers assign **opaque** MIG UUIDs (`MIG-<uuid>`) that carry no placement information, so for those the fallback is guaranteed to fail — and the only error ever logged is the misleading `unable to parse UUID as MIG device`, masking the actual NVML failure (e.g. `ERROR_NO_PERMISSION`, `ERROR_NOT_FOUND`).

This PR:
- Propagates the NVML return code alongside the parse failure, so the health-check log shows the real reason, e.g. `failed to get MIG device handle for MIG-30d00c09-...: ERROR_NO_PERMISSION; unable to parse UUID as MIG device`.
- Adds unit tests for `parseMigDeviceUUID` and `getMigDeviceParts` (previously uncovered), using minimal embedded `nvml.Interface`/`nvml.Device` test doubles (the go-nvml `mock` package is not in the vendor tree, so no vendor changes are needed).

No behavior change for devices whose placement resolves successfully or whose legacy UUID parses; only the error message for the already-failing path improves.

## Motivation

Project-HAMi adapts this resource-manager code, and the masked error made a real-world report (all MIG devices on H200 NVL marked unhealthy, Project-HAMi/HAMi#1950) impossible to diagnose from device-plugin logs. The identical fix was reviewed and merged there as Project-HAMi/HAMi#1999. Upstreaming it so both codebases stay aligned and other users of this plugin get diagnosable health-check failures.
