### PR TITLE
Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Description
+
+<!-- Brief description of the change, including context or motivation -->
+
+<!--
+Link the related issue so it closes on merge, e.g. `Closes #1234`.
+See CONTRIBUTING.md for when an issue is required before a pull request.
+-->
+
+## Checklist
+
+- [ ] No secrets, sensitive information, or unrelated changes
+- [ ] Lint checks passing (`make lint`)
+- [ ] Unit tests passing (`make test`)
+- [ ] Go mod artifacts in-sync (`make check-modules`)
+- [ ] Third-party notices in-sync (`make check-third-party-notices`)
+- [ ] Test cases are added for new code paths
+
+## Testing
+
+<!-- How was this tested? e.g., unit tests, manual testing on a GPU node -->


### PR DESCRIPTION
Adds a pull request template so that pull requests consistently describe what changed and why, link the related issue, and record how the change was tested.

The structure mirrors the template already used in the gpu-operator repository. The checklist is adapted to this repository's make targets.
