### PR TITLE
Make visible devices configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1026,6 +1026,13 @@ helm upgrade -i nvdp nvdp/nvidia-device-plugin \
 and the `--version` flag to `helm upgrade -i` if this is a pre-release
 version (e.g. `<version>-rc.1`). Full releases will be listed without this.
 
+#### Setting extra environment variables on the device plugin main container
+
+`devicePlugin.containers.main.env` sets environment variables passed to the
+main device plugin container.
+Overriding this value replaces the list entirely.
+All env vars present in the default should be explicitly included when adjusting this value.
+
 ### Deploying via `helm install` with a direct URL to the `helm` package
 
 If you prefer not to install from the `nvidia-device-plugin` `helm` repo, you can

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -200,7 +200,7 @@ spec:
             value: {{ .Values.deviceDiscoveryStrategy }}
         {{- end }}
           - name: NVIDIA_VISIBLE_DEVICES
-            value: all
+            value: {{ .Values.visibleDevices }}
           - name: NVIDIA_DRIVER_CAPABILITIES
             value: compute,utility
         securityContext:

--- a/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
+++ b/deployments/helm/nvidia-device-plugin/templates/daemonset-device-plugin.yml
@@ -199,10 +199,9 @@ spec:
           - name: DEVICE_DISCOVERY_STRATEGY
             value: {{ .Values.deviceDiscoveryStrategy }}
         {{- end }}
-          - name: NVIDIA_VISIBLE_DEVICES
-            value: all
-          - name: NVIDIA_DRIVER_CAPABILITIES
-            value: compute,utility
+        {{- with .Values.devicePlugin.containers.main.env }}
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         securityContext:
           {{- include "nvidia-device-plugin.securityContext" . | nindent 10 }}
         volumeMounts:

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -37,6 +37,7 @@ gdrcopyEnabled: null
 gdsEnabled: null
 mofedEnabled: null
 deviceDiscoveryStrategy: null
+visibleDevices: all
 
 nameOverride: ""
 fullnameOverride: ""

--- a/deployments/helm/nvidia-device-plugin/values.yaml
+++ b/deployments/helm/nvidia-device-plugin/values.yaml
@@ -106,6 +106,14 @@ devicePlugin:
   # This can be useful in non-overlay network environments (e.g., AWS, Azure, GCP)
   # to avoid unnecessary IP allocation for daemon pods.
   # enableHostNetwork: false
+  containers:
+    main:
+      # env vars specific to the main container of the device plugin DaemonSet
+      env:
+      - name: NVIDIA_VISIBLE_DEVICES
+        value: "all"
+      - name: NVIDIA_DRIVER_CAPABILITIES
+        value: "compute,utility"
 
 gfd:
   enabled: false


### PR DESCRIPTION
As adjusting this env var is necessary for the current suggested workaround for issues [1] and [2].
This saves overhead for operators who previously had to adjust the env var via a kustomization or helm post-renderer.

  [1]: https://github.com/NVIDIA/k8s-device-plugin/issues/1683
  [2]: https://github.com/NVIDIA/nvidia-container-toolkit/issues/1740
