### PR TITLE
validate vGPU capability record lengths

### DIFF
--- a/internal/vgpu/vgpu.go
+++ b/internal/vgpu/vgpu.go
@@ -40,7 +40,7 @@ type Info struct {
 
 const (
 	// VGPUCapabilityRecordStart indicates offset of beginning vGPU capability record
-	VGPUCapabilityRecordStart uint8 = 5
+	VGPUCapabilityRecordStart = 5
 	// HostDriverVersionLength indicates max length of driver version
 	HostDriverVersionLength = 10
 	// HostDriverBranchLength indicates max length of driver branch
@@ -111,38 +111,50 @@ func (d *Device) GetInfo() (*Info, error) {
 	}
 
 	// traverse vGPU vendor capability records until host driver version record(id: 0) is found
-	var hostDriverVersion string
-	var hostDriverBranch string
-	foundDriverVersionRecord := false
 	pos := VGPUCapabilityRecordStart
-	record := GetByte(d.vGPUCapability, VGPUCapabilityRecordStart)
-	for record != 0 && int(pos) < len(d.vGPUCapability) {
-		// find next record
-		recordLength := GetByte(d.vGPUCapability, pos+1)
+	for {
+		if pos >= len(d.vGPUCapability) {
+			return nil, fmt.Errorf("cannot find driver version record in vendor specific capability for device %s", d.pci.Address)
+		}
+
+		record := d.vGPUCapability[pos]
+		if record == 0 {
+			break
+		}
+
+		if len(d.vGPUCapability)-pos < 2 {
+			return nil, fmt.Errorf("truncated vendor capability record for device %s at offset %d", d.pci.Address, pos)
+		}
+
+		recordLength := int(d.vGPUCapability[pos+1])
+		if recordLength < 2 {
+			return nil, fmt.Errorf("invalid vendor capability record length %d for device %s at offset %d", recordLength, d.pci.Address, pos)
+		}
+		if recordLength > len(d.vGPUCapability)-pos {
+			return nil, fmt.Errorf("vendor capability record exceeds capability bounds for device %s at offset %d", d.pci.Address, pos)
+		}
+
 		pos += recordLength
-		record = GetByte(d.vGPUCapability, pos)
 	}
 
-	if record == 0 && int(pos+2+HostDriverVersionLength+HostDriverBranchLength) <= len(d.vGPUCapability) {
-		foundDriverVersionRecord = true
-		// found vGPU host driver version record type
-		// initialized at record data byte, i.e pos + 1(record id byte) + 1(record lengh byte)
-		i := pos + 2
-		// 10 bytes of driver version
-		for ; i < pos+2+HostDriverVersionLength; i++ {
-			hostDriverVersion += string(GetByte(d.vGPUCapability, i))
-		}
-		hostDriverVersion = strings.Trim(hostDriverVersion, "\x00")
-		// 10 bytes of driver branch
-		for ; i < pos+2+HostDriverVersionLength+HostDriverBranchLength; i++ {
-			hostDriverBranch += string(GetByte(d.vGPUCapability, i))
-		}
-		hostDriverBranch = strings.Trim(hostDriverBranch, "\x00")
+	driverRecordLength := 2 + HostDriverVersionLength + HostDriverBranchLength
+	if len(d.vGPUCapability)-pos < 2 {
+		return nil, fmt.Errorf("truncated driver version record in vendor specific capability for device %s", d.pci.Address)
 	}
 
-	if !foundDriverVersionRecord {
-		return nil, fmt.Errorf("cannot find driver version record in vendor specific capability for device %s", d.pci.Address)
+	recordLength := int(d.vGPUCapability[pos+1])
+	if recordLength < driverRecordLength {
+		return nil, fmt.Errorf("invalid driver version record length %d for device %s", recordLength, d.pci.Address)
 	}
+	if recordLength > len(d.vGPUCapability)-pos {
+		return nil, fmt.Errorf("driver version record exceeds capability bounds for device %s", d.pci.Address)
+	}
+
+	payloadStart := pos + 2
+	versionEnd := payloadStart + HostDriverVersionLength
+	branchEnd := versionEnd + HostDriverBranchLength
+	hostDriverVersion := strings.Trim(string(d.vGPUCapability[payloadStart:versionEnd]), "\x00")
+	hostDriverBranch := strings.Trim(string(d.vGPUCapability[versionEnd:branchEnd]), "\x00")
 
 	info := &Info{
 		HostDriverVersion: hostDriverVersion,

--- a/internal/vgpu/vgpu_test.go
+++ b/internal/vgpu/vgpu_test.go
@@ -72,3 +72,86 @@ func TestVGPUGetInfo(t *testing.T) {
 		}
 	}
 }
+
+func TestVGPUGetInfoRejectsMalformedRecords(t *testing.T) {
+	tests := []struct {
+		name       string
+		capability []byte
+		err        string
+	}{
+		{
+			name:       "missing record",
+			capability: []byte{0x09, 0x00, 0x05, 0x56, 0x46},
+			err:        "cannot find driver version record",
+		},
+		{
+			name:       "truncated record header",
+			capability: []byte{0x09, 0x00, 0x06, 0x56, 0x46, 0x01},
+			err:        "truncated vendor capability record",
+		},
+		{
+			name:       "zero-length record",
+			capability: []byte{0x09, 0x00, 0x07, 0x56, 0x46, 0x01, 0x00},
+			err:        "invalid vendor capability record length 0",
+		},
+		{
+			name:       "record shorter than header",
+			capability: []byte{0x09, 0x00, 0x07, 0x56, 0x46, 0x01, 0x01},
+			err:        "invalid vendor capability record length 1",
+		},
+		{
+			name:       "record exceeds capability",
+			capability: []byte{0x09, 0x00, 0x07, 0x56, 0x46, 0x01, 0xff},
+			err:        "vendor capability record exceeds capability bounds",
+		},
+		{
+			name:       "truncated driver record header",
+			capability: []byte{0x09, 0x00, 0x06, 0x56, 0x46, 0x00},
+			err:        "truncated driver version record",
+		},
+		{
+			name:       "driver record shorter than payload",
+			capability: []byte{0x09, 0x00, 0x07, 0x56, 0x46, 0x00, 0x02},
+			err:        "invalid driver version record length 2",
+		},
+		{
+			name:       "driver record exceeds capability",
+			capability: []byte{0x09, 0x00, 0x07, 0x56, 0x46, 0x00, 0x16},
+			err:        "driver version record exceeds capability bounds",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			device := &Device{
+				pci:            &PCIDevice{Address: "malformed"},
+				vGPUCapability: tc.capability,
+			}
+
+			info, err := device.GetInfo()
+
+			require.ErrorContains(t, err, tc.err)
+			require.Nil(t, info)
+		})
+	}
+}
+
+func TestVGPUGetInfoSkipsUnknownRecords(t *testing.T) {
+	capability := make([]byte, 30)
+	copy(capability, []byte{0x09, 0x00, 0x1e, 0x56, 0x46})
+	copy(capability[5:], []byte{0x01, 0x03, 0xff})
+	copy(capability[8:], []byte{0x00, 0x16})
+	copy(capability[10:], []byte("460.16"))
+	copy(capability[20:], []byte("r460_00"))
+
+	device := &Device{
+		pci:            &PCIDevice{Address: "vgpu"},
+		vGPUCapability: capability,
+	}
+
+	info, err := device.GetInfo()
+
+	require.NoError(t, err)
+	require.Equal(t, "460.16", info.HostDriverVersion)
+	require.Equal(t, "r460_00", info.HostDriverBranch)
+}


### PR DESCRIPTION
### Summary
Fixes vGPU capability parsing so malformed PCI records cannot cause GPU Feature Discovery to hang or read outside the capability buffer.

### Details
A nonterminal vGPU capability record with a zero-length field caused Device.GetInfo() to repeatedly process the same record, resulting in an infinite loop and 100% CPU usage.

This change:

Uses an int cursor to prevent uint8 wraparound.
Requires nonterminal records to include at least their two-byte header.
Validates record boundaries before reading or advancing.
Validates the host-driver record and payload length.
Adds tests for zero-length, truncated, undersized, oversized, and valid records.