### PR TITLE
bump toolkit to 1151f013

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/NVIDIA/go-gpuallocator v0.6.0
 	github.com/NVIDIA/go-nvlib v0.12.0
 	github.com/NVIDIA/go-nvml v0.13.3-1
-	github.com/NVIDIA/nvidia-container-toolkit v1.20.0-rc.1
+	github.com/NVIDIA/nvidia-container-toolkit v1.20.0-rc.1.0.20260727174247-1151f0130747
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/google/renameio v1.0.1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/NVIDIA/go-nvlib v0.12.0 h1:LICVlUGlDnpbwQv64rOZQn11xQae1J+c+dvH9CCi7j
 github.com/NVIDIA/go-nvlib v0.12.0/go.mod h1:J5M/QPIJJtaipjdONqevSnfgBlkW49uVWX5cFOoQpoA=
 github.com/NVIDIA/go-nvml v0.13.3-1 h1:P76U2h88OZSiMtdhRsJjSF5DXyXUqHIXKeDicVAaae0=
 github.com/NVIDIA/go-nvml v0.13.3-1/go.mod h1:ahi2psRYoa+wYUBIrZPRO+wJs9lcvMhxSSkjjvsJJNQ=
-github.com/NVIDIA/nvidia-container-toolkit v1.20.0-rc.1 h1:TaMDmzBmvoM7vLaVX4qbT83pnuwyUXMl5OEIUmSmiU0=
-github.com/NVIDIA/nvidia-container-toolkit v1.20.0-rc.1/go.mod h1:EE/RbRH0Hb8pkbjXJ+xtf1yBaZziOn4kTyfRoMeyNME=
+github.com/NVIDIA/nvidia-container-toolkit v1.20.0-rc.1.0.20260727174247-1151f0130747 h1:KZZYH691lwQDpVMAxEjCF1MkMcjtDMbNZc4SWULOyX4=
+github.com/NVIDIA/nvidia-container-toolkit v1.20.0-rc.1.0.20260727174247-1151f0130747/go.mod h1:4woEX5v29O/b5QW/WdB1cK7zyIzBzXiORZxCVuNYS7k=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/application_profile.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/application_profile.go
@@ -1,0 +1,22 @@
+/**
+# Copyright (c) NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package discover
+
+// NewApplicationProfileHookDiscoverer creates a discoverer for the update-application-profile hook.
+func NewApplicationProfileHookDiscoverer(hookCreator HookCreator) Discover {
+	return hookCreator.Create(ApplicationProfileHook)
+}

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/graphics.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/graphics.go
@@ -111,14 +111,17 @@ func newVulkanConfigsDiscover(logger logger.Interface, driver *root.Driver) Disc
 
 type graphicsDriverLibraries struct {
 	Discover
-	logger      logger.Interface
-	hookCreator HookCreator
+	logger        logger.Interface
+	hookCreator   HookCreator
+	driverVersion string
 }
 
 var _ Discover = (*graphicsDriverLibraries)(nil)
 
 func newGraphicsLibrariesDiscoverer(logger logger.Interface, driver *root.Driver, hookCreator HookCreator) (Discover, error) {
-	cudaVersionPattern, err := driver.Version()
+	// We use the driver version as a suffix for matching libraries that are
+	// part of the driver.
+	driverVersion, err := driver.Version()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get driver version: %w", err)
 	}
@@ -143,8 +146,8 @@ func newGraphicsLibrariesDiscoverer(logger logger.Interface, driver *root.Driver
 			// * libnvidia-allocator.so.RM_VERSION
 			// * libnvidia-vulkan-producer.so.RM_VERSION
 			// but need to be handled for the legacy case too.
-			"libnvidia-allocator.so." + cudaVersionPattern,
-			"libnvidia-vulkan-producer.so." + cudaVersionPattern,
+			"libnvidia-allocator.so." + driverVersion,
+			"libnvidia-vulkan-producer.so." + driverVersion,
 		},
 	)
 
@@ -159,14 +162,15 @@ func newGraphicsLibrariesDiscoverer(logger logger.Interface, driver *root.Driver
 		driver.Root,
 		[]string{
 			"nvidia_drv.so",
-			"libglxserver_nvidia.so." + cudaVersionPattern,
+			"libglxserver_nvidia.so." + driverVersion,
 		},
 	)
 
 	return &graphicsDriverLibraries{
-		Discover:    Merge(libraries, xorgLibraries),
-		logger:      logger,
-		hookCreator: hookCreator,
+		Discover:      Merge(libraries, xorgLibraries),
+		logger:        logger,
+		hookCreator:   hookCreator,
+		driverVersion: driverVersion,
 	}, nil
 }
 
@@ -234,10 +238,7 @@ func (d graphicsDriverLibraries) Hooks() ([]Hook, error) {
 
 // isDriverLibrary checks whether the specified filename is a specific driver library.
 func (d graphicsDriverLibraries) isDriverLibrary(filename string, libraryName string) bool {
-	// TODO: Instead of `.*.*` we could use the driver version.
-	pattern := strings.TrimSuffix(libraryName, ".") + ".*.*"
-	match, _ := filepath.Match(pattern, filename)
-	return match
+	return filename == strings.TrimSuffix(libraryName, ".")+"."+d.driverVersion
 }
 
 // buildXOrgSearchPaths returns search paths from all roots

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/hooks.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/internal/discover/hooks.go
@@ -42,6 +42,10 @@ const (
 	// AllHooks is a special hook name that allows all hooks to be matched.
 	AllHooks = HookName("all")
 
+	// An ApplicationProfileHook updates driver settings through "application
+	// profiles". It currently restricts EGL/Vulkan GPU visibility inside the
+	// container to the GPUs actually mounted.
+	ApplicationProfileHook = HookName("update-application-profile")
 	// A ChmodHook is used to set the file mode of the specified paths.
 	//
 	// Deprecated: The chmod hook is deprecated and will be removed in a future release.
@@ -216,7 +220,7 @@ func (c cdiHookCreator) Create(name HookName, args ...string) *Hook {
 
 func (c cdiHookCreator) getOCIHookType(name HookName) OCIHookType {
 	switch name {
-	case CreateSymlinksHook, ChmodHook, DisableDeviceNodeModificationHook, EnableCudaCompatHook, UpdateLDCacheHook:
+	case CreateSymlinksHook, ChmodHook, DisableDeviceNodeModificationHook, EnableCudaCompatHook, UpdateLDCacheHook, ApplicationProfileHook:
 		return OCIHookTypeCreateContainer
 	default:
 		return OCIHookTypeCreateContainer

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/common-nvml.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/common-nvml.go
@@ -37,10 +37,13 @@ func (l *nvmllib) newCommonNVMLDiscoverer() (discover.Discover, error) {
 		return nil, fmt.Errorf("failed to create discoverer for driver files: %v", err)
 	}
 
+	applicationProfileHook := discover.NewApplicationProfileHookDiscoverer(l.hookCreator)
+
 	d := discover.Merge(
 		metaDevices,
 		graphicsMounts,
 		driverFiles,
+		applicationProfileHook,
 	)
 
 	return d, nil

--- a/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/options.go
+++ b/vendor/github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/options.go
@@ -114,9 +114,8 @@ func populateOptions(opts ...Option) *options {
 	}
 
 	if o.mode == ModeManagement {
-		// For management mode we explicitly disable the hooks that enable CUDA
-		// compatibility and disable device node modifications.
-		o.disabledHooks = append(o.disabledHooks, HookEnableCudaCompat, DisableDeviceNodeModificationHook)
+		// For management mode we explicitly disable the hook that disables device node modifications.
+		o.disabledHooks = append(o.disabledHooks, DisableDeviceNodeModificationHook)
 	}
 
 	if o.editsFactory == nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -20,7 +20,7 @@ github.com/NVIDIA/go-nvlib/pkg/pciids
 ## explicit; go 1.20
 github.com/NVIDIA/go-nvml/pkg/dl
 github.com/NVIDIA/go-nvml/pkg/nvml
-# github.com/NVIDIA/nvidia-container-toolkit v1.20.0-rc.1
+# github.com/NVIDIA/nvidia-container-toolkit v1.20.0-rc.1.0.20260727174247-1151f0130747
 ## explicit; go 1.25.0
 github.com/NVIDIA/nvidia-container-toolkit/internal/config/image
 github.com/NVIDIA/nvidia-container-toolkit/internal/devices


### PR DESCRIPTION
Commits since 1.20.0-rc.1: https://github.com/NVIDIA/nvidia-container-toolkit/compare/v1.20.0-rc.1...1151f013074712dc6dabd00752b6b57d6637fdeb

One bug fix that is relevant for k8s-device-plugin is: https://github.com/NVIDIA/nvidia-container-toolkit/issues/1899