### PR TITLE
Document issue-first workflow and review process in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,43 +1,20 @@
 # Contribute to the NVIDIA Kubernetes Device Plugin
 
-Want to hack on the NVIDIA Kubernetes Device plugin Project? Awesome!
-We only require you to sign your work, the below section describes this!
+To file feature requests, bugs, or questions, submit an issue at https://github.com/NVIDIA/k8s-device-plugin/issues
+
+To contribute to the project, file a Pull Request at https://github.com/NVIDIA/k8s-device-plugin/pulls.
+Contributions do not require explicit contributor license agreements (CLA), but we expect
+contributors to sign their work.
+
+Before beginning implementation or opening a Pull Request for a significant change, first open an
+issue describing the problem or proposal. A significant change includes, but is not limited to,
+architectural changes, new features, breaking changes to API or behavior, and non-trivial bug fixes.
+
+Pull Requests require an approving review from a maintainer, and all required status checks must
+pass, before they can be merged.
+The approval / decision-making process is documented in [GOVERNANCE.md](GOVERNANCE.md)
 
 All contributions must adhere to the [Code of Conduct](CODE_OF_CONDUCT.md).
-
-## Open an issue first
-
-Before beginning implementation or opening a pull request for a significant change,
-first open an issue describing the problem or proposal. A significant change includes,
-but is not limited to, architectural changes, new features, breaking changes to API or
-behavior, and non-trivial bug fixes.
-
-Waiting for a maintainer to acknowledge the issue before you start writing code avoids
-work that turns out to conflict with the direction of the project. See
-[GOVERNANCE.md](GOVERNANCE.md) for how these decisions are made.
-
-Two exceptions:
-
-- Trivial changes — typos, formatting, broken links — can go straight to a pull request.
-- Security vulnerabilities must never start with a public issue. Report them through
-  the process in [SECURITY.md](SECURITY.md) instead.
-
-Reference the issue in your pull request description with `Closes #1234` so that merging
-the pull request closes it.
-
-## Review process
-
-All changes land through a pull request against `main`; nobody pushes to `main` directly.
-Opening a pull request runs the CI suite — lint, unit tests, `helm` tests, CodeQL
-analysis, image builds, and end-to-end tests — alongside a Developer Certificate of
-Origin check on your commits. All of these must pass before a pull request can merge.
-
-A pull request also needs an approving review from a maintainer. Maintainers make the
-final call on what is accepted; see [GOVERNANCE.md](GOVERNANCE.md) for the decision
-making model.
-
-If your pull request has gone quiet, comment on it to ask for attention. That is welcome
-and effective — a stalled review is usually an oversight rather than a rejection.
 
 ## Sign your work
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,40 @@ We only require you to sign your work, the below section describes this!
 
 All contributions must adhere to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
+## Open an issue first
+
+Before beginning implementation or opening a pull request for a significant change,
+first open an issue describing the problem or proposal. A significant change includes,
+but is not limited to, architectural changes, new features, breaking changes to API or
+behavior, and non-trivial bug fixes.
+
+Waiting for a maintainer to acknowledge the issue before you start writing code avoids
+work that turns out to conflict with the direction of the project. See
+[GOVERNANCE.md](GOVERNANCE.md) for how these decisions are made.
+
+Two exceptions:
+
+- Trivial changes — typos, formatting, broken links — can go straight to a pull request.
+- Security vulnerabilities must never start with a public issue. Report them through
+  the process in [SECURITY.md](SECURITY.md) instead.
+
+Reference the issue in your pull request description with `Closes #1234` so that merging
+the pull request closes it.
+
+## Review process
+
+All changes land through a pull request against `main`; nobody pushes to `main` directly.
+Opening a pull request runs the CI suite — lint, unit tests, `helm` tests, CodeQL
+analysis, image builds, and end-to-end tests — alongside a Developer Certificate of
+Origin check on your commits. All of these must pass before a pull request can merge.
+
+A pull request also needs an approving review from a maintainer. Maintainers make the
+final call on what is accepted; see [GOVERNANCE.md](GOVERNANCE.md) for the decision
+making model.
+
+If your pull request has gone quiet, comment on it to ask for attention. That is welcome
+and effective — a stalled review is usually an oversight rather than a rejection.
+
 ## Sign your work
 
 The sign-off is a simple line at the end of the explanation for the patch. Your


### PR DESCRIPTION
Documents two things in CONTRIBUTING.md that were previously unwritten: the expectation that significant changes start with an issue rather than a pull request, and how the review process works.

The issue-first requirement already exists in GOVERNANCE.md under Core Decisions. This makes it visible to contributors where they are most likely to look for it. The review process section describes the checks and approval a pull request needs before it can merge, and what to do if a review stalls.
