### PR TITLE
fix: address review feedback on config-manager symlink handling

### DIFF
--- a/cmd/config-manager/main.go
+++ b/cmd/config-manager/main.go
@@ -405,17 +405,17 @@ func updateSymlink(config string, f *Flags) (bool, error) {
 			return false, nil
 		}
 	} else if !os.IsNotExist(err) && !errors.Is(err, syscall.EINVAL) {
-		return false, fmt.Errorf("error reading symlink '%s': %v", f.ConfigFileDst, err)
+		return false, fmt.Errorf("error reading symlink %s: %w", f.ConfigFileDst, err)
 	}
 
 	err = os.Remove(f.ConfigFileDst)
 	if err != nil && !os.IsNotExist(err) {
-		return false, fmt.Errorf("error removing existing config: %v", err)
+		return false, fmt.Errorf("error removing existing config: %w", err)
 	}
 
 	err = os.Symlink(src, f.ConfigFileDst)
 	if err != nil {
-		return false, fmt.Errorf("error creating symlink: %v", err)
+		return false, fmt.Errorf("error creating symlink: %w", err)
 	}
 
 	return true, nil

--- a/cmd/config-manager/main_test.go
+++ b/cmd/config-manager/main_test.go
@@ -31,37 +31,37 @@ func newTestFlags(srcdir, dst string) *Flags {
 	}
 }
 
-func TestUpdateSymlinkDanglingDestination(t *testing.T) {
+func newSymlinkTestFixture(t *testing.T) (string, *Flags) {
 	srcdir := t.TempDir()
 	dst := filepath.Join(t.TempDir(), "config.yaml")
-	f := newTestFlags(srcdir, dst)
+	return srcdir, newTestFlags(srcdir, dst)
+}
 
-	testCases := []struct {
-		description string
-		config      string
-		wantChanged bool
-	}{
-		{
-			description: "create dangling symlink",
-			config:      "missing-config",
-			wantChanged: true,
-		},
-		{
-			description: "dangling symlink already pointing at config is a no operation",
-			config:      "missing-config",
-			wantChanged: false,
-		},
-	}
+func TestUpdateSymlinkDanglingDestination(t *testing.T) {
+	t.Run("create dangling symlink", func(t *testing.T) {
+		srcdir, f := newSymlinkTestFixture(t)
 
-	for _, tc := range testCases {
-		t.Run(tc.description, func(t *testing.T) {
-			changed, err := updateSymlink(tc.config, f)
-			require.NoError(t, err)
-			require.Equal(t, tc.wantChanged, changed)
-		})
-	}
+		changed, err := updateSymlink("missing-config", f)
+		require.NoError(t, err)
+		require.True(t, changed)
 
-	link, err := os.Readlink(dst)
-	require.NoError(t, err)
-	require.Equal(t, filepath.Join(srcdir, "missing-config"), link)
+		link, err := os.Readlink(f.ConfigFileDst)
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(srcdir, "missing-config"), link)
+	})
+
+	t.Run("dangling symlink already pointing at config is a no operation", func(t *testing.T) {
+		srcdir, f := newSymlinkTestFixture(t)
+
+		_, err := updateSymlink("missing-config", f)
+		require.NoError(t, err)
+
+		changed, err := updateSymlink("missing-config", f)
+		require.NoError(t, err)
+		require.False(t, changed)
+
+		link, err := os.Readlink(f.ConfigFileDst)
+		require.NoError(t, err)
+		require.Equal(t, filepath.Join(srcdir, "missing-config"), link)
+	})
 }


### PR DESCRIPTION
Follow-up to #1982, addressing review feedback from @tariq1890 that came in after the PR had already merged.

- Wrap errors with `%w` instead of `%v`, and drop the redundant quoting around the destination path since these logs are already emitted in JSON.
- Split `TestUpdateSymlinkDanglingDestination` into two independent subtests. Previously the second subtest relied on state left behind by the first, so it failed when run in isolation (e.g. via `-run`).

I left the `!os.IsNotExist(err)` check on the `os.Remove` call as is: it guards a different error value from a different syscall than the earlier `os.Readlink` check, so it isn't actually redundant, it's the standard idiom for tolerating a concurrent removal between the two calls.