### PR TITLE
disable cooldown for nvidia controlled dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
     open-pull-requests-limit: 15
     schedule:
       interval: "daily"
+    cooldown:
+      exclude:
+      - github.com/NVIDIA/*
     labels:
     - dependencies
     groups:
@@ -53,6 +56,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    cooldown:
+      exclude:
+      - github.com/NVIDIA/*
     labels:
     - dependencies
     - maintenance


### PR DESCRIPTION
Disable cooldown for nvidia controlled dependencies and also don't specify version in third party licenses, else it will change with every version update.