### PR TITLE
fix: guard GFD PCI vendor capability parsing against bad lengths

### DIFF
--- a/internal/vgpu/pciutil.go
+++ b/internal/vgpu/pciutil.go
@@ -124,6 +124,11 @@ func (d *PCIDevice) GetVendorSpecificCapability() ([]byte, error) {
 	var visited [256]byte
 	pos := GetByte(d.Config, PciCapabilityList)
 	for pos != 0 {
+		capHeaderEnd := int(pos) + int(PciCapabilityLength) + 1
+		if capHeaderEnd > len(d.Config) {
+			break
+		}
+
 		id := GetByte(d.Config, pos+PciCapabilityListID)
 		next := GetByte(d.Config, pos+PciCapabilityListNext)
 		length := GetByte(d.Config, pos+PciCapabilityLength)
@@ -137,7 +142,11 @@ func (d *PCIDevice) GetVendorSpecificCapability() ([]byte, error) {
 			break
 		}
 		if id == PciCapabilityVendorSpecificID {
-			capability := d.Config[pos+PciCapabilityListID : pos+PciCapabilityListID+length]
+			capEnd := int(pos) + int(PciCapabilityListID) + int(length)
+			if capEnd > len(d.Config) {
+				break
+			}
+			capability := d.Config[pos+PciCapabilityListID : capEnd]
 			return capability, nil
 		}
 

--- a/internal/vgpu/pciutil_test.go
+++ b/internal/vgpu/pciutil_test.go
@@ -23,6 +23,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestGetVendorSpecificCapabilityMalformedLength(t *testing.T) {
+	config := make([]byte, 256)
+	config[PciStatusByte] = PciStatusCapabilityList
+	config[PciCapabilityList] = 224
+
+	config[224+PciCapabilityListID] = PciCapabilityVendorSpecificID
+	config[224+PciCapabilityLength] = 100
+
+	device := &PCIDevice{
+		Address: "malformed",
+		Config:  config,
+	}
+
+	capability, err := device.GetVendorSpecificCapability()
+	require.NoError(t, err)
+	require.Nil(t, capability)
+}
+
 func TestGetVendorSpecificCapability(t *testing.T) {
 	devices, _ := NewMockNvidiaPCI().Devices()
 	for _, device := range devices {


### PR DESCRIPTION
Fixes #1891

GFD was panicking on at least one H100 node when it walked a vendor-specific PCI capability with a length that runs past the end of the config buffer.

The fix checks the capability header and body fit inside the config before slicing. Bad entries are skipped like any other broken capability chain instead of crashing the pod.

Added a unit test with a malformed config that used to trigger the panic.

## Testing

- go test ./internal/vgpu/... -run TestGetVendorSpecificCapability