### PR TITLE
Add OCI standard image labels

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -48,7 +48,8 @@ jobs:
       - name: Build image
         env:
           IMAGE_NAME: ghcr.io/nvidia/k8s-device-plugin
-          VERSION: ${{ inputs.version }}-${{ matrix.arch }}
+          VERSION: ${{ inputs.version }}
+          IMAGE_TAG: ${{ inputs.version }}-${{ matrix.arch }}
           PUSH_ON_BUILD: true
           GOPROXY: ${{ steps.setup-go-proxy.outputs.goproxy-url }}
           DOCKER_BUILD_PLATFORM_OPTIONS: "--platform=linux/${{ matrix.arch }}"

--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -65,6 +65,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 
 ARG VERSION="N/A"
 ARG GIT_COMMIT="unknown"
+ARG BUILD_TIMESTAMP
 
 LABEL io.k8s.display-name="NVIDIA Device Plugin"
 LABEL name="NVIDIA Device Plugin"
@@ -73,7 +74,17 @@ LABEL version=${VERSION}
 LABEL com.nvidia.git-commit=${GIT_COMMIT}
 LABEL release="N/A"
 LABEL summary="NVIDIA device plugin for Kubernetes"
-LABEL description="See summary"
+LABEL description="NVIDIA device plugin for Kubernetes"
+LABEL org.opencontainers.image.base.name="nvcr.io/nvidia/distroless/go"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="NVIDIA device plugin for Kubernetes"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/k8s-device-plugin.git"
+LABEL org.opencontainers.image.title="NVIDIA Device Plugin"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/containers/k8s-device-plugin"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${VERSION}"
 
 COPY LICENSE /licenses/
 

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -76,6 +76,7 @@ $(IMAGE_TARGETS): image-%:
 		--build-arg VERSION="$(VERSION)" \
 		--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
 		--build-arg GOPROXY="$(GOPROXY)" \
+		--build-arg BUILD_TIMESTAMP="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" \
 		$(if $(LABEL_IMAGE_SOURCE),--label "org.opencontainers.image.source=$(LABEL_IMAGE_SOURCE)",) \
 		-f $(DOCKERFILE) \
 		$(CURDIR)


### PR DESCRIPTION
This PR adds well-known OCI Image labels to the k8s-device-plugin image metadata.

**Before**
```
$ docker inspect --format='{{json .Config.Labels}}' nvcr.io/nvidia/k8s-device-plugin:v0.19.3 | jq
{
  "com.nvidia.git-commit": "570e776d6813cb9f3e9c8c105cf8d79989db6650",
  "description": "See summary",
  "io.k8s.display-name": "NVIDIA Device Plugin",
  "name": "NVIDIA Device Plugin",
  "org.opencontainers.image.created": "2026-06-11T18:01:15Z",
  "org.opencontainers.image.documentation": "https://developer.download.nvidia.com/distroless-oss/docs.html",
  "org.opencontainers.image.revision": "d5891068bf92407b17825c29f462da9643457b04",
  "org.opencontainers.image.title": "Golang Distroless Image",
  "org.opencontainers.image.url": "https://developer.download.nvidia.com/distroless-oss/index.html",
  "org.opencontainers.image.version": "v4.0.8",
  "release": "N/A",
  "summary": "NVIDIA device plugin for Kubernetes",
  "vendor": "NVIDIA",
  "version": "570e776d-amd64"
}
```

**After** — built from this branch
```
$ docker inspect --format='{{json .Config.Labels}}' nvcr.io/nvidia/k8s-device-plugin:062ee70b | jq
{
  "com.nvidia.git-commit": "062ee70bd2c94398b2da1bc3b5b5c40a58e20b3e",
  "description": "NVIDIA device plugin for Kubernetes",
  "io.k8s.display-name": "NVIDIA Device Plugin",
  "name": "NVIDIA Device Plugin",
  "org.opencontainers.image.base.name": "nvcr.io/nvidia/distroless/go",
  "org.opencontainers.image.created": "2026-08-17T18:55:03Z",
  "org.opencontainers.image.description": "NVIDIA device plugin for Kubernetes",
  "org.opencontainers.image.documentation": "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator",
  "org.opencontainers.image.revision": "062ee70bd2c94398b2da1bc3b5b5c40a58e20b3e",
  "org.opencontainers.image.source": "https://github.com/NVIDIA/k8s-device-plugin.git",
  "org.opencontainers.image.title": "NVIDIA Device Plugin",
  "org.opencontainers.image.url": "https://catalog.ngc.nvidia.com/orgs/nvidia/containers/k8s-device-plugin",
  "org.opencontainers.image.vendor": "NVIDIA",
  "org.opencontainers.image.version": "062ee70b",
  "release": "N/A",
  "summary": "NVIDIA device plugin for Kubernetes",
  "vendor": "NVIDIA",
  "version": "062ee70b"
}
```
